### PR TITLE
counter correct index

### DIFF
--- a/jsprit-core/src/main/java/com/graphhopper/jsprit/core/algorithm/VehicleRoutingAlgorithm.java
+++ b/jsprit-core/src/main/java/com/graphhopper/jsprit/core/algorithm/VehicleRoutingAlgorithm.java
@@ -72,7 +72,7 @@ public class VehicleRoutingAlgorithm {
         }
 
         public void incCounter() {
-            long i = counter++;
+            long i = ++counter;
             long n = nextCounter;
             if (i >= n) {
                 nextCounter = n * 2;


### PR DESCRIPTION
Because of
x = 1;
y = ++x;
System.out.println(y);
prints 2

,And
x = 1;
y = x++;
System.out.println(y);
prints 1

Currently, the logger prints iterations 1 after the iterationEnds of 1 has already been printed.
Here is the fix