### PR TITLE
penalty vehicles are not used when building initial solution

### DIFF
--- a/jsprit-core/src/test/java/jsprit/core/algorithm/InitialSolutionTest.java
+++ b/jsprit-core/src/test/java/jsprit/core/algorithm/InitialSolutionTest.java
@@ -1,0 +1,24 @@
+package jsprit.core.algorithm;
+
+import jsprit.core.algorithm.box.GreedySchrimpfFactory;
+import jsprit.core.problem.VehicleRoutingProblem;
+import jsprit.core.problem.job.Service;
+import jsprit.core.problem.solution.route.activity.TimeWindow;
+import jsprit.core.problem.vehicle.VehicleImpl;
+import jsprit.core.util.Coordinate;
+import org.junit.Test;
+
+public class InitialSolutionTest {
+
+	@Test
+	public void testPenaltyVehicleWithInitialSolution() {
+		VehicleRoutingProblem.Builder builder = VehicleRoutingProblem.Builder.newInstance();
+		builder.addVehicle(VehicleImpl.Builder.newInstance("v1").setEarliestStart(0).setLatestArrival(12).setStartLocationCoordinate(Coordinate.newInstance(1, 1)).build());
+		builder.addJob(Service.Builder.newInstance("j1").setCoord(Coordinate.newInstance(0, 0)).setTimeWindow(TimeWindow.newInstance(0, 12)).setServiceTime(1).build());
+		builder.addJob(Service.Builder.newInstance("j2").setCoord(Coordinate.newInstance(2, 2)).setTimeWindow(TimeWindow.newInstance(12, 24)).setServiceTime(1).build());
+		builder.addPenaltyVehicles(2.0);
+		VehicleRoutingProblem vrp = builder.build();
+		VehicleRoutingAlgorithm algorithm = new GreedySchrimpfFactory().createAlgorithm(vrp);
+		algorithm.searchSolutions();
+	}
+}


### PR DESCRIPTION
This one is not really meant to be integrated. I just want to demonstrate something and ask a question.

This test case is a simplification of a problem I am facing sometime:

When the time constraints are impossible to meet, but even when using penalty vehicles, it fail fast with the `NoSolutionFoundException: given the vehicles, could not insert job` error when the algorithm is creating the initial solution (`jsprit.core.algorithm.InsertionInitialSolutionFactory - create initial solution.`).

Is this the expected behaviour ?
I would have expected the initial solution to use a penalty vehicle (for `j2` in my test case).

How can I work around this ?

Thank you!
