### PR TITLE
fix in Resource loading utils class to avoid using the filesystem

### DIFF
--- a/jsprit-core/src/main/java/jsprit/core/util/Resource.java
+++ b/jsprit-core/src/main/java/jsprit/core/util/Resource.java
@@ -35,32 +35,41 @@ public class Resource {
 	private static Logger log = Logger.getLogger(Resource.class);
 	
 	public final static URL getAsURL(final String filename) {
+		URL url = Resource.class.getClassLoader().getResource(filename);
+		if (url != null) {
+			return url;
+		}
+		log.info("Resource " + filename + " is unreachable by the current class loader, try the filesystem");
 		File file = new File(filename);
-		if (file.exists()) {
-			try {
-				return file.toURI().toURL();
-			} catch (MalformedURLException e) {
-				log.warn("Even resource exists, could not return its URL.", e);				
-			}
+		if (!file.exists()) {
+			log.warn("Resource " + filename + " do not exists on the filesystem");
+			return null;
 		}
-		URL url = Resource.class.getResource("/" + filename);
-		if (url == null) {
-			log.warn("Could not find resource '" + filename + "'!");
+		try {
+			return file.toURI().toURL();
+		} catch (MalformedURLException e) {
+			log.warn("Resource " + filename + " exists on the filesystem, but its URL is invalid: " + e.getMessage());
+			return null;
 		}
-		return url;
 	}
 
 	public final static InputStream getAsInputStream(final String filename) {
+		InputStream stream = Resource.class.getClassLoader().getResourceAsStream(filename);
+		if (stream != null) {
+			return stream;
+		}
+		log.info("Resource " + filename + " is unreachable by the current class loader, try the filesystem");
+		File file = new File(filename);
+		if (!file.exists()) {
+			log.warn("Resource " + filename + " do not exists on the filesystem");
+			return null;
+		}
 		try {
-			return new FileInputStream("/" + filename);
+			return new FileInputStream(file);
 		} catch (FileNotFoundException e) {
-			log.info("Could not find '" + filename + "'!.");
+			log.warn("Resource " + filename + " exists on the filesystem, but its URL is invalid: " + e.getMessage());
+			return null;
 		}
-		InputStream stream = Resource.class.getResourceAsStream("/" + filename);
-		if (stream == null) {
-			log.warn("Could not find resource '" + filename + "'!");
-		}
-		return stream;
 	}
 	
 }


### PR DESCRIPTION
Here is a little fix in your Resource util class.

This is a simple fix that change the order the search is done to find a resource.
Before this fix, a resource was searched first in the filesystem, then in the classpath.

This caused me some trouble with the platform as a service (Google AppEngine) I am using, because I am not allowed to use the filesystem.

Also, maybe, this bit of code will run a little faster since, at runtime, the majority of resource we want to load is in the classpath anyway.

I run all the tests, everything was green.

Let me know what you think!

Thank you
