### PR TITLE
UnassignedJobReasonTracker improvement

### DIFF
--- a/jsprit-core/src/main/java/com/graphhopper/jsprit/core/algorithm/recreate/AbstractInsertionCalculator.java
+++ b/jsprit-core/src/main/java/com/graphhopper/jsprit/core/algorithm/recreate/AbstractInsertionCalculator.java
@@ -39,10 +39,11 @@ abstract class AbstractInsertionCalculator implements JobInsertionCostsCalculato
         for (HardRouteConstraint hardRouteConstraint : constraintManager.getHardRouteConstraints()) {
             if (!hardRouteConstraint.fulfilled(insertionContext)) {
                 InsertionData emptyInsertionData = new InsertionData.NoInsertionFound();
-                emptyInsertionData.addFailedConstrainInfo(new FailedConstraintInfo(
-                    hardRouteConstraint.getClass().getSimpleName(),
-                    insertionContext
-                ));
+                emptyInsertionData.addFailedConstrainInfo(FailedConstraintInfo.Builder.newInstance()
+                    .setFailedConstraint(hardRouteConstraint.getClass().getSimpleName())
+                    .loadInsertionContextData(insertionContext)
+                    .build()
+                );
                 return emptyInsertionData;
             }
         }
@@ -55,17 +56,17 @@ abstract class AbstractInsertionCalculator implements JobInsertionCostsCalculato
         for (HardActivityConstraint c : constraintManager.getCriticalHardActivityConstraints()) {
             ConstraintsStatus status = c.fulfilled(iFacts, prevAct, newAct, nextAct, prevActDepTime);
             if (status.equals(ConstraintsStatus.NOT_FULFILLED_BREAK)) {
-                failedActivityConstraints.add(new FailedConstraintInfo(
-                    c.getClass().getSimpleName(),
-                    iFacts
-                ));
+                failedActivityConstraints.add(FailedConstraintInfo.Builder.newInstance()
+                    .setFailedConstraint(c.getClass().getSimpleName())
+                    .loadInsertionContextData(iFacts).build()
+                );
                 return status;
             } else {
                 if (status.equals(ConstraintsStatus.NOT_FULFILLED)) {
-                    failed.add(new FailedConstraintInfo(
-                        c.getClass().getSimpleName(),
-                        iFacts
-                    ));
+                    failed.add(FailedConstraintInfo.Builder.newInstance()
+                        .setFailedConstraint(c.getClass().getSimpleName())
+                        .loadInsertionContextData(iFacts).build()
+                    );
                     notFulfilled = status;
                 }
             }
@@ -78,17 +79,17 @@ abstract class AbstractInsertionCalculator implements JobInsertionCostsCalculato
         for (HardActivityConstraint c : constraintManager.getHighPrioHardActivityConstraints()) {
             ConstraintsStatus status = c.fulfilled(iFacts, prevAct, newAct, nextAct, prevActDepTime);
             if (status.equals(ConstraintsStatus.NOT_FULFILLED_BREAK)) {
-                failedActivityConstraints.add(new FailedConstraintInfo(
-                    c.getClass().getSimpleName(),
-                    iFacts
-                ));
+                failedActivityConstraints.add(FailedConstraintInfo.Builder.newInstance()
+                    .setFailedConstraint(c.getClass().getSimpleName())
+                    .loadInsertionContextData(iFacts).build()
+                );
                 return status;
             } else {
                 if (status.equals(ConstraintsStatus.NOT_FULFILLED)) {
-                    failed.add(new FailedConstraintInfo(
-                        c.getClass().getSimpleName(),
-                        iFacts
-                    ));
+                    failed.add(FailedConstraintInfo.Builder.newInstance()
+                        .setFailedConstraint(c.getClass().getSimpleName())
+                        .loadInsertionContextData(iFacts).build()
+                    );
                     notFulfilled = status;
                 }
             }
@@ -101,10 +102,10 @@ abstract class AbstractInsertionCalculator implements JobInsertionCostsCalculato
         for (HardActivityConstraint constraint : constraintManager.getLowPrioHardActivityConstraints()) {
             ConstraintsStatus status = constraint.fulfilled(iFacts, prevAct, newAct, nextAct, prevActDepTime);
             if (status.equals(ConstraintsStatus.NOT_FULFILLED_BREAK) || status.equals(ConstraintsStatus.NOT_FULFILLED)) {
-                failedActivityConstraints.add(new FailedConstraintInfo(
-                    constraint.getClass().getSimpleName(),
-                    iFacts
-                ));
+                failedActivityConstraints.add(FailedConstraintInfo.Builder.newInstance()
+                    .setFailedConstraint(constraint.getClass().getSimpleName())
+                    .loadInsertionContextData(iFacts).build()
+                );
                 return status;
             }
         }

--- a/jsprit-core/src/main/java/com/graphhopper/jsprit/core/algorithm/recreate/AbstractInsertionCalculator.java
+++ b/jsprit-core/src/main/java/com/graphhopper/jsprit/core/algorithm/recreate/AbstractInsertionCalculator.java
@@ -24,6 +24,7 @@ import com.graphhopper.jsprit.core.problem.constraint.HardActivityConstraint.Con
 import com.graphhopper.jsprit.core.problem.constraint.HardRouteConstraint;
 import com.graphhopper.jsprit.core.problem.misc.JobInsertionContext;
 import com.graphhopper.jsprit.core.problem.solution.route.activity.TourActivity;
+import com.graphhopper.jsprit.core.util.FailedConstraintInfo;
 
 import java.util.ArrayList;
 import java.util.Collection;
@@ -38,24 +39,33 @@ abstract class AbstractInsertionCalculator implements JobInsertionCostsCalculato
         for (HardRouteConstraint hardRouteConstraint : constraintManager.getHardRouteConstraints()) {
             if (!hardRouteConstraint.fulfilled(insertionContext)) {
                 InsertionData emptyInsertionData = new InsertionData.NoInsertionFound();
-                emptyInsertionData.addFailedConstrainName(hardRouteConstraint.getClass().getSimpleName());
+                emptyInsertionData.addFailedConstrainInfo(new FailedConstraintInfo(
+                    hardRouteConstraint.getClass().getSimpleName(),
+                    insertionContext
+                ));
                 return emptyInsertionData;
             }
         }
         return null;
     }
 
-    ConstraintsStatus fulfilled(JobInsertionContext iFacts, TourActivity prevAct, TourActivity newAct, TourActivity nextAct, double prevActDepTime, Collection<String> failedActivityConstraints, ConstraintManager constraintManager) {
+    ConstraintsStatus fulfilled(JobInsertionContext iFacts, TourActivity prevAct, TourActivity newAct, TourActivity nextAct, double prevActDepTime, Collection<FailedConstraintInfo> failedActivityConstraints, ConstraintManager constraintManager) {
         ConstraintsStatus notFulfilled = null;
-        List<String> failed = new ArrayList<>();
+        List<FailedConstraintInfo> failed = new ArrayList<>();
         for (HardActivityConstraint c : constraintManager.getCriticalHardActivityConstraints()) {
             ConstraintsStatus status = c.fulfilled(iFacts, prevAct, newAct, nextAct, prevActDepTime);
             if (status.equals(ConstraintsStatus.NOT_FULFILLED_BREAK)) {
-                failedActivityConstraints.add(c.getClass().getSimpleName());
+                failedActivityConstraints.add(new FailedConstraintInfo(
+                    c.getClass().getSimpleName(),
+                    iFacts
+                ));
                 return status;
             } else {
                 if (status.equals(ConstraintsStatus.NOT_FULFILLED)) {
-                    failed.add(c.getClass().getSimpleName());
+                    failed.add(new FailedConstraintInfo(
+                        c.getClass().getSimpleName(),
+                        iFacts
+                    ));
                     notFulfilled = status;
                 }
             }
@@ -68,11 +78,17 @@ abstract class AbstractInsertionCalculator implements JobInsertionCostsCalculato
         for (HardActivityConstraint c : constraintManager.getHighPrioHardActivityConstraints()) {
             ConstraintsStatus status = c.fulfilled(iFacts, prevAct, newAct, nextAct, prevActDepTime);
             if (status.equals(ConstraintsStatus.NOT_FULFILLED_BREAK)) {
-                failedActivityConstraints.add(c.getClass().getSimpleName());
+                failedActivityConstraints.add(new FailedConstraintInfo(
+                    c.getClass().getSimpleName(),
+                    iFacts
+                ));
                 return status;
             } else {
                 if (status.equals(ConstraintsStatus.NOT_FULFILLED)) {
-                    failed.add(c.getClass().getSimpleName());
+                    failed.add(new FailedConstraintInfo(
+                        c.getClass().getSimpleName(),
+                        iFacts
+                    ));
                     notFulfilled = status;
                 }
             }
@@ -85,7 +101,10 @@ abstract class AbstractInsertionCalculator implements JobInsertionCostsCalculato
         for (HardActivityConstraint constraint : constraintManager.getLowPrioHardActivityConstraints()) {
             ConstraintsStatus status = constraint.fulfilled(iFacts, prevAct, newAct, nextAct, prevActDepTime);
             if (status.equals(ConstraintsStatus.NOT_FULFILLED_BREAK) || status.equals(ConstraintsStatus.NOT_FULFILLED)) {
-                failedActivityConstraints.add(constraint.getClass().getSimpleName());
+                failedActivityConstraints.add(new FailedConstraintInfo(
+                    constraint.getClass().getSimpleName(),
+                    iFacts
+                ));
                 return status;
             }
         }

--- a/jsprit-core/src/main/java/com/graphhopper/jsprit/core/algorithm/recreate/AbstractInsertionStrategy.java
+++ b/jsprit-core/src/main/java/com/graphhopper/jsprit/core/algorithm/recreate/AbstractInsertionStrategy.java
@@ -93,8 +93,8 @@ public abstract class AbstractInsertionStrategy implements InsertionStrategy {
         return badJobs;
     }
 
-    public void markUnassigned(Job unassigned, List<String> reasons) {
-        insertionsListeners.informJobUnassignedListeners(unassigned, reasons);
+    public void markUnassigned(Job unassigned, InsertionData insertionData) {
+        insertionsListeners.informJobUnassignedListeners(unassigned, insertionData);
     }
 
     public abstract Collection<Job> insertUnassignedJobs(Collection<VehicleRoute> vehicleRoutes, Collection<Job> unassignedJobs);

--- a/jsprit-core/src/main/java/com/graphhopper/jsprit/core/algorithm/recreate/AbstractInsertionStrategy.java
+++ b/jsprit-core/src/main/java/com/graphhopper/jsprit/core/algorithm/recreate/AbstractInsertionStrategy.java
@@ -26,6 +26,7 @@ import com.graphhopper.jsprit.core.problem.driver.Driver;
 import com.graphhopper.jsprit.core.problem.job.Job;
 import com.graphhopper.jsprit.core.problem.solution.route.VehicleRoute;
 import com.graphhopper.jsprit.core.problem.vehicle.Vehicle;
+import com.graphhopper.jsprit.core.util.FailedConstraintInfo;
 import com.graphhopper.jsprit.core.util.RandomNumberGeneration;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -93,8 +94,8 @@ public abstract class AbstractInsertionStrategy implements InsertionStrategy {
         return badJobs;
     }
 
-    public void markUnassigned(Job unassigned, InsertionData insertionData) {
-        insertionsListeners.informJobUnassignedListeners(unassigned, insertionData);
+    public void markUnassigned(Job unassigned, List<FailedConstraintInfo> failedConstraint) {
+        insertionsListeners.informJobUnassignedListeners(unassigned, failedConstraint);
     }
 
     public abstract Collection<Job> insertUnassignedJobs(Collection<VehicleRoute> vehicleRoutes, Collection<Job> unassignedJobs);

--- a/jsprit-core/src/main/java/com/graphhopper/jsprit/core/algorithm/recreate/AbstractInsertionStrategy.java
+++ b/jsprit-core/src/main/java/com/graphhopper/jsprit/core/algorithm/recreate/AbstractInsertionStrategy.java
@@ -94,8 +94,8 @@ public abstract class AbstractInsertionStrategy implements InsertionStrategy {
         return badJobs;
     }
 
-    public void markUnassigned(Job unassigned, List<FailedConstraintInfo> failedConstraint) {
-        insertionsListeners.informJobUnassignedListeners(unassigned, failedConstraint);
+    public void markUnassigned(Job unassigned, List<FailedConstraintInfo> failedConstraints) {
+        insertionsListeners.informJobUnassignedListeners(unassigned, failedConstraints);
     }
 
     public abstract Collection<Job> insertUnassignedJobs(Collection<VehicleRoute> vehicleRoutes, Collection<Job> unassignedJobs);

--- a/jsprit-core/src/main/java/com/graphhopper/jsprit/core/algorithm/recreate/BestInsertion.java
+++ b/jsprit-core/src/main/java/com/graphhopper/jsprit/core/algorithm/recreate/BestInsertion.java
@@ -94,7 +94,7 @@ public final class BestInsertion extends AbstractInsertionStrategy {
             }
             if (bestInsertion == null) {
                 badJobs.add(unassignedJob);
-                markUnassigned(unassignedJob, empty.getFailedConstraintNames());
+                markUnassigned(unassignedJob, empty);
             }
             else insertJob(unassignedJob, bestInsertion.getInsertionData(), bestInsertion.getRoute());
         }

--- a/jsprit-core/src/main/java/com/graphhopper/jsprit/core/algorithm/recreate/BestInsertion.java
+++ b/jsprit-core/src/main/java/com/graphhopper/jsprit/core/algorithm/recreate/BestInsertion.java
@@ -74,7 +74,7 @@ public final class BestInsertion extends AbstractInsertionStrategy {
             for (VehicleRoute vehicleRoute : vehicleRoutes) {
                 InsertionData iData = bestInsertionCostCalculator.getInsertionData(vehicleRoute, unassignedJob, NO_NEW_VEHICLE_YET, NO_NEW_DEPARTURE_TIME_YET, NO_NEW_DRIVER_YET, bestInsertionCost);
                 if (iData instanceof InsertionData.NoInsertionFound) {
-                    empty.getFailedConstraintNames().addAll(iData.getFailedConstraintNames());
+                    empty.getFailedConstraints().addAll(iData.getFailedConstraints());
                     continue;
                 }
                 if (iData.getInsertionCost() < bestInsertionCost + noiseMaker.makeNoise()) {
@@ -90,11 +90,11 @@ public final class BestInsertion extends AbstractInsertionStrategy {
                     vehicleRoutes.add(newRoute);
                 }
             } else {
-                empty.getFailedConstraintNames().addAll(newIData.getFailedConstraintNames());
+                empty.getFailedConstraints().addAll(newIData.getFailedConstraints());
             }
             if (bestInsertion == null) {
                 badJobs.add(unassignedJob);
-                markUnassigned(unassignedJob, empty);
+                markUnassigned(unassignedJob, empty.getFailedConstraints());
             }
             else insertJob(unassignedJob, bestInsertion.getInsertionData(), bestInsertion.getRoute());
         }

--- a/jsprit-core/src/main/java/com/graphhopper/jsprit/core/algorithm/recreate/InsertionData.java
+++ b/jsprit-core/src/main/java/com/graphhopper/jsprit/core/algorithm/recreate/InsertionData.java
@@ -19,6 +19,7 @@ package com.graphhopper.jsprit.core.algorithm.recreate;
 
 import com.graphhopper.jsprit.core.problem.driver.Driver;
 import com.graphhopper.jsprit.core.problem.vehicle.Vehicle;
+import com.graphhopper.jsprit.core.util.FailedConstraintInfo;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -76,7 +77,7 @@ public class InsertionData {
         return events;
     }
 
-    private List<String> reasons = new ArrayList<>();
+    private List<FailedConstraintInfo> reasons = new ArrayList<>();
 
     /**
      * @return the additionalTime
@@ -85,11 +86,11 @@ public class InsertionData {
         return additionalTime;
     }
 
-    public void addFailedConstrainName(String name) {
-        reasons.add(name);
+    public void addFailedConstrainInfo(FailedConstraintInfo failedConstraintInfo) {
+        reasons.add(failedConstraintInfo);
     }
 
-    public List<String> getFailedConstraintNames() {
+    public List<FailedConstraintInfo> getFailedConstraints() {
         return reasons;
     }
 

--- a/jsprit-core/src/main/java/com/graphhopper/jsprit/core/algorithm/recreate/InsertionDataUpdater.java
+++ b/jsprit-core/src/main/java/com/graphhopper/jsprit/core/algorithm/recreate/InsertionDataUpdater.java
@@ -23,6 +23,7 @@ import com.graphhopper.jsprit.core.problem.solution.route.VehicleRoute;
 import com.graphhopper.jsprit.core.problem.vehicle.Vehicle;
 import com.graphhopper.jsprit.core.problem.vehicle.VehicleFleetManager;
 import com.graphhopper.jsprit.core.problem.vehicle.VehicleImpl;
+import com.graphhopper.jsprit.core.util.FailedConstraintInfo;
 
 import java.util.*;
 
@@ -79,7 +80,7 @@ class InsertionDataUpdater {
             InsertionData secondBest = null;
             TreeSet<VersionedInsertionData> priorityQueue = priorityQueues[j.getIndex()];
             Iterator<VersionedInsertionData> iterator = priorityQueue.iterator();
-            List<String> failedConstraintNames = new ArrayList<>();
+            List<FailedConstraintInfo> failedConstraintNames = new ArrayList<>();
             while(iterator.hasNext()){
                 VersionedInsertionData versionedIData = iterator.next();
                 if(bestRoute != null){
@@ -88,7 +89,7 @@ class InsertionDataUpdater {
                     }
                 }
                 if (versionedIData.getiData() instanceof InsertionData.NoInsertionFound) {
-                    failedConstraintNames.addAll(versionedIData.getiData().getFailedConstraintNames());
+                    failedConstraintNames.addAll(versionedIData.getiData().getFailedConstraints());
                     continue;
                 }
                 if(!(versionedIData.getRoute().getVehicle() instanceof VehicleImpl.NoVehicle)) {
@@ -140,7 +141,7 @@ class InsertionDataUpdater {
                 } else if (secondBest == null || (iData.getInsertionCost() < secondBest.getInsertionCost())) {
                     secondBest = iData;
                 }
-            } else failedConstraintNames.addAll(iData.getFailedConstraintNames());
+            } else failedConstraintNames.addAll(iData.getFailedConstraints());
             if (best == null) {
                 badJobs.add(new ScoredJob.BadJob(j, failedConstraintNames));
                 continue;

--- a/jsprit-core/src/main/java/com/graphhopper/jsprit/core/algorithm/recreate/InsertionDataUpdater.java
+++ b/jsprit-core/src/main/java/com/graphhopper/jsprit/core/algorithm/recreate/InsertionDataUpdater.java
@@ -80,7 +80,7 @@ class InsertionDataUpdater {
             InsertionData secondBest = null;
             TreeSet<VersionedInsertionData> priorityQueue = priorityQueues[j.getIndex()];
             Iterator<VersionedInsertionData> iterator = priorityQueue.iterator();
-            List<FailedConstraintInfo> failedConstraintNames = new ArrayList<>();
+            List<FailedConstraintInfo> failedConstraints = new ArrayList<>();
             while(iterator.hasNext()){
                 VersionedInsertionData versionedIData = iterator.next();
                 if(bestRoute != null){
@@ -89,7 +89,7 @@ class InsertionDataUpdater {
                     }
                 }
                 if (versionedIData.getiData() instanceof InsertionData.NoInsertionFound) {
-                    failedConstraintNames.addAll(versionedIData.getiData().getFailedConstraints());
+                    failedConstraints.addAll(versionedIData.getiData().getFailedConstraints());
                     continue;
                 }
                 if(!(versionedIData.getRoute().getVehicle() instanceof VehicleImpl.NoVehicle)) {
@@ -141,9 +141,9 @@ class InsertionDataUpdater {
                 } else if (secondBest == null || (iData.getInsertionCost() < secondBest.getInsertionCost())) {
                     secondBest = iData;
                 }
-            } else failedConstraintNames.addAll(iData.getFailedConstraints());
+            } else failedConstraints.addAll(iData.getFailedConstraints());
             if (best == null) {
-                badJobs.add(new ScoredJob.BadJob(j, failedConstraintNames));
+                badJobs.add(new ScoredJob.BadJob(j, failedConstraints));
                 continue;
             }
             double score = score(j, best, secondBest, scoringFunction);

--- a/jsprit-core/src/main/java/com/graphhopper/jsprit/core/algorithm/recreate/RegretInsertion.java
+++ b/jsprit-core/src/main/java/com/graphhopper/jsprit/core/algorithm/recreate/RegretInsertion.java
@@ -121,7 +121,7 @@ public class RegretInsertion extends AbstractInsertionStrategy {
                 Job unassigned = bad.getJob();
                 jobs.remove(unassigned);
                 badJobs.add(unassigned);
-                markUnassigned(unassigned, bad.getInsertionData().getFailedConstraintNames());
+                markUnassigned(unassigned, bad.getInsertionData());
             }
         }
         return badJobs;

--- a/jsprit-core/src/main/java/com/graphhopper/jsprit/core/algorithm/recreate/RegretInsertionConcurrent.java
+++ b/jsprit-core/src/main/java/com/graphhopper/jsprit/core/algorithm/recreate/RegretInsertionConcurrent.java
@@ -125,7 +125,7 @@ public class RegretInsertionConcurrent extends AbstractInsertionStrategy {
                 Job unassigned = bad.getJob();
                 jobs.remove(unassigned);
                 badJobs.add(unassigned);
-                markUnassigned(unassigned, bad.getInsertionData().getFailedConstraintNames());
+                markUnassigned(unassigned, bad.getInsertionData());
             }
         }
         return badJobs;

--- a/jsprit-core/src/main/java/com/graphhopper/jsprit/core/algorithm/recreate/RegretInsertionConcurrent.java
+++ b/jsprit-core/src/main/java/com/graphhopper/jsprit/core/algorithm/recreate/RegretInsertionConcurrent.java
@@ -125,7 +125,7 @@ public class RegretInsertionConcurrent extends AbstractInsertionStrategy {
                 Job unassigned = bad.getJob();
                 jobs.remove(unassigned);
                 badJobs.add(unassigned);
-                markUnassigned(unassigned, bad.getInsertionData());
+                markUnassigned(unassigned, bad.getInsertionData().getFailedConstraints());
             }
         }
         return badJobs;

--- a/jsprit-core/src/main/java/com/graphhopper/jsprit/core/algorithm/recreate/RegretInsertionConcurrentFast.java
+++ b/jsprit-core/src/main/java/com/graphhopper/jsprit/core/algorithm/recreate/RegretInsertionConcurrentFast.java
@@ -163,7 +163,7 @@ public class RegretInsertionConcurrentFast extends AbstractInsertionStrategy {
                 Job unassigned = bad.getJob();
                 jobs.remove(unassigned);
                 badJobs.add(unassigned);
-                markUnassigned(unassigned, bad.getInsertionData().getFailedConstraintNames());
+                markUnassigned(unassigned, bad.getInsertionData());
             }
         }
         return badJobs;

--- a/jsprit-core/src/main/java/com/graphhopper/jsprit/core/algorithm/recreate/RegretInsertionConcurrentFast.java
+++ b/jsprit-core/src/main/java/com/graphhopper/jsprit/core/algorithm/recreate/RegretInsertionConcurrentFast.java
@@ -163,7 +163,7 @@ public class RegretInsertionConcurrentFast extends AbstractInsertionStrategy {
                 Job unassigned = bad.getJob();
                 jobs.remove(unassigned);
                 badJobs.add(unassigned);
-                markUnassigned(unassigned, bad.getInsertionData());
+                markUnassigned(unassigned, bad.getInsertionData().getFailedConstraints());
             }
         }
         return badJobs;

--- a/jsprit-core/src/main/java/com/graphhopper/jsprit/core/algorithm/recreate/RegretInsertionFast.java
+++ b/jsprit-core/src/main/java/com/graphhopper/jsprit/core/algorithm/recreate/RegretInsertionFast.java
@@ -160,7 +160,7 @@ public class RegretInsertionFast extends AbstractInsertionStrategy {
                 Job unassigned = bad.getJob();
                 jobs.remove(unassigned);
                 badJobs.add(unassigned);
-                markUnassigned(unassigned, bad.getInsertionData());
+                markUnassigned(unassigned, bad.getInsertionData().getFailedConstraints());
             }
         }
         return badJobs;

--- a/jsprit-core/src/main/java/com/graphhopper/jsprit/core/algorithm/recreate/RegretInsertionFast.java
+++ b/jsprit-core/src/main/java/com/graphhopper/jsprit/core/algorithm/recreate/RegretInsertionFast.java
@@ -160,7 +160,7 @@ public class RegretInsertionFast extends AbstractInsertionStrategy {
                 Job unassigned = bad.getJob();
                 jobs.remove(unassigned);
                 badJobs.add(unassigned);
-                markUnassigned(unassigned, bad.getInsertionData().getFailedConstraintNames());
+                markUnassigned(unassigned, bad.getInsertionData());
             }
         }
         return badJobs;

--- a/jsprit-core/src/main/java/com/graphhopper/jsprit/core/algorithm/recreate/ScoredJob.java
+++ b/jsprit-core/src/main/java/com/graphhopper/jsprit/core/algorithm/recreate/ScoredJob.java
@@ -20,6 +20,7 @@ package com.graphhopper.jsprit.core.algorithm.recreate;
 
 import com.graphhopper.jsprit.core.problem.job.Job;
 import com.graphhopper.jsprit.core.problem.solution.route.VehicleRoute;
+import com.graphhopper.jsprit.core.util.FailedConstraintInfo;
 
 import java.util.List;
 
@@ -30,13 +31,13 @@ class ScoredJob {
 
     static class BadJob extends ScoredJob {
 
-        BadJob(Job job, List<String> failedConstraintNames) {
-            super(job, 0., getEmptyInsertion(failedConstraintNames), null, false);
+        BadJob(Job job, List<FailedConstraintInfo> failedConstraints) {
+            super(job, 0., getEmptyInsertion(failedConstraints), null, false);
         }
 
-        private static InsertionData getEmptyInsertion(List<String> failedConstraintNames) {
+        private static InsertionData getEmptyInsertion(List<FailedConstraintInfo> failedConstraints) {
             InsertionData empty = new InsertionData.NoInsertionFound();
-            empty.getFailedConstraintNames().addAll(failedConstraintNames);
+            empty.getFailedConstraints().addAll(failedConstraints);
             return empty;
         }
     }

--- a/jsprit-core/src/main/java/com/graphhopper/jsprit/core/algorithm/recreate/ServiceInsertionCalculator.java
+++ b/jsprit-core/src/main/java/com/graphhopper/jsprit/core/algorithm/recreate/ServiceInsertionCalculator.java
@@ -35,6 +35,7 @@ import com.graphhopper.jsprit.core.problem.solution.route.activity.Start;
 import com.graphhopper.jsprit.core.problem.solution.route.activity.TimeWindow;
 import com.graphhopper.jsprit.core.problem.solution.route.activity.TourActivity;
 import com.graphhopper.jsprit.core.problem.vehicle.Vehicle;
+import com.graphhopper.jsprit.core.util.FailedConstraintInfo;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -111,7 +112,7 @@ final class ServiceInsertionCalculator extends AbstractInsertionCalculator {
         InsertionData noInsertion = checkRouteContraints(insertionContext, constraintManager);
         if (noInsertion != null) return noInsertion;
 
-        Collection<String> failedActivityConstraints = new ArrayList<>();
+        Collection<FailedConstraintInfo> failedActivityConstraints = new ArrayList<>();
 
         /*
         check soft constraints at route level
@@ -170,7 +171,7 @@ final class ServiceInsertionCalculator extends AbstractInsertionCalculator {
         }
         if(insertionIndex == InsertionData.NO_INDEX) {
             InsertionData emptyInsertionData = new InsertionData.NoInsertionFound();
-            emptyInsertionData.getFailedConstraintNames().addAll(failedActivityConstraints);
+            emptyInsertionData.getFailedConstraints().addAll(failedActivityConstraints);
             return emptyInsertionData;
         }
         InsertionData insertionData = new InsertionData(bestCost, InsertionData.NO_INDEX, insertionIndex, newVehicle, newDriver);

--- a/jsprit-core/src/main/java/com/graphhopper/jsprit/core/algorithm/recreate/ShipmentInsertionCalculator.java
+++ b/jsprit-core/src/main/java/com/graphhopper/jsprit/core/algorithm/recreate/ShipmentInsertionCalculator.java
@@ -35,6 +35,7 @@ import com.graphhopper.jsprit.core.problem.solution.route.activity.Start;
 import com.graphhopper.jsprit.core.problem.solution.route.activity.TimeWindow;
 import com.graphhopper.jsprit.core.problem.solution.route.activity.TourActivity;
 import com.graphhopper.jsprit.core.problem.vehicle.Vehicle;
+import com.graphhopper.jsprit.core.util.FailedConstraintInfo;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -135,7 +136,7 @@ final class ShipmentInsertionCalculator extends AbstractInsertionCalculator {
         //pickupShipmentLoop
         List<TourActivity> activities = currentRoute.getTourActivities().getActivities();
 
-        List<String> failedActivityConstraints = new ArrayList<>();
+        List<FailedConstraintInfo> failedActivityConstraints = new ArrayList<>();
         while (!tourEnd) {
             TourActivity nextAct;
             if (i < activities.size()) {
@@ -235,7 +236,7 @@ final class ShipmentInsertionCalculator extends AbstractInsertionCalculator {
         }
         if (pickupInsertionIndex == InsertionData.NO_INDEX) {
             InsertionData emptyInsertionData = new InsertionData.NoInsertionFound();
-            emptyInsertionData.getFailedConstraintNames().addAll(failedActivityConstraints);
+            emptyInsertionData.getFailedConstraints().addAll(failedActivityConstraints);
             return emptyInsertionData;
         }
         InsertionData insertionData = new InsertionData(bestCost, pickupInsertionIndex, deliveryInsertionIndex, newVehicle, newDriver);

--- a/jsprit-core/src/main/java/com/graphhopper/jsprit/core/algorithm/recreate/VehicleTypeDependentJobInsertionCalculator.java
+++ b/jsprit-core/src/main/java/com/graphhopper/jsprit/core/algorithm/recreate/VehicleTypeDependentJobInsertionCalculator.java
@@ -115,7 +115,7 @@ final class VehicleTypeDependentJobInsertionCalculator implements JobInsertionCo
             else depTime = v.getEarliestDeparture();
             InsertionData iData = insertionCalculator.getInsertionData(currentRoute, jobToInsert, v, depTime, selectedDriver, bestKnownCost_);
             if (iData instanceof InsertionData.NoInsertionFound) {
-                bestIData.getFailedConstraintNames().addAll(iData.getFailedConstraintNames());
+                bestIData.getFailedConstraints().addAll(iData.getFailedConstraints());
                 continue;
             }
             if (iData.getInsertionCost() < bestKnownCost_) {

--- a/jsprit-core/src/main/java/com/graphhopper/jsprit/core/algorithm/recreate/listener/InsertionListeners.java
+++ b/jsprit-core/src/main/java/com/graphhopper/jsprit/core/algorithm/recreate/listener/InsertionListeners.java
@@ -75,10 +75,10 @@ public class InsertionListeners {
         }
     }
 
-    public void informJobUnassignedListeners(Job unassigned, List<String> reasons) {
+    public void informJobUnassignedListeners(Job unassigned, InsertionData insertionData) {
         for (InsertionListener l : listeners) {
             if (l instanceof JobUnassignedListener) {
-                ((JobUnassignedListener) l).informJobUnassigned(unassigned, reasons);
+                ((JobUnassignedListener) l).informJobUnassigned(unassigned, insertionData);
             }
         }
     }

--- a/jsprit-core/src/main/java/com/graphhopper/jsprit/core/algorithm/recreate/listener/InsertionListeners.java
+++ b/jsprit-core/src/main/java/com/graphhopper/jsprit/core/algorithm/recreate/listener/InsertionListeners.java
@@ -21,6 +21,7 @@ import com.graphhopper.jsprit.core.algorithm.recreate.InsertionData;
 import com.graphhopper.jsprit.core.problem.job.Job;
 import com.graphhopper.jsprit.core.problem.solution.route.VehicleRoute;
 import com.graphhopper.jsprit.core.problem.vehicle.Vehicle;
+import com.graphhopper.jsprit.core.util.FailedConstraintInfo;
 
 import java.util.ArrayList;
 import java.util.Collection;
@@ -75,10 +76,10 @@ public class InsertionListeners {
         }
     }
 
-    public void informJobUnassignedListeners(Job unassigned, InsertionData insertionData) {
+    public void informJobUnassignedListeners(Job unassigned, List<FailedConstraintInfo> failedConstraints) {
         for (InsertionListener l : listeners) {
             if (l instanceof JobUnassignedListener) {
-                ((JobUnassignedListener) l).informJobUnassigned(unassigned, insertionData);
+                ((JobUnassignedListener) l).informJobUnassigned(unassigned, failedConstraints);
             }
         }
     }

--- a/jsprit-core/src/main/java/com/graphhopper/jsprit/core/algorithm/recreate/listener/JobUnassignedListener.java
+++ b/jsprit-core/src/main/java/com/graphhopper/jsprit/core/algorithm/recreate/listener/JobUnassignedListener.java
@@ -18,8 +18,8 @@
 
 package com.graphhopper.jsprit.core.algorithm.recreate.listener;
 
-import com.graphhopper.jsprit.core.algorithm.recreate.InsertionData;
 import com.graphhopper.jsprit.core.problem.job.Job;
+import com.graphhopper.jsprit.core.util.FailedConstraintInfo;
 
 import java.util.List;
 
@@ -28,6 +28,6 @@ import java.util.List;
  */
 public interface JobUnassignedListener extends InsertionListener {
 
-    void informJobUnassigned(Job unassigned, InsertionData insertionData);
+    void informJobUnassigned(Job unassigned, List<FailedConstraintInfo> failedConstraintsInfo);
 
 }

--- a/jsprit-core/src/main/java/com/graphhopper/jsprit/core/algorithm/recreate/listener/JobUnassignedListener.java
+++ b/jsprit-core/src/main/java/com/graphhopper/jsprit/core/algorithm/recreate/listener/JobUnassignedListener.java
@@ -21,13 +21,13 @@ package com.graphhopper.jsprit.core.algorithm.recreate.listener;
 import com.graphhopper.jsprit.core.problem.job.Job;
 import com.graphhopper.jsprit.core.util.FailedConstraintInfo;
 
-import java.util.List;
+import java.util.Collection;
 
 /**
  * Created by schroeder on 06/02/17.
  */
 public interface JobUnassignedListener extends InsertionListener {
 
-    void informJobUnassigned(Job unassigned, List<FailedConstraintInfo> failedConstraintsInfo);
+    void informJobUnassigned(Job unassigned, Collection<FailedConstraintInfo> failedConstraints);
 
 }

--- a/jsprit-core/src/main/java/com/graphhopper/jsprit/core/algorithm/recreate/listener/JobUnassignedListener.java
+++ b/jsprit-core/src/main/java/com/graphhopper/jsprit/core/algorithm/recreate/listener/JobUnassignedListener.java
@@ -18,15 +18,16 @@
 
 package com.graphhopper.jsprit.core.algorithm.recreate.listener;
 
+import com.graphhopper.jsprit.core.algorithm.recreate.InsertionData;
 import com.graphhopper.jsprit.core.problem.job.Job;
 
-import java.util.Collection;
+import java.util.List;
 
 /**
  * Created by schroeder on 06/02/17.
  */
 public interface JobUnassignedListener extends InsertionListener {
 
-    void informJobUnassigned(Job unassigned, Collection<String> failedConstraintNames);
+    void informJobUnassigned(Job unassigned, InsertionData insertionData);
 
 }

--- a/jsprit-core/src/main/java/com/graphhopper/jsprit/core/util/FailedConstraintInfo.java
+++ b/jsprit-core/src/main/java/com/graphhopper/jsprit/core/util/FailedConstraintInfo.java
@@ -1,0 +1,68 @@
+package com.graphhopper.jsprit.core.util;
+
+import com.graphhopper.jsprit.core.problem.job.Job;
+import com.graphhopper.jsprit.core.problem.misc.JobInsertionContext;
+import com.graphhopper.jsprit.core.problem.solution.route.activity.TourActivity;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Created by tonirajkovski on 7/23/17.
+ */
+public class FailedConstraintInfo {
+    private String failedConstraint;
+    private String job;
+    private String vehicle;
+    private List<String> activities = new ArrayList<>();
+    private int insertionIndex;
+
+    public FailedConstraintInfo(String failedConstraint, JobInsertionContext jobInsertionContext) {
+        this.failedConstraint = failedConstraint;
+        if (jobInsertionContext != null) {
+            this.job = jobInsertionContext.getJob().getId();
+            this.vehicle = jobInsertionContext.getNewVehicle().getId();
+            if (jobInsertionContext.getActivityContext() != null) {
+                this.insertionIndex = jobInsertionContext.getActivityContext().getInsertionIndex();
+            }
+            if (jobInsertionContext.getRoute() != null && jobInsertionContext.getRoute().getActivities() != null) {
+                for (TourActivity activity: jobInsertionContext.getRoute().getTourActivities().getActivities()) {
+                    if (activity instanceof TourActivity.JobActivity) {
+                        activities.add(((TourActivity.JobActivity) activity).getJob().getId() + "-" + activity.getName());
+                    }
+                }
+            }
+        }
+    }
+
+    public String getFailedConstraint() {
+        return failedConstraint;
+    }
+
+    public String getVehicle() {
+        return vehicle;
+    }
+
+    public int getInsertionIndex() {
+        return insertionIndex;
+    }
+
+    public List<String> getActivities() {
+        return activities;
+    }
+
+    public String toString() {
+        StringBuilder route = new StringBuilder();
+        route.append(vehicle).append(" [ ");
+        for (String activity: activities) {
+            route.append(activity).append(" ");
+        }
+        route.append("]");
+        return String.format("Constraint '%s' failed for job insertion of job '%s' on position '%d' on route '%s'",
+            failedConstraint,
+            job,
+            insertionIndex,
+            route
+        );
+    }
+}

--- a/jsprit-core/src/main/java/com/graphhopper/jsprit/core/util/FailedConstraintInfo.java
+++ b/jsprit-core/src/main/java/com/graphhopper/jsprit/core/util/FailedConstraintInfo.java
@@ -1,6 +1,7 @@
 package com.graphhopper.jsprit.core.util;
 
 import com.graphhopper.jsprit.core.problem.job.Job;
+import com.graphhopper.jsprit.core.problem.job.Service;
 import com.graphhopper.jsprit.core.problem.misc.JobInsertionContext;
 import com.graphhopper.jsprit.core.problem.solution.route.activity.TourActivity;
 
@@ -11,28 +12,66 @@ import java.util.List;
  * Created by tonirajkovski on 7/23/17.
  */
 public class FailedConstraintInfo {
+
+    public static class Builder<T extends FailedConstraintInfo> {
+
+        private String failedConstraint;
+        private String job;
+        private String vehicle;
+        private List<String> activities = new ArrayList<>();
+        private int insertionIndex;
+
+        public static FailedConstraintInfo.Builder newInstance() {
+            return new FailedConstraintInfo.Builder();
+        }
+
+        /**
+         * Builds the Failed Constraint info.
+         *
+         * @return {@link Service}
+         * @throws IllegalArgumentException if neither locationId nor coordinate is set.
+         */
+        public T build() {
+            if (failedConstraint == null) throw new IllegalArgumentException("failed constraint is missing");
+            return (T) new FailedConstraintInfo(this);
+        }
+
+        public FailedConstraintInfo.Builder<T> setFailedConstraint(String failedConstraint) {
+            this.failedConstraint = failedConstraint;
+            return this;
+        }
+
+        public FailedConstraintInfo.Builder<T> loadInsertionContextData(JobInsertionContext insertionContext) {
+            if (insertionContext != null) {
+                this.job = insertionContext.getJob().getId();
+                this.vehicle = insertionContext.getNewVehicle().getId();
+                if (insertionContext.getActivityContext() != null) {
+                    this.insertionIndex = insertionContext.getActivityContext().getInsertionIndex();
+                }
+                if (insertionContext.getRoute() != null && insertionContext.getRoute().getActivities() != null) {
+                    for (TourActivity activity: insertionContext.getRoute().getTourActivities().getActivities()) {
+                        if (activity instanceof TourActivity.JobActivity) {
+                            activities.add(((TourActivity.JobActivity) activity).getJob().getId() + "-" + activity.getName());
+                        }
+                    }
+                }
+            }
+            return this;
+        }
+    }
+
     private String failedConstraint;
     private String job;
     private String vehicle;
     private List<String> activities = new ArrayList<>();
-    private int insertionIndex;
+    private int insertionIndex = -1;
 
-    public FailedConstraintInfo(String failedConstraint, JobInsertionContext jobInsertionContext) {
-        this.failedConstraint = failedConstraint;
-        if (jobInsertionContext != null) {
-            this.job = jobInsertionContext.getJob().getId();
-            this.vehicle = jobInsertionContext.getNewVehicle().getId();
-            if (jobInsertionContext.getActivityContext() != null) {
-                this.insertionIndex = jobInsertionContext.getActivityContext().getInsertionIndex();
-            }
-            if (jobInsertionContext.getRoute() != null && jobInsertionContext.getRoute().getActivities() != null) {
-                for (TourActivity activity: jobInsertionContext.getRoute().getTourActivities().getActivities()) {
-                    if (activity instanceof TourActivity.JobActivity) {
-                        activities.add(((TourActivity.JobActivity) activity).getJob().getId() + "-" + activity.getName());
-                    }
-                }
-            }
-        }
+    private FailedConstraintInfo(Builder<?> builder) {
+        this.failedConstraint = builder.failedConstraint;
+        this.job = builder.job;
+        this.vehicle = builder.vehicle;
+        this.activities = builder.activities;
+        this.insertionIndex = builder.insertionIndex;
     }
 
     public String getFailedConstraint() {
@@ -49,6 +88,10 @@ public class FailedConstraintInfo {
 
     public List<String> getActivities() {
         return activities;
+    }
+
+    public String getJob() {
+        return job;
     }
 
     public String toString() {

--- a/jsprit-core/src/main/java/com/graphhopper/jsprit/core/util/FailedConstraintInfo.java
+++ b/jsprit-core/src/main/java/com/graphhopper/jsprit/core/util/FailedConstraintInfo.java
@@ -6,6 +6,7 @@ import com.graphhopper.jsprit.core.problem.misc.JobInsertionContext;
 import com.graphhopper.jsprit.core.problem.solution.route.activity.TourActivity;
 
 import java.util.ArrayList;
+import java.util.Iterator;
 import java.util.List;
 
 /**
@@ -18,7 +19,6 @@ public class FailedConstraintInfo {
         private String failedConstraint;
         private String job;
         private String vehicle;
-        private List<String> activities = new ArrayList<>();
         private int insertionIndex;
 
         public static FailedConstraintInfo.Builder newInstance() {
@@ -48,13 +48,6 @@ public class FailedConstraintInfo {
                 if (insertionContext.getActivityContext() != null) {
                     this.insertionIndex = insertionContext.getActivityContext().getInsertionIndex();
                 }
-                if (insertionContext.getRoute() != null && insertionContext.getRoute().getActivities() != null) {
-                    for (TourActivity activity: insertionContext.getRoute().getTourActivities().getActivities()) {
-                        if (activity instanceof TourActivity.JobActivity) {
-                            activities.add(((TourActivity.JobActivity) activity).getJob().getId() + "-" + activity.getName());
-                        }
-                    }
-                }
             }
             return this;
         }
@@ -63,14 +56,12 @@ public class FailedConstraintInfo {
     private String failedConstraint;
     private String job;
     private String vehicle;
-    private List<String> activities = new ArrayList<>();
     private int insertionIndex = -1;
 
     private FailedConstraintInfo(Builder<?> builder) {
         this.failedConstraint = builder.failedConstraint;
         this.job = builder.job;
         this.vehicle = builder.vehicle;
-        this.activities = builder.activities;
         this.insertionIndex = builder.insertionIndex;
     }
 
@@ -86,26 +77,17 @@ public class FailedConstraintInfo {
         return insertionIndex;
     }
 
-    public List<String> getActivities() {
-        return activities;
-    }
-
     public String getJob() {
         return job;
     }
 
     public String toString() {
-        StringBuilder route = new StringBuilder();
-        route.append(vehicle).append(" [ ");
-        for (String activity: activities) {
-            route.append(activity).append(" ");
-        }
-        route.append("]");
-        return String.format("Constraint '%s' failed for job insertion of job '%s' on position '%d' on route '%s'",
+        return String.format("Constraint '%s' failed for job insertion of job '%s' on position '%d' in vehicle '%s'",
             failedConstraint,
             job,
             insertionIndex,
-            route
+            vehicle
         );
     }
+
 }

--- a/jsprit-core/src/main/java/com/graphhopper/jsprit/core/util/UnassignedJobReasonTracker.java
+++ b/jsprit-core/src/main/java/com/graphhopper/jsprit/core/util/UnassignedJobReasonTracker.java
@@ -79,12 +79,12 @@ public class UnassignedJobReasonTracker implements JobUnassignedListener, Iterat
     }
 
     @Override
-    public void informJobUnassigned(Job unassigned, List<FailedConstraintInfo> failedConstraintInfo) {
+    public void informJobUnassigned(Job unassigned, Collection<FailedConstraintInfo> failedConstraintsInfo) {
         Map<String, List<FailedConstraintInfo>> failedConstraintsInIteration = failedConstraints.get(iterationNumber);
         if (!failedConstraintsInIteration.containsKey(unassigned.getId())) {
             failedConstraintsInIteration.put(unassigned.getId(), new ArrayList<FailedConstraintInfo>());
         }
-        failedConstraintsInIteration.get(unassigned.getId()).addAll(failedConstraintInfo);
+        failedConstraintsInIteration.get(unassigned.getId()).addAll(failedConstraintsInfo);
     }
 
     public void put(String simpleNameOfFailedConstraint, int code, String reason) {

--- a/jsprit-core/src/main/java/com/graphhopper/jsprit/core/util/UnassignedJobReasonTracker.java
+++ b/jsprit-core/src/main/java/com/graphhopper/jsprit/core/util/UnassignedJobReasonTracker.java
@@ -140,9 +140,9 @@ public class UnassignedJobReasonTracker implements JobUnassignedListener, Iterat
 
     public Collection<FailedConstraintInfo> getFailedConstraintsForJob(String jobId) {
         Collection<FailedConstraintInfo> result = new ArrayList<>();
-        for (Map<String, List<FailedConstraintInfo>> failedConstraints: failedConstraints.values()) {
-            if (failedConstraints.containsKey(jobId)) {
-                result.addAll(failedConstraints.get(jobId));
+        for (Map<String, List<FailedConstraintInfo>> failedConstraintsMap: failedConstraints.values()) {
+            if (failedConstraintsMap.containsKey(jobId)) {
+                result.addAll(failedConstraintsMap.get(jobId));
             }
         }
         return result;

--- a/jsprit-core/src/test/java/com/graphhopper/jsprit/core/util/FailedConstraintInfoTest.java
+++ b/jsprit-core/src/test/java/com/graphhopper/jsprit/core/util/FailedConstraintInfoTest.java
@@ -34,10 +34,6 @@ public class FailedConstraintInfoTest {
     @Mock
     private ActivityContext activityContext;
     @Mock
-    private VehicleRoute route;
-    @Mock
-    private TourActivities tourActivities;
-    @Mock
     private JobInsertionContext jobInsertionContext;
 
     @Test
@@ -67,11 +63,8 @@ public class FailedConstraintInfoTest {
         when(job.getId()).thenReturn("job");
         when(vehicle.getId()).thenReturn("vehicle");
         when(activityContext.getInsertionIndex()).thenReturn(2);
-        when(route.getTourActivities()).thenReturn(tourActivities);
-        when(tourActivities.getActivities()).thenReturn(activities);
 
         when(jobInsertionContext.getJob()).thenReturn(job);
-        when(jobInsertionContext.getRoute()).thenReturn(route);
         when(jobInsertionContext.getActivityContext()).thenReturn(activityContext);
         when(jobInsertionContext.getNewVehicle()).thenReturn(vehicle);
 
@@ -82,8 +75,6 @@ public class FailedConstraintInfoTest {
         Assert.assertEquals("job", failedConstraintInfo.getJob());
         Assert.assertEquals(2, failedConstraintInfo.getInsertionIndex());
         Assert.assertEquals("vehicle", failedConstraintInfo.getVehicle());
-        Assert.assertEquals(1, failedConstraintInfo.getActivities().size());
-        Assert.assertEquals("testService-service", failedConstraintInfo.getActivities().get(0));
     }
 
 }

--- a/jsprit-core/src/test/java/com/graphhopper/jsprit/core/util/FailedConstraintInfoTest.java
+++ b/jsprit-core/src/test/java/com/graphhopper/jsprit/core/util/FailedConstraintInfoTest.java
@@ -1,0 +1,89 @@
+package com.graphhopper.jsprit.core.util;
+
+import com.graphhopper.jsprit.core.problem.Location;
+import com.graphhopper.jsprit.core.problem.job.Job;
+import com.graphhopper.jsprit.core.problem.job.Service;
+import com.graphhopper.jsprit.core.problem.misc.ActivityContext;
+import com.graphhopper.jsprit.core.problem.misc.JobInsertionContext;
+import com.graphhopper.jsprit.core.problem.solution.route.VehicleRoute;
+import com.graphhopper.jsprit.core.problem.solution.route.activity.ServiceActivity;
+import com.graphhopper.jsprit.core.problem.solution.route.activity.TourActivities;
+import com.graphhopper.jsprit.core.problem.solution.route.activity.TourActivity;
+import com.graphhopper.jsprit.core.problem.vehicle.Vehicle;
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.mockito.Mockito.when;
+
+/**
+ * Created by tonirajkovski on 7/24/17.
+ */
+@RunWith(MockitoJUnitRunner.class)
+public class FailedConstraintInfoTest {
+
+    @Mock
+    private Job job;
+    @Mock
+    private Vehicle vehicle;
+    @Mock
+    private ActivityContext activityContext;
+    @Mock
+    private VehicleRoute route;
+    @Mock
+    private TourActivities tourActivities;
+    @Mock
+    private JobInsertionContext jobInsertionContext;
+
+    @Test
+    public void shouldLoadJobInsertionContextWhenNull() {
+        // given
+        FailedConstraintInfo.Builder builder = FailedConstraintInfo.Builder.newInstance().setFailedConstraint("c1");
+
+        //when
+        FailedConstraintInfo failedConstraintInfo = builder.loadInsertionContextData(null).build();
+
+        //then
+        Assert.assertNull(failedConstraintInfo.getVehicle());
+        Assert.assertNull(failedConstraintInfo.getJob());
+        Assert.assertEquals(0, failedConstraintInfo.getInsertionIndex());
+        // just assert that there will be no exception because of null values and will produce some value
+        Assert.assertNotNull(failedConstraintInfo.toString());
+    }
+
+    @Test
+    public void shouldLoadJobInsertionContextWhenNotNull() {
+        // given
+        FailedConstraintInfo.Builder builder = FailedConstraintInfo.Builder.newInstance().setFailedConstraint("c1");
+
+        List<TourActivity> activities = new ArrayList<>();
+        activities.add(ServiceActivity.newInstance(Service.Builder.newInstance("testService").setLocation(Location.newInstance(1, 1)).build()));
+
+        when(job.getId()).thenReturn("job");
+        when(vehicle.getId()).thenReturn("vehicle");
+        when(activityContext.getInsertionIndex()).thenReturn(2);
+        when(route.getTourActivities()).thenReturn(tourActivities);
+        when(tourActivities.getActivities()).thenReturn(activities);
+
+        when(jobInsertionContext.getJob()).thenReturn(job);
+        when(jobInsertionContext.getRoute()).thenReturn(route);
+        when(jobInsertionContext.getActivityContext()).thenReturn(activityContext);
+        when(jobInsertionContext.getNewVehicle()).thenReturn(vehicle);
+
+        //when
+        FailedConstraintInfo failedConstraintInfo = builder.loadInsertionContextData(jobInsertionContext).build();
+
+        //then
+        Assert.assertEquals("job", failedConstraintInfo.getJob());
+        Assert.assertEquals(2, failedConstraintInfo.getInsertionIndex());
+        Assert.assertEquals("vehicle", failedConstraintInfo.getVehicle());
+        Assert.assertEquals(1, failedConstraintInfo.getActivities().size());
+        Assert.assertEquals("testService-service", failedConstraintInfo.getActivities().get(0));
+    }
+
+}

--- a/jsprit-core/src/test/java/com/graphhopper/jsprit/core/util/UnassignedJobReasonTrackerTest.java
+++ b/jsprit-core/src/test/java/com/graphhopper/jsprit/core/util/UnassignedJobReasonTrackerTest.java
@@ -147,15 +147,15 @@ public class UnassignedJobReasonTrackerTest {
 
         // iteration 0
         List<FailedConstraintInfo> failedConstraints = new ArrayList<>();
-        failedConstraints.add(new FailedConstraintInfo("constraint1", null));
-        failedConstraints.add(new FailedConstraintInfo("constraint2", null));
+        failedConstraints.add(FailedConstraintInfo.Builder.newInstance().setFailedConstraint("constraint1").build());
+        failedConstraints.add(FailedConstraintInfo.Builder.newInstance().setFailedConstraint("constraint2").build());
         reasonTracker.informIterationStarts(0, null, null);
         reasonTracker.informJobUnassigned(job, failedConstraints);
 
         // iteration 1
         failedConstraints.clear();
-        failedConstraints.add(new FailedConstraintInfo("constraint2", null));
-        failedConstraints.add(new FailedConstraintInfo("constraint3", null));
+        failedConstraints.add(FailedConstraintInfo.Builder.newInstance().setFailedConstraint("constraint2").build());
+        failedConstraints.add(FailedConstraintInfo.Builder.newInstance().setFailedConstraint("constraint3").build());
         reasonTracker.informIterationStarts(1, null, null);
         reasonTracker.informJobUnassigned(job, failedConstraints);
 
@@ -176,13 +176,13 @@ public class UnassignedJobReasonTrackerTest {
 
         // iteration1
         List<FailedConstraintInfo> failedConstraints = new ArrayList<>();
-        failedConstraints.add(new FailedConstraintInfo("c1", null));
+        failedConstraints.add(FailedConstraintInfo.Builder.newInstance().setFailedConstraint("c1").build());
         reasonTracker.informIterationStarts(0, null, null);
         reasonTracker.informJobUnassigned(job, failedConstraints);
 
         // iteration2
         failedConstraints.clear();
-        failedConstraints.add(new FailedConstraintInfo("c2", null));
+        failedConstraints.add(FailedConstraintInfo.Builder.newInstance().setFailedConstraint("c2").build());
         reasonTracker.informIterationStarts(2, null, null);
         reasonTracker.informJobUnassigned(job, failedConstraints);
 
@@ -207,13 +207,13 @@ public class UnassignedJobReasonTrackerTest {
         List<FailedConstraintInfo> failedConstraints = new ArrayList<>();
 
         // iteration1
-        failedConstraints.add(new FailedConstraintInfo("c1", null));
+        failedConstraints.add(FailedConstraintInfo.Builder.newInstance().setFailedConstraint("c1").build());
         reasonTracker.informIterationStarts(0, null, null);
         reasonTracker.informJobUnassigned(job1, failedConstraints);
 
         // iteration2
         failedConstraints.clear();
-        failedConstraints.add(new FailedConstraintInfo("c2", null));
+        failedConstraints.add(FailedConstraintInfo.Builder.newInstance().setFailedConstraint("c2").build());
         reasonTracker.informIterationStarts(2, null, null);
         reasonTracker.informJobUnassigned(job2, failedConstraints);
 
@@ -260,7 +260,7 @@ public class UnassignedJobReasonTrackerTest {
 
         List<FailedConstraintInfo> failedConstraints = new ArrayList<>();
         // adding the failed constraint in iteration 1
-        failedConstraints.add(new FailedConstraintInfo("c1", null));
+        failedConstraints.add(FailedConstraintInfo.Builder.newInstance().setFailedConstraint("c1").build());
         reasonTracker.informIterationStarts(1, null, null);
         reasonTracker.informJobUnassigned(job, failedConstraints);
 
@@ -280,13 +280,13 @@ public class UnassignedJobReasonTrackerTest {
 
         List<FailedConstraintInfo> failedConstraints = new ArrayList<>();
         // adding the failed constraint in iteration 1 for job1
-        failedConstraints.add(new FailedConstraintInfo("c1", null));
+        failedConstraints.add(FailedConstraintInfo.Builder.newInstance().setFailedConstraint("c1").build());
         reasonTracker.informIterationStarts(1, null, null);
         reasonTracker.informJobUnassigned(job1, failedConstraints);
 
         // adding the failed constraint in iteration 2 for job2
         failedConstraints.clear();
-        failedConstraints.add(new FailedConstraintInfo("c2", null));
+        failedConstraints.add(FailedConstraintInfo.Builder.newInstance().setFailedConstraint("c2").build());
         reasonTracker.informIterationStarts(2, null, null);
         reasonTracker.informJobUnassigned(job2, failedConstraints);
 

--- a/jsprit-examples/src/main/java/com/graphhopper/jsprit/examples/UnassignedJobReasonTrackerExample.java
+++ b/jsprit-examples/src/main/java/com/graphhopper/jsprit/examples/UnassignedJobReasonTrackerExample.java
@@ -9,6 +9,7 @@ import com.graphhopper.jsprit.core.problem.VehicleRoutingProblem;
 import com.graphhopper.jsprit.core.problem.constraint.ConstraintManager;
 import com.graphhopper.jsprit.core.problem.constraint.HardRouteConstraint;
 import com.graphhopper.jsprit.core.problem.job.Job;
+import com.graphhopper.jsprit.core.problem.job.Service;
 import com.graphhopper.jsprit.core.problem.job.Shipment;
 import com.graphhopper.jsprit.core.problem.misc.JobInsertionContext;
 import com.graphhopper.jsprit.core.problem.solution.VehicleRoutingProblemSolution;
@@ -65,9 +66,13 @@ public class UnassignedJobReasonTrackerExample {
             .setDeliveryTimeWindow(new TimeWindow(15, 16))
             .build();
 
+        Service service1 = Service.Builder.newInstance("service1").addSizeDimension(WEIGHT_INDEX, 1).setLocation(Location.newInstance(5, 7)).build();
+        // service2 required more capacity that both vehicles are not able to provide
+        Service service2 = Service.Builder.newInstance("service2").addSizeDimension(WEIGHT_INDEX, 10).setLocation(Location.newInstance(5, 5)).build();
+
         VehicleRoutingProblem.Builder vrpBuilder = VehicleRoutingProblem.Builder.newInstance();
         vrpBuilder.addVehicle(v1).addVehicle(v2);
-        vrpBuilder.addJob(shipment1).addJob(shipment2).addJob(shipment3).addJob(shipment4);
+        vrpBuilder.addJob(shipment1).addJob(shipment2).addJob(shipment3).addJob(shipment4).addJob(service1).addJob(service2);
 
         // prepare the algorithm
         VehicleRoutingProblem problem = vrpBuilder.build();
@@ -91,6 +96,7 @@ public class UnassignedJobReasonTrackerExample {
         Collection<VehicleRoutingProblemSolution> solutions = algorithm.searchSolutions();
         VehicleRoutingProblemSolution bestSolution = Solutions.bestOf(solutions);
 
+        // print the info about each unassigned job
         for (Job unassignedJob: bestSolution.getUnassignedJobs()) {
             Collection<FailedConstraintInfo> failedConstraints = tracker.getFailedConstraintsForJob(unassignedJob.getId());
             for (FailedConstraintInfo failedConstraint : failedConstraints) {

--- a/jsprit-examples/src/main/java/com/graphhopper/jsprit/examples/UnassignedJobReasonTrackerExample.java
+++ b/jsprit-examples/src/main/java/com/graphhopper/jsprit/examples/UnassignedJobReasonTrackerExample.java
@@ -1,0 +1,111 @@
+package com.graphhopper.jsprit.examples;
+
+import com.graphhopper.jsprit.analysis.toolbox.GraphStreamViewer;
+import com.graphhopper.jsprit.core.algorithm.VehicleRoutingAlgorithm;
+import com.graphhopper.jsprit.core.algorithm.box.Jsprit;
+import com.graphhopper.jsprit.core.algorithm.state.StateManager;
+import com.graphhopper.jsprit.core.problem.Location;
+import com.graphhopper.jsprit.core.problem.VehicleRoutingProblem;
+import com.graphhopper.jsprit.core.problem.constraint.ConstraintManager;
+import com.graphhopper.jsprit.core.problem.constraint.HardRouteConstraint;
+import com.graphhopper.jsprit.core.problem.job.Job;
+import com.graphhopper.jsprit.core.problem.job.Shipment;
+import com.graphhopper.jsprit.core.problem.misc.JobInsertionContext;
+import com.graphhopper.jsprit.core.problem.solution.VehicleRoutingProblemSolution;
+import com.graphhopper.jsprit.core.problem.solution.route.activity.TimeWindow;
+import com.graphhopper.jsprit.core.problem.vehicle.VehicleImpl;
+import com.graphhopper.jsprit.core.problem.vehicle.VehicleImpl.Builder;
+import com.graphhopper.jsprit.core.problem.vehicle.VehicleType;
+import com.graphhopper.jsprit.core.problem.vehicle.VehicleTypeImpl;
+import com.graphhopper.jsprit.core.util.FailedConstraintInfo;
+import com.graphhopper.jsprit.core.util.Solutions;
+import com.graphhopper.jsprit.core.util.UnassignedJobReasonTracker;
+
+import java.util.Collection;
+
+public class UnassignedJobReasonTrackerExample {
+
+
+    public static void main(String[] args) {
+        final int WEIGHT_INDEX = 0;
+        VehicleType vehicleType1 = VehicleTypeImpl.Builder.newInstance("vehicleType1").addCapacityDimension(WEIGHT_INDEX, 2).build();
+        VehicleType vehicleType2 = VehicleTypeImpl.Builder.newInstance("vehicleType2").addCapacityDimension(WEIGHT_INDEX, 4).build();
+
+        // vehicles
+        VehicleImpl v1 = Builder.newInstance("vehicle1").setStartLocation(Location.newInstance(0, 0)).setType(vehicleType1).build();
+        VehicleImpl v2 = Builder.newInstance("vehicle2").setStartLocation(Location.newInstance(0, 10)).setType(vehicleType2).build();
+
+        // jobs
+        Shipment shipment1 = Shipment.Builder.newInstance("shipment1").addSizeDimension(WEIGHT_INDEX, 1)
+            .setPickupLocation(Location.newInstance(1, 0))
+            .setDeliveryLocation(Location.newInstance(3, 0))
+            .setPickupTimeWindow(new TimeWindow(0, 3))
+            .setDeliveryTimeWindow(new TimeWindow(2, 7))
+            .build();
+        Shipment shipment2 = Shipment.Builder.newInstance("shipment2").addSizeDimension(WEIGHT_INDEX, 1)
+            .setPickupLocation(Location.newInstance(1, 10))
+            .setDeliveryLocation(Location.newInstance(3, 10))
+            .setPickupTimeWindow(new TimeWindow(1, 3))
+            .setDeliveryTimeWindow(new TimeWindow(3, 7))
+            .build();
+
+        // shipment3 requires more capacity so v1 is not be able to fulfill it, and v2 is too far away and it cannot fit into time windows
+        Shipment shipment3 = Shipment.Builder.newInstance("shipment3").addSizeDimension(WEIGHT_INDEX, 3)
+            .setPickupLocation(Location.newInstance(10, 0))
+            .setDeliveryLocation(Location.newInstance(15, 0))
+            .setPickupTimeWindow(new TimeWindow(10, 15))
+            .setDeliveryTimeWindow(new TimeWindow(15, 16))
+            .build();
+
+        // shipment4 is too far away from v1 so the time windows will fail, and for v2 the custom constraint will fail
+        Shipment shipment4 = Shipment.Builder.newInstance("shipment4").addSizeDimension(WEIGHT_INDEX, 1)
+            .setPickupLocation(Location.newInstance(10, 10))
+            .setDeliveryLocation(Location.newInstance(15, 10))
+            .setPickupTimeWindow(new TimeWindow(10, 15))
+            .setDeliveryTimeWindow(new TimeWindow(15, 16))
+            .build();
+
+        VehicleRoutingProblem.Builder vrpBuilder = VehicleRoutingProblem.Builder.newInstance();
+        vrpBuilder.addVehicle(v1).addVehicle(v2);
+        vrpBuilder.addJob(shipment1).addJob(shipment2).addJob(shipment3).addJob(shipment4);
+
+        // prepare the algorithm
+        VehicleRoutingProblem problem = vrpBuilder.build();
+        StateManager stateManager = new StateManager(problem);
+
+        ConstraintManager constraintManager = new ConstraintManager(problem, stateManager);
+        DummyConstraint dummyConstraint = new DummyConstraint();
+        constraintManager.addConstraint(dummyConstraint);
+        VehicleRoutingAlgorithm algorithm = Jsprit.Builder.newInstance(problem)
+            .setStateAndConstraintManager(stateManager, constraintManager)
+            .setProperty(Jsprit.Parameter.VEHICLE_SWITCH, "false") // needed so that constraint works
+            .buildAlgorithm();
+        algorithm.setMaxIterations(10);
+
+        // set the tracker
+        UnassignedJobReasonTracker tracker = new UnassignedJobReasonTracker();
+        tracker.put("DummyConstraint", 50, "prevent shipment4 in vehicle2");
+        algorithm.addListener(tracker);
+
+        // run the algorithm'
+        Collection<VehicleRoutingProblemSolution> solutions = algorithm.searchSolutions();
+        VehicleRoutingProblemSolution bestSolution = Solutions.bestOf(solutions);
+
+        for (Job unassignedJob: bestSolution.getUnassignedJobs()) {
+            Collection<FailedConstraintInfo> failedConstraints = tracker.getFailedConstraintsForJob(unassignedJob.getId());
+            for (FailedConstraintInfo failedConstraint : failedConstraints) {
+                System.out.println(failedConstraint.toString());
+            }
+        }
+
+        new GraphStreamViewer(problem, bestSolution).labelWith(GraphStreamViewer.Label.ID).setRenderDelay(200).display();
+    }
+
+    static class DummyConstraint implements HardRouteConstraint {
+        @Override
+        public boolean fulfilled(JobInsertionContext insertionContext) {
+            return !(insertionContext.getJob().getId().equals("shipment4") && insertionContext.getNewVehicle().getId().equals("vehicle2"));
+        }
+    }
+
+}


### PR DESCRIPTION
This PR extends the UnassignedJobReasonTracker.

It is connected to #180 and provides more info about not successful insertions which failed because some hard constraint was not fulfilled.

Additional info about why some constraint has failed for certain insertion:
1. In which iteration
2. In which vehicle
3. At which position there was an attempt for insertion

The change is backward compatible, no breaking changes are introduced to UnassignedJobReasonTracker.

The PR also contains an example about how to use the UnassignedJobReasonTracker and how the results can be displayed.

Example how the additional data looks like:
```
Constraint 'PickupAndDeliverShipmentLoadActivityLevelConstraint' failed for job insertion of job 'shipment3' on position '2' on route 'vehicle1 [ shipment1-pickupShipment shipment1-deliverShipment ]'
Constraint 'VehicleDependentTimeWindowConstraints' failed for job insertion of job 'shipment3' on position '0' on route 'vehicle2 [ ]'
Constraint 'DummyConstraint' failed for job insertion of job 'shipment4' on position '0' on route 'vehicle2 [ ]'
Constraint 'ServiceLoadRouteLevelConstraint' failed for job insertion of job 'service2' on position '0' on route 'vehicle2 [ shipment2-pickupShipment shipment2-deliverShipment service1-service ]'
```

**Edit**

Due to performance degradation the only the vehicle will be tracked and not the activities on the route of that vehicle.
The additional data after removing the activities looks like:
```
Constraint 'VehicleDependentTimeWindowConstraints' failed for job insertion of job 'shipment4' on position '2' in vehicle 'vehicle1'
```