### PR TITLE
disallow duplicate break id

### DIFF
--- a/jsprit-core/src/main/java/com/graphhopper/jsprit/core/problem/VehicleRoutingProblem.java
+++ b/jsprit-core/src/main/java/com/graphhopper/jsprit/core/problem/VehicleRoutingProblem.java
@@ -281,8 +281,11 @@ public class VehicleRoutingProblem {
 
         private boolean addBreaksToActivityMap() {
             boolean hasBreaks = false;
+            Set<String> uniqueBreakIds = new HashSet<>();
             for (Vehicle v : uniqueVehicles) {
                 if (v.getBreak() != null) {
+                    if (!uniqueBreakIds.add(v.getBreak().getId()))
+                        throw new IllegalArgumentException("problem already contains a vehicle break with id " + v.getBreak().getId() + ". choose unique ids for each vehicle break.");
                     hasBreaks = true;
                     List<AbstractActivity> breakActivities = jobActivityFactory.createActivities(v.getBreak());
                     if(breakActivities.isEmpty()) throw new IllegalArgumentException("at least one activity for break needs to be created by activityFactory");

--- a/jsprit-core/src/test/java/com/graphhopper/jsprit/core/problem/VehicleRoutingProblemTest.java
+++ b/jsprit-core/src/test/java/com/graphhopper/jsprit/core/problem/VehicleRoutingProblemTest.java
@@ -22,10 +22,7 @@ import com.graphhopper.jsprit.core.problem.cost.AbstractForwardVehicleRoutingTra
 import com.graphhopper.jsprit.core.problem.cost.VehicleRoutingActivityCosts;
 import com.graphhopper.jsprit.core.problem.driver.Driver;
 import com.graphhopper.jsprit.core.problem.driver.DriverImpl;
-import com.graphhopper.jsprit.core.problem.job.Delivery;
-import com.graphhopper.jsprit.core.problem.job.Pickup;
-import com.graphhopper.jsprit.core.problem.job.Service;
-import com.graphhopper.jsprit.core.problem.job.Shipment;
+import com.graphhopper.jsprit.core.problem.job.*;
 import com.graphhopper.jsprit.core.problem.solution.route.VehicleRoute;
 import com.graphhopper.jsprit.core.problem.solution.route.activity.TourActivity;
 import com.graphhopper.jsprit.core.problem.vehicle.Vehicle;
@@ -312,7 +309,22 @@ public class VehicleRoutingProblemTest {
         VehicleImpl vehicle2 = VehicleImpl.Builder.newInstance("v").setStartLocation(Location.newInstance("loc")).setType(type).build();
         builder.addVehicle(vehicle1);
         builder.addVehicle(vehicle2);
+    }
 
+    @Test(expected = IllegalArgumentException.class)
+    public void whenBuildingProblemWithSameBreakId_itShouldThrowException(){
+        VehicleRoutingProblem.Builder builder = VehicleRoutingProblem.Builder.newInstance();
+        VehicleType type = VehicleTypeImpl.Builder.newInstance("type").build();
+        VehicleImpl vehicle1 = VehicleImpl.Builder.newInstance("v1").setStartLocation(Location.newInstance("loc")).setType(type)
+            .setBreak(Break.Builder.newInstance("break").build())
+            .build();
+        VehicleImpl vehicle2 = VehicleImpl.Builder.newInstance("v2").setStartLocation(Location.newInstance("loc")).setType(type)
+            .setBreak(Break.Builder.newInstance("break").build())
+            .build();
+        builder.addVehicle(vehicle1);
+        builder.addVehicle(vehicle2);
+        builder.setFleetSize(FleetSize.FINITE);
+        builder.build();
     }
 
     @Test


### PR DESCRIPTION
the issue with duplicate break id was reported in the forum:
https://discuss.graphhopper.com/t/duplicate-break-ids/1908

> if multiple vehicles have breaks with the same id but different break service times, they will get to have the same service time.

the fix is just to disallow duplicate break id when building the vrp.