### PR TITLE
Bug createStateId inside StateUpdater

### DIFF
--- a/jsprit-examples/src/main/java/com/graphhopper/jsprit/examples/JobAndActivityDependenciesExample.java
+++ b/jsprit-examples/src/main/java/com/graphhopper/jsprit/examples/JobAndActivityDependenciesExample.java
@@ -78,6 +78,9 @@ public class JobAndActivityDependenciesExample {
 
         @Override
         public void visit(TourActivity activity) {
+            String jobId = ((TourActivity.JobActivity) activity).getJob().getId();
+            stateManager.createStateId(jobId);
+            
             if (((TourActivity.JobActivity) activity).getJob().getName().equals("use key")) {
                 stateManager.putProblemState(keyUsedStateId, VehicleRoute.class, route);
             } else if (((TourActivity.JobActivity) activity).getJob().getName().equals("get key")) {


### PR DESCRIPTION
When different statesId are created inside a stateUpdate it throws
java.lang.IllegalArgumentException: arg must not be null
at com.graphhopper.jsprit.core.problem.Capacity.max(Capacity.java:279)