### PR TITLE
SchrimpfAcceptance unit tests

### DIFF
--- a/jsprit-core/src/test/java/jsprit/core/algorithm/acceptor/SchrimpfAcceptanceTest.java
+++ b/jsprit-core/src/test/java/jsprit/core/algorithm/acceptor/SchrimpfAcceptanceTest.java
@@ -1,0 +1,73 @@
+package jsprit.core.algorithm.acceptor;
+
+import jsprit.core.problem.solution.VehicleRoutingProblemSolution;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.Collection;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class SchrimpfAcceptanceTest {
+
+	protected SchrimpfAcceptance schrimpfAcceptance;
+	protected Collection<VehicleRoutingProblemSolution> memory;
+
+	protected static VehicleRoutingProblemSolution createSolutionWithCost(double cost) {
+		return when(mock(VehicleRoutingProblemSolution.class).getCost()).thenReturn(cost).getMock();
+	}
+
+	@Before
+	public void setup() {
+		schrimpfAcceptance = new SchrimpfAcceptance(1, 0.3, 100);
+		// we skip the warmup, but still want to test that the initialThreshold is set
+		schrimpfAcceptance.setInitialThreshold(0.0);
+		// create empty memory with an initial capacity of 1
+		memory = new ArrayList<VehicleRoutingProblemSolution>(1);
+		// insert the initial (worst) solution, will be accepted anyway since its the first in the memory
+		assertTrue("Solution (initial cost = 2.0) should be accepted since the memory is empty", schrimpfAcceptance.acceptSolution(memory, createSolutionWithCost(2.0)));
+	}
+
+	@Test
+	public void respectsTheZeroThreshold_usingWorstCostSolution() {
+		assertFalse("Worst cost solution (2.1 > 2.0) should not be accepted", schrimpfAcceptance.acceptSolution(memory, createSolutionWithCost(2.1)));
+	}
+
+	@Test
+	public void respectsTheZeroThreshold_usingBetterCostSolution() {
+		assertTrue("Better cost solution (1.9 < 2.0) should be accepted", schrimpfAcceptance.acceptSolution(memory, createSolutionWithCost(1.9)));
+	}
+
+	@Test
+	public void respectsTheZeroThreshold_usingSameCostSolution() {
+		assertFalse("Same cost solution (2.0 == 2.0) should not be accepted", schrimpfAcceptance.acceptSolution(memory, createSolutionWithCost(2.0)));
+	}
+
+	@Test
+	public void respectsTheNonZeroThreshold_usingWorstCostSolution() {
+		schrimpfAcceptance.setInitialThreshold(0.5);
+		assertFalse("Worst cost solution (2.1 > 2.0) should not be accepted", schrimpfAcceptance.acceptSolution(memory, createSolutionWithCost(2.1)));
+	}
+
+	@Test
+	public void respectsTheNonZeroThreshold_usingBetterCostSolution() {
+		schrimpfAcceptance.setInitialThreshold(0.5);
+		assertTrue("Better cost solution (1.0 < 2.0) should be accepted since the better cost bust the threshold", schrimpfAcceptance.acceptSolution(memory, createSolutionWithCost(1.0)));
+	}
+
+	@Test
+	public void respectsTheNonZeroThreshold_usingBetterButBelowTheThresholdCostSolution() {
+		schrimpfAcceptance.setInitialThreshold(0.5);
+		assertFalse("Better cost solution (1.9 < 2.0) should not be accepted since the better cost is still below the threshold", schrimpfAcceptance.acceptSolution(memory, createSolutionWithCost(1.9)));
+	}
+
+	@Test
+	public void respectsTheNonZeroThreshold_usingSameCostSolution() {
+		schrimpfAcceptance.setInitialThreshold(0.5);
+		assertFalse("Same cost solution (2.0 == 2.0) should not be accepted", schrimpfAcceptance.acceptSolution(memory, createSolutionWithCost(2.0)));
+	}
+}


### PR DESCRIPTION
This is more to initiate a talk about my prematureTermination problem rather than a real PR.

Not long ago we talk by email about a problem I have with the premature termination feature.

Here is what I do in my (groovy) code:

```
def algorithm = new SchrimpfFactory().createAlgorithm(problem)
algorithm.nuOfIterations = 10000
algorithm.prematureAlgorithmTermination = new IterationWithoutImprovementTermination(1000)
```

Whatever the algorithm do, it always ends at iteration `10000`.

I dig into this problem, and found the reason:

The `IterationWithoutImprovementTermination` uses the `DiscoveredSolution.accepted` field to determine how many `iterationsWithoutImprovement` have passed.

The problem with my problem instance is that `DiscoveredSolution.accepted` is always `true`, so `iterationsWithoutImprovement` never increments.

I dig a little deeper and found that in my problem setup, it is the `SchrimpfAcceptance` that is responsible to accept new solution.

I discover two things about `SchrimpfAcceptance`:
- if during its warmup the `initialThreshold` is found to be `0.0`, my problem can not be reproduced.
- but if the `initialThreshold` is found to be a positive number during the warmup, `SchrimpfAcceptance` become too permissive.

I wrote some unit tests that demonstrate exactly this behaviour in this PR.

For example, it accepts the `newSolution` even if `newSolution`'s `cost` is equal to the `worst`'s `cost`, and this is exactly my case: the solution improve in the first 100 iterations, but all the 9900 others, the costs are the same, but `SchrimpfAcceptance` do not reject the new identical solutions.

Even if I can explain my problem, I may be wrong here since I do not know the theory behind the Schrimpf algorithm. Please correct me if I am wrong.

But if I am not wrong, here is the fix:

I think this line:
https://github.com/pierredavidbelanger/jsprit/blob/master/jsprit-core/src/main/java/jsprit/core/algorithm/acceptor/SchrimpfAcceptance.java#L80

should be:

`if(newSolution.getCost() + threshold < worst.getCost())`

This branch fixes this issue:
https://github.com/pierredavidbelanger/jsprit/tree/schrimpf-acceptance-threshold-fix
