### PR TITLE
fix memory leak

### DIFF
--- a/jsprit-core/src/main/java/com/graphhopper/jsprit/core/algorithm/box/Jsprit.java
+++ b/jsprit-core/src/main/java/com/graphhopper/jsprit/core/algorithm/box/Jsprit.java
@@ -629,12 +629,20 @@ public class Jsprit {
             });
         }
         if (es != null) {
-            Runtime.getRuntime().addShutdownHook(new Thread() {
+            final Thread hook = new Thread() {
                 public void run() {
                     if (!es.isShutdown()) {
                         System.err.println("shutdowHook shuts down executorService");
                         es.shutdown();
                     }
+                }
+            };
+            Runtime.getRuntime().addShutdownHook(hook);
+            vra.addListener(new AlgorithmEndsListener() {
+                @Override
+                public void informAlgorithmEnds(VehicleRoutingProblem aProblem,
+                        Collection<VehicleRoutingProblemSolution> aSolutions) {
+                    Runtime.getRuntime().removeShutdownHook(hook);
                 }
             });
         }


### PR DESCRIPTION
I noticed a memory leak in my production environment. It can be reproduced with custom TransportCosts and huge array in it(after some amount of invocation same vrp, without stopping jsprit jvm and transportCost should be created each invocation, you wil recieve OOM). If we don`t remove shutdown hook it will be stored in runtime.