### PR TITLE
Add an operationTimeFactor to Vehicle.

### DIFF
--- a/jsprit-core/src/main/java/jsprit/core/algorithm/recreate/AuxilliaryCostCalculator.java
+++ b/jsprit-core/src/main/java/jsprit/core/algorithm/recreate/AuxilliaryCostCalculator.java
@@ -22,6 +22,7 @@ import jsprit.core.problem.driver.Driver;
 import jsprit.core.problem.solution.route.activity.End;
 import jsprit.core.problem.solution.route.activity.TourActivity;
 import jsprit.core.problem.vehicle.Vehicle;
+import jsprit.core.util.CalculationUtils;
 
 import java.util.Iterator;
 import java.util.List;
@@ -69,7 +70,8 @@ final class AuxilliaryCostCalculator {
 			double transportTime = routingCosts.getTransportTime(prevAct.getLocation(), act.getLocation(), departureTimePrevAct, driver, vehicle);
 			cost += transportCost;
 			double actStartTime = departureTimePrevAct + transportTime;
-            departureTimePrevAct = Math.max(actStartTime, act.getTheoreticalEarliestOperationStartTime()) + act.getOperationTime();
+			double operationTime = CalculationUtils.getActivityOperationTime(vehicle, act);
+			departureTimePrevAct = Math.max(actStartTime, act.getTheoreticalEarliestOperationStartTime()) + operationTime;
 			cost += activityCosts.getActivityCost(act, actStartTime, driver, vehicle);
 			prevAct = act;
 		}

--- a/jsprit-core/src/main/java/jsprit/core/algorithm/recreate/LocalActivityInsertionCostsCalculator.java
+++ b/jsprit-core/src/main/java/jsprit/core/algorithm/recreate/LocalActivityInsertionCostsCalculator.java
@@ -54,7 +54,7 @@ class LocalActivityInsertionCostsCalculator implements ActivityInsertionCostsCal
 		double tp_costs_prevAct_newAct = routingCosts.getTransportCost(prevAct.getLocation(), newAct.getLocation(), depTimeAtPrevAct, iFacts.getNewDriver(), iFacts.getNewVehicle());
 		double tp_time_prevAct_newAct = routingCosts.getTransportTime(prevAct.getLocation(), newAct.getLocation(), depTimeAtPrevAct, iFacts.getNewDriver(), iFacts.getNewVehicle());
 		double newAct_arrTime = depTimeAtPrevAct + tp_time_prevAct_newAct;
-		double newAct_endTime = CalculationUtils.getActivityEndTime(newAct_arrTime, newAct);
+		double newAct_endTime = CalculationUtils.getActivityEndTime(newAct_arrTime, iFacts.getNewVehicle(), newAct);
 		double act_costs_newAct = activityCosts.getActivityCost(newAct, newAct_arrTime, iFacts.getNewDriver(), iFacts.getNewVehicle());
 		
 		//open routes

--- a/jsprit-core/src/main/java/jsprit/core/algorithm/recreate/ServiceInsertionCalculator.java
+++ b/jsprit-core/src/main/java/jsprit/core/algorithm/recreate/ServiceInsertionCalculator.java
@@ -136,7 +136,7 @@ final class ServiceInsertionCalculator implements JobInsertionCostsCalculator{
 				break;
 			}
 			double nextActArrTime = prevActStartTime + transportCosts.getTransportTime(prevAct.getLocation(), nextAct.getLocation(), prevActStartTime, newDriver, newVehicle);
-			prevActStartTime = CalculationUtils.getActivityEndTime(nextActArrTime, nextAct);
+			prevActStartTime = CalculationUtils.getActivityEndTime(nextActArrTime, newVehicle, nextAct);
 			prevAct = nextAct;
 			actIndex++;
 		}

--- a/jsprit-core/src/main/java/jsprit/core/algorithm/recreate/ServiceInsertionOnRouteLevelCalculator.java
+++ b/jsprit-core/src/main/java/jsprit/core/algorithm/recreate/ServiceInsertionOnRouteLevelCalculator.java
@@ -36,6 +36,7 @@ import jsprit.core.problem.solution.route.activity.TourActivity;
 import jsprit.core.problem.solution.route.state.RouteAndActivityStateGetter;
 import jsprit.core.problem.vehicle.Vehicle;
 import jsprit.core.problem.vehicle.VehicleImpl.NoVehicle;
+import jsprit.core.util.CalculationUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
@@ -206,7 +207,8 @@ final class ServiceInsertionOnRouteLevelCalculator implements JobInsertionCostsC
 			/**
 			 * departure time at nextAct with new vehicle
 			 */
-			double depTime_nextAct_newVehicle = Math.max(arrTime_nextAct_newVehicle, nextAct.getTheoreticalEarliestOperationStartTime()) + nextAct.getOperationTime();
+			double operationTime = CalculationUtils.getActivityOperationTime(newVehicle, nextAct);
+			double depTime_nextAct_newVehicle = Math.max(arrTime_nextAct_newVehicle, nextAct.getTheoreticalEarliestOperationStartTime()) + operationTime;
 
 			/**
 			 * set previous to next

--- a/jsprit-core/src/main/java/jsprit/core/algorithm/recreate/ShipmentInsertionCalculator.java
+++ b/jsprit-core/src/main/java/jsprit/core/algorithm/recreate/ShipmentInsertionCalculator.java
@@ -127,7 +127,7 @@ final class ShipmentInsertionCalculator implements JobInsertionCostsCalculator{
 			ConstraintsStatus pickupShipmentConstraintStatus = hardActivityLevelConstraint.fulfilled(insertionContext, prevAct, pickupShipment, activities.get(i), prevActEndTime);
 			if(pickupShipmentConstraintStatus.equals(ConstraintsStatus.NOT_FULFILLED)){
 				double nextActArrTime = prevActEndTime + transportCosts.getTransportTime(prevAct.getLocation(), activities.get(i).getLocation(), prevActEndTime, newDriver, newVehicle);
-				prevActEndTime = CalculationUtils.getActivityEndTime(nextActArrTime, activities.get(i));
+				prevActEndTime = CalculationUtils.getActivityEndTime(nextActArrTime, newVehicle, activities.get(i));
 				prevAct = activities.get(i);
 				continue;
 			}
@@ -140,7 +140,7 @@ final class ShipmentInsertionCalculator implements JobInsertionCostsCalculator{
 
 			TourActivity prevAct_deliveryLoop = pickupShipment;
 			double shipmentPickupArrTime = prevActEndTime + transportCosts.getTransportTime(prevAct.getLocation(), pickupShipment.getLocation(), prevActEndTime, newDriver, newVehicle);
-			double shipmentPickupEndTime = CalculationUtils.getActivityEndTime(shipmentPickupArrTime, pickupShipment);
+			double shipmentPickupEndTime = CalculationUtils.getActivityEndTime(shipmentPickupArrTime, newVehicle, pickupShipment);
 
             pickupContext.setArrivalTime(shipmentPickupArrTime);
             pickupContext.setEndTime(shipmentPickupEndTime);
@@ -169,7 +169,7 @@ final class ShipmentInsertionCalculator implements JobInsertionCostsCalculator{
 				}	
 				//update prevAct and endTime
 				double nextActArrTime = prevActEndTime_deliveryLoop + transportCosts.getTransportTime(prevAct_deliveryLoop.getLocation(), activities.get(j).getLocation(), prevActEndTime_deliveryLoop, newDriver, newVehicle);
-				prevActEndTime_deliveryLoop = CalculationUtils.getActivityEndTime(nextActArrTime, activities.get(j));
+				prevActEndTime_deliveryLoop = CalculationUtils.getActivityEndTime(nextActArrTime, newVehicle, activities.get(j));
 				prevAct_deliveryLoop = activities.get(j);
 			}
 			if(!deliverShipmentLoopBroken){ //check insertion between lastAct and endOfTour
@@ -188,7 +188,7 @@ final class ShipmentInsertionCalculator implements JobInsertionCostsCalculator{
 			}
 			//update prevAct and endTime
 			double nextActArrTime = prevActEndTime + transportCosts.getTransportTime(prevAct.getLocation(), activities.get(i).getLocation(), prevActEndTime, newDriver, newVehicle);
-			prevActEndTime = CalculationUtils.getActivityEndTime(nextActArrTime, activities.get(i));
+			prevActEndTime = CalculationUtils.getActivityEndTime(nextActArrTime, newVehicle, activities.get(i));
 			prevAct = activities.get(i);
 		}
 		if(!pickupShipmentLoopBroken){ //check insertion of pickupShipment and deliverShipment at just before tour ended
@@ -198,7 +198,7 @@ final class ShipmentInsertionCalculator implements JobInsertionCostsCalculator{
 				double pickupAIC = calculate(insertionContext,prevAct,pickupShipment,end,prevActEndTime);
 				TourActivity prevAct_deliveryLoop = pickupShipment;
 				double shipmentPickupArrTime = prevActEndTime + transportCosts.getTransportTime(prevAct.getLocation(), pickupShipment.getLocation(), prevActEndTime, newDriver, newVehicle);
-				double shipmentPickupEndTime = CalculationUtils.getActivityEndTime(shipmentPickupArrTime, pickupShipment);
+				double shipmentPickupEndTime = CalculationUtils.getActivityEndTime(shipmentPickupArrTime, newVehicle, pickupShipment);
 				double prevActEndTime_deliveryLoop = shipmentPickupEndTime;
 
                 pickupContext.setArrivalTime(shipmentPickupArrTime);

--- a/jsprit-core/src/main/java/jsprit/core/algorithm/recreate/VariableTransportCostCalculator.java
+++ b/jsprit-core/src/main/java/jsprit/core/algorithm/recreate/VariableTransportCostCalculator.java
@@ -38,7 +38,7 @@ public class VariableTransportCostCalculator implements SoftActivityConstraint{
 		double tp_time_prevAct_newAct = routingCosts.getTransportTime(prevAct.getLocation(), newAct.getLocation(), depTimeAtPrevAct, iFacts.getNewDriver(), iFacts.getNewVehicle());
 		
 		double newAct_arrTime = depTimeAtPrevAct + tp_time_prevAct_newAct;
-		double newAct_endTime = CalculationUtils.getActivityEndTime(newAct_arrTime, newAct);
+		double newAct_endTime = CalculationUtils.getActivityEndTime(newAct_arrTime, iFacts.getNewVehicle(), newAct);
 		
 		//open routes
 		if(nextAct instanceof End){

--- a/jsprit-core/src/main/java/jsprit/core/algorithm/state/UpdateActivityTimes.java
+++ b/jsprit-core/src/main/java/jsprit/core/algorithm/state/UpdateActivityTimes.java
@@ -70,6 +70,7 @@ public class UpdateActivityTimes implements ActivityVisitor, StateUpdater{
 		timeTracker.visit(activity);
 		activity.setArrTime(timeTracker.getActArrTime());
 		activity.setEndTime(timeTracker.getActEndTime());
+		activity.setOperationTime(timeTracker.getActOperationTime());
 	}
 
 	@Override

--- a/jsprit-core/src/main/java/jsprit/core/algorithm/state/UpdatePracticalTimeWindows.java
+++ b/jsprit-core/src/main/java/jsprit/core/algorithm/state/UpdatePracticalTimeWindows.java
@@ -20,6 +20,7 @@ import jsprit.core.problem.cost.VehicleRoutingTransportCosts;
 import jsprit.core.problem.solution.route.VehicleRoute;
 import jsprit.core.problem.solution.route.activity.ReverseActivityVisitor;
 import jsprit.core.problem.solution.route.activity.TourActivity;
+import jsprit.core.util.CalculationUtils;
 
 /**
  * Updates and memorizes latest operation start times at activities.
@@ -54,7 +55,8 @@ class UpdatePracticalTimeWindows implements ReverseActivityVisitor, StateUpdater
 
 	@Override
 	public void visit(TourActivity activity) {
-		double potentialLatestArrivalTimeAtCurrAct = latestArrTimeAtPrevAct - transportCosts.getBackwardTransportTime(activity.getLocation(), prevAct.getLocation(), latestArrTimeAtPrevAct, route.getDriver(),route.getVehicle()) - activity.getOperationTime();
+		double operationTime = CalculationUtils.getActivityOperationTime(route.getVehicle(), activity);
+		double potentialLatestArrivalTimeAtCurrAct = latestArrTimeAtPrevAct - transportCosts.getBackwardTransportTime(activity.getLocation(), prevAct.getLocation(), latestArrTimeAtPrevAct, route.getDriver(), route.getVehicle()) - operationTime;
 		double latestArrivalTime = Math.min(activity.getTheoreticalLatestOperationStartTime(), potentialLatestArrivalTimeAtCurrAct);
 		
 		states.putInternalTypedActivityState(activity, InternalStates.LATEST_OPERATION_START_TIME, latestArrivalTime);

--- a/jsprit-core/src/main/java/jsprit/core/algorithm/state/UpdateVehicleDependentPracticalTimeWindows.java
+++ b/jsprit-core/src/main/java/jsprit/core/algorithm/state/UpdateVehicleDependentPracticalTimeWindows.java
@@ -23,6 +23,7 @@ import jsprit.core.problem.solution.route.VehicleRoute;
 import jsprit.core.problem.solution.route.activity.ReverseActivityVisitor;
 import jsprit.core.problem.solution.route.activity.TourActivity;
 import jsprit.core.problem.vehicle.Vehicle;
+import jsprit.core.util.CalculationUtils;
 
 import java.util.Arrays;
 import java.util.Collection;
@@ -83,10 +84,11 @@ public class UpdateVehicleDependentPracticalTimeWindows implements ReverseActivi
         for(Vehicle vehicle : vehicles){
             double latestArrTimeAtPrevAct = latest_arrTimes_at_prevAct[vehicle.getVehicleTypeIdentifier().getIndex()];
             Location prevLocation = location_of_prevAct[vehicle.getVehicleTypeIdentifier().getIndex()];
-            double potentialLatestArrivalTimeAtCurrAct = latestArrTimeAtPrevAct - transportCosts.getBackwardTransportTime(activity.getLocation(), prevLocation,
-                    latestArrTimeAtPrevAct, route.getDriver(), vehicle) - activity.getOperationTime();
-            double latestArrivalTime = Math.min(activity.getTheoreticalLatestOperationStartTime(), potentialLatestArrivalTimeAtCurrAct);
-            stateManager.putInternalTypedActivityState(activity, vehicle, InternalStates.LATEST_OPERATION_START_TIME, latestArrivalTime);
+			double operationTime = CalculationUtils.getActivityOperationTime(vehicle, activity);
+			double potentialLatestArrivalTimeAtCurrAct = latestArrTimeAtPrevAct - transportCosts.getBackwardTransportTime(activity.getLocation(), prevLocation,
+					latestArrTimeAtPrevAct, route.getDriver(), vehicle) - operationTime;
+			double latestArrivalTime = Math.min(activity.getTheoreticalLatestOperationStartTime(), potentialLatestArrivalTimeAtCurrAct);
+			stateManager.putInternalTypedActivityState(activity, vehicle, InternalStates.LATEST_OPERATION_START_TIME, latestArrivalTime);
             latest_arrTimes_at_prevAct[vehicle.getVehicleTypeIdentifier().getIndex()] = latestArrivalTime;
             location_of_prevAct[vehicle.getVehicleTypeIdentifier().getIndex()] = activity.getLocation();
         }

--- a/jsprit-core/src/main/java/jsprit/core/analysis/SolutionAnalyser.java
+++ b/jsprit-core/src/main/java/jsprit/core/analysis/SolutionAnalyser.java
@@ -29,6 +29,7 @@ import jsprit.core.problem.solution.VehicleRoutingProblemSolution;
 import jsprit.core.problem.solution.route.VehicleRoute;
 import jsprit.core.problem.solution.route.activity.*;
 import jsprit.core.util.ActivityTimeTracker;
+import jsprit.core.util.CalculationUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
@@ -286,9 +287,9 @@ public class SolutionAnalyser {
             sum_transport_time += transportTime;
             prevActDeparture = activity.getEndTime();
             //service time
-            sum_service_time += activity.getOperationTime();
-            
-            stateManager.putActivityState(activity, transport_time_id, sum_transport_time);
+			sum_service_time += CalculationUtils.getActivityOperationTime(route.getVehicle(), activity);
+
+			stateManager.putActivityState(activity, transport_time_id, sum_transport_time);
 
         }
 

--- a/jsprit-core/src/main/java/jsprit/core/problem/AbstractActivity.java
+++ b/jsprit-core/src/main/java/jsprit/core/problem/AbstractActivity.java
@@ -8,8 +8,18 @@ import jsprit.core.problem.solution.route.activity.TourActivity;
 public abstract class AbstractActivity implements TourActivity {
 
     private int index;
+	private double operationTime = -1;
 
     public int getIndex(){ return index; }
 
     protected void setIndex(int index){ this.index = index; }
+
+	@Override
+	public double getOperationTime() {
+		return operationTime;
+	}
+
+	public void setOperationTime(double operationTime) {
+		this.operationTime = operationTime;
+	}
 }

--- a/jsprit-core/src/main/java/jsprit/core/problem/constraint/AdditionalTransportationCosts.java
+++ b/jsprit-core/src/main/java/jsprit/core/problem/constraint/AdditionalTransportationCosts.java
@@ -57,7 +57,7 @@ class AdditionalTransportationCosts implements SoftActivityConstraint{
 		double tp_time_prevAct_newAct = routingCosts.getTransportTime(prevAct.getLocation(), newAct.getLocation(), depTimeAtPrevAct, iFacts.getNewDriver(), iFacts.getNewVehicle());
 		
 		double newAct_arrTime = depTimeAtPrevAct + tp_time_prevAct_newAct;
-		double newAct_endTime = CalculationUtils.getActivityEndTime(newAct_arrTime, newAct);
+		double newAct_endTime = CalculationUtils.getActivityEndTime(newAct_arrTime, iFacts.getNewVehicle(), newAct);
 		
 		//open routes
 		if(nextAct instanceof End){

--- a/jsprit-core/src/main/java/jsprit/core/problem/constraint/TimeWindowConstraint.java
+++ b/jsprit-core/src/main/java/jsprit/core/problem/constraint/TimeWindowConstraint.java
@@ -107,7 +107,7 @@ import jsprit.core.util.CalculationUtils;
 
             double latestArrTimeAtNewAct = Math.min(newAct.getTheoreticalLatestOperationStartTime(),latestArrTimeAtNextAct -
                     routingCosts.getBackwardTransportTime(nextActLocation, newAct.getLocation(), latestArrTimeAtNextAct, iFacts.getNewDriver(),
-                            iFacts.getNewVehicle()) - newAct.getOperationTime());
+							iFacts.getNewVehicle()) - CalculationUtils.getActivityOperationTime(iFacts.getNewVehicle(), newAct));
 			/*
 			 *  |--- prevAct ---|
 			 *                       		                 |--- vehicle's arrival @newAct
@@ -123,7 +123,7 @@ import jsprit.core.util.CalculationUtils;
 				}
 			}
 //			log.info(newAct + " arrTime=" + arrTimeAtNewAct);
-			double endTimeAtNewAct = CalculationUtils.getActivityEndTime(arrTimeAtNewAct, newAct);
+			double endTimeAtNewAct = CalculationUtils.getActivityEndTime(arrTimeAtNewAct, iFacts.getNewVehicle(), newAct);
 			double arrTimeAtNextAct = endTimeAtNewAct + routingCosts.getTransportTime(newAct.getLocation(), nextAct.getLocation(), endTimeAtNewAct, iFacts.getNewDriver(), iFacts.getNewVehicle());
 
 			/*

--- a/jsprit-core/src/main/java/jsprit/core/problem/constraint/VehicleDependentTimeWindowConstraints.java
+++ b/jsprit-core/src/main/java/jsprit/core/problem/constraint/VehicleDependentTimeWindowConstraints.java
@@ -112,13 +112,13 @@ public class VehicleDependentTimeWindowConstraints implements HardActivityConstr
         }
         //			log.info("check insertion of " + newAct + " between " + prevAct + " and " + nextAct + ". prevActDepTime=" + prevActDepTime);
         double arrTimeAtNewAct = prevActDepTime + routingCosts.getTransportTime(prevAct.getLocation(), newAct.getLocation(), prevActDepTime, iFacts.getNewDriver(), iFacts.getNewVehicle());
-        double endTimeAtNewAct = CalculationUtils.getActivityEndTime(arrTimeAtNewAct, newAct);
-        double latestArrTimeAtNewAct =
-                Math.min(newAct.getTheoreticalLatestOperationStartTime(),
+		double endTimeAtNewAct = CalculationUtils.getActivityEndTime(arrTimeAtNewAct, iFacts.getNewVehicle(), newAct);
+		double latestArrTimeAtNewAct =
+				Math.min(newAct.getTheoreticalLatestOperationStartTime(),
                         latestArrTimeAtNextAct -
                                 routingCosts.getBackwardTransportTime(newAct.getLocation(),nextActLocation,latestArrTimeAtNextAct,iFacts.getNewDriver(),iFacts.getNewVehicle())
-                                    - newAct.getOperationTime()
-                );
+								- CalculationUtils.getActivityOperationTime(iFacts.getNewVehicle(), newAct)
+				);
 //ToDo: SUSPICIOUS - hier muss noch operation time weg
 			/*
 			 *  |--- prevAct ---|

--- a/jsprit-core/src/main/java/jsprit/core/problem/solution/route/activity/DeliverService.java
+++ b/jsprit-core/src/main/java/jsprit/core/problem/solution/route/activity/DeliverService.java
@@ -43,6 +43,7 @@ public final class DeliverService extends AbstractActivity implements DeliveryAc
 		this.endTime=deliveryActivity.getEndTime();
 		capacity = deliveryActivity.getSize();
         setIndex(deliveryActivity.getIndex());
+		setOperationTime(deliveryActivity.getOperationTime());
 	}
 
 	@Override
@@ -71,7 +72,7 @@ public final class DeliverService extends AbstractActivity implements DeliveryAc
 	}
 
 	@Override
-	public double getOperationTime() {
+	public double getTheoreticalOperationTime() {
 		return delivery.getServiceDuration();
 	}
 

--- a/jsprit-core/src/main/java/jsprit/core/problem/solution/route/activity/DeliverShipment.java
+++ b/jsprit-core/src/main/java/jsprit/core/problem/solution/route/activity/DeliverShipment.java
@@ -45,6 +45,7 @@ public final class DeliverShipment extends AbstractActivity implements DeliveryA
 		this.endTime = deliveryShipmentActivity.getEndTime();
 		this.capacity = deliveryShipmentActivity.getSize();
         setIndex(deliveryShipmentActivity.getIndex());
+		setOperationTime(deliveryShipmentActivity.getOperationTime());
 	}
 
 	@Override
@@ -78,7 +79,7 @@ public final class DeliverShipment extends AbstractActivity implements DeliveryA
 	}
 
 	@Override
-	public double getOperationTime() {
+	public double getTheoreticalOperationTime() {
 		return shipment.getDeliveryServiceTime();
 	}
 

--- a/jsprit-core/src/main/java/jsprit/core/problem/solution/route/activity/End.java
+++ b/jsprit-core/src/main/java/jsprit/core/problem/solution/route/activity/End.java
@@ -135,10 +135,14 @@ public final class End extends AbstractActivity implements TourActivity {
     }
 
     @Override
-	public double getOperationTime() {
+	public double getTheoreticalOperationTime() {
 		return 0.0;
 	}
 
+	@Override
+	public double getOperationTime() {
+		return getTheoreticalOperationTime();
+	}
 
 	@Override
 	public String toString() {

--- a/jsprit-core/src/main/java/jsprit/core/problem/solution/route/activity/PickupService.java
+++ b/jsprit-core/src/main/java/jsprit/core/problem/solution/route/activity/PickupService.java
@@ -44,6 +44,7 @@ public final class PickupService extends AbstractActivity implements PickupActiv
 		this.arrTime=pickupActivity.getArrTime();
 		this.depTime=pickupActivity.getEndTime();
         setIndex(pickupActivity.getIndex());
+		setOperationTime(pickupActivity.getOperationTime());
 	}
 
 	@Override
@@ -72,7 +73,7 @@ public final class PickupService extends AbstractActivity implements PickupActiv
 	}
 
 	@Override
-	public double getOperationTime() {
+	public double getTheoreticalOperationTime() {
 		return pickup.getServiceDuration();
 	}
 

--- a/jsprit-core/src/main/java/jsprit/core/problem/solution/route/activity/PickupShipment.java
+++ b/jsprit-core/src/main/java/jsprit/core/problem/solution/route/activity/PickupShipment.java
@@ -41,6 +41,7 @@ public final class PickupShipment extends AbstractActivity implements PickupActi
 		this.arrTime = pickupShipmentActivity.getArrTime();
 		this.endTime = pickupShipmentActivity.getEndTime();
         setIndex(pickupShipmentActivity.getIndex());
+		setOperationTime(pickupShipmentActivity.getOperationTime());
 	}
 
 	@Override
@@ -74,7 +75,7 @@ public final class PickupShipment extends AbstractActivity implements PickupActi
 	}
 
 	@Override
-	public double getOperationTime() {
+	public double getTheoreticalOperationTime() {
 		return shipment.getPickupServiceTime();
 	}
 

--- a/jsprit-core/src/main/java/jsprit/core/problem/solution/route/activity/ServiceActivity.java
+++ b/jsprit-core/src/main/java/jsprit/core/problem/solution/route/activity/ServiceActivity.java
@@ -80,6 +80,7 @@ public class ServiceActivity extends AbstractActivity implements JobActivity{
 		this.arrTime = serviceActivity.getArrTime();
 		this.endTime = serviceActivity.getEndTime();
         setIndex(serviceActivity.getIndex());
+		setOperationTime(serviceActivity.getOperationTime());
 	}
 	
 	
@@ -123,7 +124,7 @@ public class ServiceActivity extends AbstractActivity implements JobActivity{
 	}
 
 	@Override
-	public double getOperationTime() {
+	public double getTheoreticalOperationTime() {
 		return service.getServiceDuration();
 	}
 

--- a/jsprit-core/src/main/java/jsprit/core/problem/solution/route/activity/Start.java
+++ b/jsprit-core/src/main/java/jsprit/core/problem/solution/route/activity/Start.java
@@ -114,8 +114,13 @@ public final class Start extends AbstractActivity implements TourActivity {
     }
 
     @Override
-	public double getOperationTime() {
+	public double getTheoreticalOperationTime() {
 		return 0.0;
+	}
+
+	@Override
+	public double getOperationTime() {
+		return getTheoreticalOperationTime();
 	}
 
 	@Override

--- a/jsprit-core/src/main/java/jsprit/core/problem/solution/route/activity/TourActivity.java
+++ b/jsprit-core/src/main/java/jsprit/core/problem/solution/route/activity/TourActivity.java
@@ -91,15 +91,31 @@ public interface TourActivity extends HasIndex {
 	public abstract double getTheoreticalLatestOperationStartTime();
 
 	/**
-	 * Returns the operation-time this activity takes.
+	 * Returns the theoretical operation-time this activity takes.
 	 * 
 	 * <p>Note that this is not necessarily the duration of this activity, but the 
 	 * service time a pickup/delivery actually takes, that is for example <code>service.getServiceTime()</code>.
-	 *  
-	 * @return operation time
+	 *
+	 * @return theoretical operation time
+	 */
+	public abstract double getTheoreticalOperationTime();
+
+	/**
+	 * Returns the actual operation-time this activity takes.
+	 * <p/>
+	 * <p>Note that this is time is taking into account the vehicle operation time factor if set.
+	 *
+	 * @return theoretical operation time
 	 */
 	public abstract double getOperationTime();
-	
+
+	/**
+	 * Set the actual operation-time this activity takes.
+	 *
+	 * @param operationTime the actual operation-time
+	 */
+	public abstract void setOperationTime(double operationTime);
+
 	/**
 	 * Returns the arrival-time of this activity.
 	 * 

--- a/jsprit-core/src/main/java/jsprit/core/problem/vehicle/Vehicle.java
+++ b/jsprit-core/src/main/java/jsprit/core/problem/vehicle/Vehicle.java
@@ -98,4 +98,13 @@ public interface Vehicle extends HasId, HasIndex {
     public abstract VehicleTypeKey getVehicleTypeIdentifier();
 
     public abstract Skills getSkills();
+
+	/**
+	 * This factor is used to calculate the actual operation time (ActEndTime) for an activity when this vehicle is doing it.
+	 * <p/>
+	 * If this field is set to 1.5 and the job operation time is 1h, it means that this vehicle will do it in 1.5h.
+	 *
+	 * @return the operation time factor for this vehicle
+	 */
+	public abstract Float getOperationTimeFactor();
 }

--- a/jsprit-core/src/main/java/jsprit/core/problem/vehicle/VehicleImpl.java
+++ b/jsprit-core/src/main/java/jsprit/core/problem/vehicle/VehicleImpl.java
@@ -112,7 +112,12 @@ public class VehicleImpl extends AbstractVehicle{
         public Skills getSkills() {
             return null;
         }
-    }
+
+		@Override
+		public Float getOperationTimeFactor() {
+			return null;
+		}
+	}
 	
 	/**
 	 * Builder that builds the vehicle.
@@ -158,7 +163,9 @@ public class VehicleImpl extends AbstractVehicle{
 
         private Location endLocation;
 
-        private Builder(String id) {
+		private Float operationTimeFactor;
+
+		private Builder(String id) {
 			super();
 			this.id = id;
 		}
@@ -290,7 +297,12 @@ public class VehicleImpl extends AbstractVehicle{
             skillBuilder.addSkill(skill);
             return this;
         }
-		
+
+		public Builder setOperationTimeFactor(Float operationTimeFactor) {
+			this.operationTimeFactor = operationTimeFactor;
+			return this;
+		}
+
 		/**
 		 * Builds and returns the vehicle.
 		 * 
@@ -381,6 +393,8 @@ public class VehicleImpl extends AbstractVehicle{
 
     private final Location startLocation;
 
+	private final Float operationTimeFactor;
+
 	private VehicleImpl(Builder builder){
 		id = builder.id;
 		type = builder.type;
@@ -390,7 +404,8 @@ public class VehicleImpl extends AbstractVehicle{
 	    skills = builder.skills;
         endLocation = builder.endLocation;
         startLocation = builder.startLocation;
-        setVehicleIdentifier(new VehicleTypeKey(type.getTypeId(),startLocation.getId(),endLocation.getId(),earliestDeparture,latestArrival,skills));
+		operationTimeFactor = builder.operationTimeFactor;
+		setVehicleIdentifier(new VehicleTypeKey(type.getTypeId(), startLocation.getId(), endLocation.getId(), earliestDeparture, latestArrival, skills));
 	}
 	
 	/**
@@ -466,7 +481,12 @@ public class VehicleImpl extends AbstractVehicle{
     @Override
     public Skills getSkills() {
         return skills;
-    }
+	}
+
+	@Override
+	public Float getOperationTimeFactor() {
+		return operationTimeFactor;
+	}
 
     /* (non-Javadoc)
      * @see java.lang.Object#hashCode()

--- a/jsprit-core/src/main/java/jsprit/core/util/ActivityTimeTracker.java
+++ b/jsprit-core/src/main/java/jsprit/core/util/ActivityTimeTracker.java
@@ -43,7 +43,9 @@ public class ActivityTimeTracker implements ActivityVisitor{
 	
 	private double actEndTime;
 
-    private ActivityPolicy activityPolicy = ActivityPolicy.AS_SOON_AS_TIME_WINDOW_OPENS;
+	private double actOperationTime;
+
+	private ActivityPolicy activityPolicy = ActivityPolicy.AS_SOON_AS_TIME_WINDOW_OPENS;
 	
 	public ActivityTimeTracker(ForwardTransportTime transportTime) {
 		super();
@@ -63,7 +65,11 @@ public class ActivityTimeTracker implements ActivityVisitor{
 	public double getActEndTime(){
 		return actEndTime;
 	}
-	
+
+	public double getActOperationTime() {
+		return actOperationTime;
+	}
+
 	@Override
 	public void begin(VehicleRoute route) {
 		prevAct = route.getStart(); 
@@ -90,7 +96,9 @@ public class ActivityTimeTracker implements ActivityVisitor{
         }
 		else operationStartTime = actArrTime;
 
-		double operationEndTime = operationStartTime + activity.getOperationTime();
+		actOperationTime = CalculationUtils.getActivityOperationTime(route.getVehicle(), activity);
+
+		double operationEndTime = operationStartTime + actOperationTime;
 		
 		actEndTime = operationEndTime;
 		

--- a/jsprit-core/src/main/java/jsprit/core/util/CalculationUtils.java
+++ b/jsprit-core/src/main/java/jsprit/core/util/CalculationUtils.java
@@ -19,9 +19,18 @@
 package jsprit.core.util;
 
 import jsprit.core.problem.solution.route.activity.TourActivity;
+import jsprit.core.problem.vehicle.Vehicle;
 
 public class CalculationUtils {
-	
+
+	public static double getActivityOperationTime(Vehicle vehicle, TourActivity act) {
+		if (act.getOperationTime() != -1)
+			return act.getOperationTime();
+		double operationTime = act.getTheoreticalOperationTime();
+		if (vehicle != null && vehicle.getOperationTimeFactor() != null)
+			operationTime *= vehicle.getOperationTimeFactor();
+		return operationTime;
+	}
 
 	/**
 	 * Calculates actEndTime assuming that activity can at earliest start at act.getTheoreticalEarliestOperationStartTime().
@@ -30,7 +39,7 @@ public class CalculationUtils {
 	 * @param act
 	 * @return
 	 */
-	public static double getActivityEndTime(double actArrTime, TourActivity act){
-		return Math.max(actArrTime, act.getTheoreticalEarliestOperationStartTime()) + act.getOperationTime();
+	public static double getActivityEndTime(double actArrTime, Vehicle vehicle, TourActivity act) {
+		return Math.max(actArrTime, act.getTheoreticalEarliestOperationStartTime()) + getActivityOperationTime(vehicle, act);
 	}
 }

--- a/jsprit-core/src/test/java/jsprit/core/algorithm/ExampleActivityCostFunction.java
+++ b/jsprit-core/src/test/java/jsprit/core/algorithm/ExampleActivityCostFunction.java
@@ -21,6 +21,7 @@ import jsprit.core.problem.driver.Driver;
 import jsprit.core.problem.solution.route.activity.TourActivity;
 import jsprit.core.problem.solution.route.activity.TourActivity.JobActivity;
 import jsprit.core.problem.vehicle.Vehicle;
+import jsprit.core.util.CalculationUtils;
 
 
 public class ExampleActivityCostFunction implements VehicleRoutingActivityCosts{
@@ -41,7 +42,8 @@ public class ExampleActivityCostFunction implements VehicleRoutingActivityCosts{
 		}
 		else{
 			//waiting + act-time
-			double endTime = Math.max(arrivalTime, tourAct.getTheoreticalEarliestOperationStartTime()) + tourAct.getOperationTime();
+			double operationTime = CalculationUtils.getActivityOperationTime(vehicle, tourAct);
+			double endTime = Math.max(arrivalTime, tourAct.getTheoreticalEarliestOperationStartTime()) + operationTime;
 			double timeAtAct = endTime - arrivalTime;
 			
 			double totalCost = timeAtAct * parameter_timeAtAct;

--- a/jsprit-core/src/test/java/jsprit/core/util/ActivityTimeTrackerTest.java
+++ b/jsprit-core/src/test/java/jsprit/core/util/ActivityTimeTrackerTest.java
@@ -1,0 +1,76 @@
+package jsprit.core.util;
+
+import jsprit.core.problem.Location;
+import jsprit.core.problem.cost.ForwardTransportTime;
+import jsprit.core.problem.driver.Driver;
+import jsprit.core.problem.job.Service;
+import jsprit.core.problem.solution.route.VehicleRoute;
+import jsprit.core.problem.solution.route.activity.TourActivity;
+import jsprit.core.problem.vehicle.Vehicle;
+import jsprit.core.problem.vehicle.VehicleImpl;
+import junit.framework.Assert;
+import org.junit.Test;
+
+public class ActivityTimeTrackerTest {
+
+	protected void testActivityTimeTrackerForVehicleOperationTimeFactor(final double transportTime, double serviceTime, Float serviceTimeFactor, double expectedActEndTime) {
+
+		Location startLocation = Location.newInstance("1");
+		Vehicle vehicle = VehicleImpl.Builder.newInstance("1")
+				.setStartLocation(startLocation)
+				.setEarliestStart(0)
+				.setOperationTimeFactor(serviceTimeFactor)
+				.build();
+
+		Location serviceLocation = Location.newInstance("2");
+		Service service = Service.Builder.newInstance("1")
+				.setServiceTime(serviceTime)
+				.setLocation(serviceLocation)
+				.build();
+
+		VehicleRoute vehicleRoute = VehicleRoute.Builder.newInstance(vehicle).addService(service).build();
+		TourActivity startActivity = vehicleRoute.getStart();
+		TourActivity serviceActivity = vehicleRoute.getActivities().get(0);
+
+		ForwardTransportTime forwardTransportTime = new ForwardTransportTime() {
+			@Override
+			public double getTransportTime(Location from, Location to, double departureTime, Driver driver, Vehicle vehicle) {
+				if (from.equals(to)) return 0;
+				return transportTime;
+			}
+		};
+
+		ActivityTimeTracker activityTimeTracker = new ActivityTimeTracker(forwardTransportTime);
+
+		activityTimeTracker.begin(vehicleRoute);
+		activityTimeTracker.visit(startActivity);
+		activityTimeTracker.visit(serviceActivity);
+
+		Assert.assertEquals(expectedActEndTime, activityTimeTracker.getActEndTime(), 0.001);
+	}
+
+	@Test
+	public void whenVehicleDoNotSpecifyOperationTimeFactor_itShouldNotChangeTheActEndTime() {
+		testActivityTimeTrackerForVehicleOperationTimeFactor(1, 1, null, 2);
+	}
+
+	@Test
+	public void whenVehicleSpecifyNeutralOperationTimeFactor_itShouldNotChangeTheActEndTime() {
+		testActivityTimeTrackerForVehicleOperationTimeFactor(1, 1, 1f, 2);
+	}
+
+	@Test
+	public void whenVehicleSpecifyHighOperationTimeFactor_itShouldChangeTheActEndTimeAccordingly() {
+		testActivityTimeTrackerForVehicleOperationTimeFactor(1, 1, 1.5f, 2.5d);
+	}
+
+	@Test
+	public void whenVehicleSpecifyLowOperationTimeFactor_itShouldChangeTheActEndTimeAccordingly() {
+		testActivityTimeTrackerForVehicleOperationTimeFactor(1, 1, 0.5f, 1.5d);
+	}
+
+	@Test
+	public void whenVehicleSpecifyOperationTimeFactorButJobOperationTimeIsZero_itShouldNotChangeTheActEndTime() {
+		testActivityTimeTrackerForVehicleOperationTimeFactor(1, 0, 2f, 1d);
+	}
+}

--- a/jsprit-examples/src/main/java/jsprit/examples/BicycleMessenger.java
+++ b/jsprit-examples/src/main/java/jsprit/examples/BicycleMessenger.java
@@ -48,6 +48,7 @@ import jsprit.core.problem.vehicle.VehicleImpl;
 import jsprit.core.problem.vehicle.VehicleType;
 import jsprit.core.problem.vehicle.VehicleTypeImpl;
 import jsprit.core.reporting.SolutionPrinter;
+import jsprit.core.util.CalculationUtils;
 import jsprit.core.util.Coordinate;
 import jsprit.core.util.CrowFlyCosts;
 import jsprit.core.util.Solutions;
@@ -127,8 +128,8 @@ public class BicycleMessenger {
 			}
 
 			//impact on whole route, since insertion of newAct shifts all subsequent activities forward in time
-			double departureTime_at_newAct = arrTime_at_newAct + newAct.getOperationTime();
-            double latest_arrTime_at_newAct = latest_arrTime_at_nextAct - routingCosts.getTransportTime(newAct.getLocation(),nextAct.getLocation(),departureTime_at_newAct,iFacts.getNewDriver(),iFacts.getNewVehicle());
+			double departureTime_at_newAct = arrTime_at_newAct + CalculationUtils.getActivityOperationTime(iFacts.getNewVehicle(), newAct);
+			double latest_arrTime_at_newAct = latest_arrTime_at_nextAct - routingCosts.getTransportTime(newAct.getLocation(),nextAct.getLocation(),departureTime_at_newAct,iFacts.getNewDriver(),iFacts.getNewVehicle());
 			if(arrTime_at_newAct > latest_arrTime_at_newAct){
                 return ConstraintsStatus.NOT_FULFILLED;
             }
@@ -215,7 +216,7 @@ public class BicycleMessenger {
 		public void visit(TourActivity currAct) {
 			double timeOfNearestMessenger = bestMessengers.get(((JobActivity)currAct).getJob().getId());
 			double potential_latest_arrTime_at_currAct =
-					latest_arrTime_at_prevAct - routingCosts.getBackwardTransportTime(currAct.getLocation(), prevAct.getLocation(), latest_arrTime_at_prevAct, route.getDriver(),route.getVehicle()) - currAct.getOperationTime();
+					latest_arrTime_at_prevAct - routingCosts.getBackwardTransportTime(currAct.getLocation(), prevAct.getLocation(), latest_arrTime_at_prevAct, route.getDriver(), route.getVehicle()) - CalculationUtils.getActivityOperationTime(route.getVehicle(), currAct);
 			double latest_arrTime_at_currAct = Math.min(3*timeOfNearestMessenger, potential_latest_arrTime_at_currAct);
 			stateManager.putActivityState(currAct, latest_act_arrival_time_stateId, latest_arrTime_at_currAct);
 			assert currAct.getArrTime() <= latest_arrTime_at_currAct : "this must not be since it breaks condition; actArrTime: " + currAct.getArrTime() + " latestArrTime: " + latest_arrTime_at_currAct + " vehicle: " + route.getVehicle().getId();


### PR DESCRIPTION
It allows one to change the job duration according to a kind of performance factor.

For example: if a vehicle operationTimeFactor field is set to 1.5 and a job operation time is 1h, it means that this vehicle will do it in 1.5h.

This is something I needed in my application, and I did not see how this was able to achieve without modding the code.

I leave this for you to look and comment.
Do not hesitate to ask questions or make me change my code :)

All tests are ok.
This commit will break only one public method : CalculationUtils.getActivityEndTime