### PR TITLE
Version 2 migration continues

### DIFF
--- a/jsprit-core/src/main/java/com/graphhopper/jsprit/core/algorithm/objectivefunction/MissedBreak.java
+++ b/jsprit-core/src/main/java/com/graphhopper/jsprit/core/algorithm/objectivefunction/MissedBreak.java
@@ -29,17 +29,13 @@ public class MissedBreak extends RouteLevelSolutionCostComponent {
     @Override
     protected double calculateRouteLevelCost(VehicleRoutingProblem problem, VehicleRoute route) {
         for (TourActivity act : route.getActivities()) {
-            if (act instanceof BreakActivity) {
+            if (act instanceof BreakActivity)
                 return 0d;
-            }
         }
         if (route.getVehicle().getBreak() != null) {
-            if (route.getEnd().getArrTime() > route.getVehicle().getBreak().getActivity().getSingleTimeWindow()
-                            .getEnd()) {
+            if (route.getEnd().getArrTime() > route.getVehicle().getBreak().getActivity().getBreakTimeWindow().getEnd())
                 return 4 * (getMaxCosts() * 2 + route.getVehicle().getBreak().getActivity().getOperationTime()
-                                * route.getVehicle().getType().getVehicleCostParams().perServiceTimeUnit);
-
-            }
+                        * route.getVehicle().getType().getVehicleCostParams().perServiceTimeUnit);
         }
         return 0d;
     }

--- a/jsprit-core/src/main/java/com/graphhopper/jsprit/core/algorithm/objectivefunction/MissedBreak.java
+++ b/jsprit-core/src/main/java/com/graphhopper/jsprit/core/algorithm/objectivefunction/MissedBreak.java
@@ -29,17 +29,14 @@ public class MissedBreak extends RouteLevelSolutionCostComponent {
     @Override
     protected double calculateRouteLevelCost(VehicleRoutingProblem problem, VehicleRoute route) {
         for (TourActivity act : route.getActivities()) {
-            if (act instanceof BreakActivity) {
+            if (act instanceof BreakActivity)
                 return 0d;
-            }
         }
         if (route.getVehicle().getBreak() != null) {
-            if (route.getEnd().getArrTime() > route.getVehicle().getBreak().getActivity().getSingleTimeWindow()
-                            .getEnd()) {
+            if (route.getEnd().getArrTime() > route.getVehicle().getBreak().getActivity().getBreakTimeWindow()
+                    .getEnd())
                 return 4 * (getMaxCosts() * 2 + route.getVehicle().getBreak().getActivity().getOperationTime()
-                                * route.getVehicle().getType().getVehicleCostParams().perServiceTimeUnit);
-
-            }
+                        * route.getVehicle().getType().getVehicleCostParams().perServiceTimeUnit);
         }
         return 0d;
     }

--- a/jsprit-core/src/main/java/com/graphhopper/jsprit/core/algorithm/recreate/BreakInsertionCalculator.java
+++ b/jsprit-core/src/main/java/com/graphhopper/jsprit/core/algorithm/recreate/BreakInsertionCalculator.java
@@ -102,12 +102,10 @@ final class BreakInsertionCalculator implements JobInsertionCostsCalculator {
     @Override
     public InsertionData getInsertionData(final VehicleRoute currentRoute, final Job jobToInsert, final Vehicle newVehicle, double newVehicleDepartureTime, final Driver newDriver, final double bestKnownCosts) {
         Break breakToInsert = (Break) jobToInsert;
-        if (newVehicle.getBreak() == null || newVehicle.getBreak() != breakToInsert) {
+        if (newVehicle.getBreak() == null || newVehicle.getBreak() != breakToInsert)
             return InsertionData.createEmptyInsertionData();
-        }
-        if (currentRoute.isEmpty()) {
+        if (currentRoute.isEmpty())
             return InsertionData.createEmptyInsertionData();
-        }
 
         JobInsertionContext insertionContext = new JobInsertionContext(currentRoute, jobToInsert, newVehicle, newDriver, newVehicleDepartureTime);
         int insertionIndex = InsertionData.NO_INDEX;
@@ -118,9 +116,8 @@ final class BreakInsertionCalculator implements JobInsertionCostsCalculator {
         /*
         check hard constraints at route level
          */
-        if (!hardRouteLevelConstraint.fulfilled(insertionContext)) {
+        if (!hardRouteLevelConstraint.fulfilled(insertionContext))
             return InsertionData.createEmptyInsertionData();
-        }
 
         /*
         check soft constraints at route level
@@ -156,7 +153,7 @@ final class BreakInsertionCalculator implements JobInsertionCostsCalculator {
             List<Location> locations = Arrays.asList(prevAct.getLocation(), nextAct.getLocation());
             for (Location location : locations) {
                 breakAct2Insert.setLocation(location);
-                TimeWindow timeWindow = breakToInsert.getActivity().getTimeWindow();
+                TimeWindow timeWindow = breakToInsert.getActivity().getBreakTimeWindow();
                 breakAct2Insert.setTheoreticalEarliestOperationStartTime(timeWindow.getStart());
                 breakAct2Insert.setTheoreticalLatestOperationStartTime(timeWindow.getEnd());
                 ConstraintsStatus status = hardActivityLevelConstraint.fulfilled(insertionContext, prevAct, breakAct2Insert, nextAct, prevActStartTime);
@@ -182,9 +179,8 @@ final class BreakInsertionCalculator implements JobInsertionCostsCalculator {
                 break;
             }
         }
-        if (insertionIndex == InsertionData.NO_INDEX) {
+        if (insertionIndex == InsertionData.NO_INDEX)
             return InsertionData.createEmptyInsertionData();
-        }
         InsertionData insertionData = new InsertionData(bestCost, InsertionData.NO_INDEX, insertionIndex, newVehicle, newDriver);
         breakAct2Insert.setLocation(bestLocation);
         insertionData.getEvents().add(new InsertBreak(currentRoute, newVehicle, breakAct2Insert, insertionIndex));

--- a/jsprit-core/src/main/java/com/graphhopper/jsprit/core/algorithm/recreate/BreakInsertionCalculator.java
+++ b/jsprit-core/src/main/java/com/graphhopper/jsprit/core/algorithm/recreate/BreakInsertionCalculator.java
@@ -156,7 +156,7 @@ final class BreakInsertionCalculator implements JobInsertionCostsCalculator {
             List<Location> locations = Arrays.asList(prevAct.getLocation(), nextAct.getLocation());
             for (Location location : locations) {
                 breakAct2Insert.setLocation(location);
-                TimeWindow timeWindow = breakToInsert.getActivity().getTimeWindow();
+                TimeWindow timeWindow = breakToInsert.getActivity().getBreakTimeWindow();
                 breakAct2Insert.setTheoreticalEarliestOperationStartTime(timeWindow.getStart());
                 breakAct2Insert.setTheoreticalLatestOperationStartTime(timeWindow.getEnd());
                 ConstraintsStatus status = hardActivityLevelConstraint.fulfilled(insertionContext, prevAct, breakAct2Insert, nextAct, prevActStartTime);

--- a/jsprit-core/src/main/java/com/graphhopper/jsprit/core/algorithm/recreate/BreakScheduling.java
+++ b/jsprit-core/src/main/java/com/graphhopper/jsprit/core/algorithm/recreate/BreakScheduling.java
@@ -50,7 +50,7 @@ public class BreakScheduling implements InsertionStartsListener, JobInsertedList
 
     private final EventListeners eventListeners;
 
-    private Set<VehicleRoute> modifiedRoutes = new HashSet<VehicleRoute>();
+    private Set<VehicleRoute> modifiedRoutes = new HashSet<>();
 
     public BreakScheduling(VehicleRoutingProblem vrp, StateManager stateManager, ConstraintManager constraintManager) {
         this.stateManager = stateManager;
@@ -69,7 +69,7 @@ public class BreakScheduling implements InsertionStartsListener, JobInsertedList
                 stateManager.removed(aBreak, inRoute);
                 stateManager.reCalculateStates(inRoute);
             }
-            if (inRoute.getEnd().getArrTime() > aBreak.getActivity().getTimeWindow().getEnd()) {
+            if (inRoute.getEnd().getArrTime() > aBreak.getActivity().getBreakTimeWindow().getEnd()) {
                 InsertionData iData = breakInsertionCalculator.getInsertionData(inRoute, aBreak, inRoute.getVehicle(), inRoute.getDepartureTime(), inRoute.getDriver(), Double.MAX_VALUE);
                 if (!(iData instanceof InsertionData.NoInsertionFound)) {
                     logger.trace("insert: [jobId={}]{}", aBreak.getId(), iData);
@@ -96,7 +96,7 @@ public class BreakScheduling implements InsertionStartsListener, JobInsertedList
                 logger.trace("ruin: {}", aBreak.getId());
             }
         }
-        List<Break> breaks = new ArrayList<Break>();
+        List<Break> breaks = new ArrayList<>();
         for (Job j : unassignedJobs) {
             if (j instanceof Break) {
                 breaks.add((Break) j);
@@ -119,7 +119,7 @@ public class BreakScheduling implements InsertionStartsListener, JobInsertedList
         for (VehicleRoute route : vehicleRoutes) {
             Break aBreak = route.getVehicle().getBreak();
             if (aBreak != null && !route.getTourActivities().servesJob(aBreak)) {
-                if (route.getEnd().getArrTime() > aBreak.getActivity().getTimeWindow().getEnd()) {
+                if (route.getEnd().getArrTime() > aBreak.getActivity().getBreakTimeWindow().getEnd()) {
                     InsertionData iData = breakInsertionCalculator.getInsertionData(route, aBreak, route.getVehicle(), route.getDepartureTime(), route.getDriver(), Double.MAX_VALUE);
                     if (!(iData instanceof InsertionData.NoInsertionFound)) {
                         logger.trace("insert: [jobId={}]{}", aBreak.getId(), iData);

--- a/jsprit-core/src/main/java/com/graphhopper/jsprit/core/algorithm/recreate/BreakScheduling.java
+++ b/jsprit-core/src/main/java/com/graphhopper/jsprit/core/algorithm/recreate/BreakScheduling.java
@@ -69,7 +69,7 @@ public class BreakScheduling implements InsertionStartsListener, JobInsertedList
                 stateManager.removed(aBreak, inRoute);
                 stateManager.reCalculateStates(inRoute);
             }
-            if (inRoute.getEnd().getArrTime() > aBreak.getActivity().getTimeWindow().getEnd()) {
+            if (inRoute.getEnd().getArrTime() > aBreak.getActivity().getBreakTimeWindow().getEnd()) {
                 InsertionData iData = breakInsertionCalculator.getInsertionData(inRoute, aBreak, inRoute.getVehicle(), inRoute.getDepartureTime(), inRoute.getDriver(), Double.MAX_VALUE);
                 if (!(iData instanceof InsertionData.NoInsertionFound)) {
                     logger.trace("insert: [jobId={}]{}", aBreak.getId(), iData);
@@ -119,7 +119,7 @@ public class BreakScheduling implements InsertionStartsListener, JobInsertedList
         for (VehicleRoute route : vehicleRoutes) {
             Break aBreak = route.getVehicle().getBreak();
             if (aBreak != null && !route.getTourActivities().servesJob(aBreak)) {
-                if (route.getEnd().getArrTime() > aBreak.getActivity().getTimeWindow().getEnd()) {
+                if (route.getEnd().getArrTime() > aBreak.getActivity().getBreakTimeWindow().getEnd()) {
                     InsertionData iData = breakInsertionCalculator.getInsertionData(route, aBreak, route.getVehicle(), route.getDepartureTime(), route.getDriver(), Double.MAX_VALUE);
                     if (!(iData instanceof InsertionData.NoInsertionFound)) {
                         logger.trace("insert: [jobId={}]{}", aBreak.getId(), iData);

--- a/jsprit-core/src/main/java/com/graphhopper/jsprit/core/algorithm/recreate/RegretInsertionConcurrentFast.java
+++ b/jsprit-core/src/main/java/com/graphhopper/jsprit/core/algorithm/recreate/RegretInsertionConcurrentFast.java
@@ -18,18 +18,28 @@
 
 package com.graphhopper.jsprit.core.algorithm.recreate;
 
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.TreeSet;
+import java.util.concurrent.Callable;
+import java.util.concurrent.ExecutorService;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import com.graphhopper.jsprit.core.problem.VehicleRoutingProblem;
 import com.graphhopper.jsprit.core.problem.constraint.DependencyType;
 import com.graphhopper.jsprit.core.problem.job.Break;
 import com.graphhopper.jsprit.core.problem.job.Job;
 import com.graphhopper.jsprit.core.problem.solution.route.VehicleRoute;
 import com.graphhopper.jsprit.core.problem.vehicle.VehicleFleetManager;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
-import java.util.*;
-import java.util.concurrent.Callable;
-import java.util.concurrent.ExecutorService;
 
 /**
  * Insertion based on regret approach.
@@ -58,7 +68,7 @@ public class RegretInsertionConcurrentFast extends AbstractInsertionStrategy {
 
     private boolean switchAllowed = true;
 
-    private DependencyType[] dependencyTypes = null;
+    private HashMap<String, DependencyType> dependencyTypes = null;
 
 
     /**
@@ -93,15 +103,15 @@ public class RegretInsertionConcurrentFast extends AbstractInsertionStrategy {
     }
 
     private Set<String> getInitialVehicleIds(VehicleRoutingProblem vehicleRoutingProblem) {
-        Set<String> ids = new HashSet<String>();
+        Set<String> ids = new HashSet<>();
         for (VehicleRoute r : vehicleRoutingProblem.getInitialVehicleRoutes()) {
             ids.add(r.getVehicle().getId());
         }
         return ids;
     }
 
-    public void setDependencyTypes(DependencyType[] dependencyTypes) {
-        this.dependencyTypes = dependencyTypes;
+    public void setDependencyTypes(HashMap<String, DependencyType> hashMap) {
+        this.dependencyTypes = hashMap;
     }
 
 
@@ -114,7 +124,7 @@ public class RegretInsertionConcurrentFast extends AbstractInsertionStrategy {
      */
     @Override
     public Collection<Job> insertUnassignedJobs(Collection<VehicleRoute> routes, Collection<Job> unassignedJobs) {
-        List<Job> badJobs = new ArrayList<Job>(unassignedJobs.size());
+        List<Job> badJobs = new ArrayList<>(unassignedJobs.size());
 
         Iterator<Job> jobIterator = unassignedJobs.iterator();
         while (jobIterator.hasNext()) {
@@ -135,18 +145,20 @@ public class RegretInsertionConcurrentFast extends AbstractInsertionStrategy {
             }
         }
 
-        List<Job> jobs = new ArrayList<Job>(unassignedJobs);
-        TreeSet<VersionedInsertionData>[] priorityQueues = new TreeSet[vrp.getJobs().values().size() + 2];
+        List<Job> jobs = new ArrayList<>(unassignedJobs);
+        Map<String, TreeSet<VersionedInsertionData>> priorityQueues = new HashMap<>(vrp.getJobs().values().size() + 2);
         VehicleRoute lastModified = null;
         boolean firstRun = true;
         int updateRound = 0;
-        Map<VehicleRoute, Integer> updates = new HashMap<VehicleRoute, Integer>();
+        Map<VehicleRoute, Integer> updates = new HashMap<>();
         while (!jobs.isEmpty()) {
-            List<Job> unassignedJobList = new ArrayList<Job>(jobs);
-            List<Job> badJobList = new ArrayList<Job>();
+            List<Job> unassignedJobList = new ArrayList<>(jobs);
+            List<Job> badJobList = new ArrayList<>();
             if (!firstRun && lastModified == null) throw new IllegalStateException("ho. this must not be.");
             updateInsertionData(priorityQueues, routes, unassignedJobList, updateRound, firstRun, lastModified, updates);
-            if (firstRun) firstRun = false;
+            if (firstRun) {
+                firstRun = false;
+            }
             updateRound++;
             ScoredJob bestScoredJob = InsertionDataUpdater.getBest(switchAllowed, initialVehicleIds, fleetManager, insertionCostsCalculator, scoringFunction, priorityQueues, updates, unassignedJobList, badJobList);
             if (bestScoredJob != null) {
@@ -156,7 +168,9 @@ public class RegretInsertionConcurrentFast extends AbstractInsertionStrategy {
                 insertJob(bestScoredJob.getJob(), bestScoredJob.getInsertionData(), bestScoredJob.getRoute());
                 jobs.remove(bestScoredJob.getJob());
                 lastModified = bestScoredJob.getRoute();
-            } else lastModified = null;
+            } else {
+                lastModified = null;
+            }
             for (Job bad : badJobList) {
                 jobs.remove(bad);
                 badJobs.add(bad);
@@ -165,32 +179,41 @@ public class RegretInsertionConcurrentFast extends AbstractInsertionStrategy {
         return badJobs;
     }
 
-    private void updateInsertionData(final TreeSet<VersionedInsertionData>[] priorityQueues, final Collection<VehicleRoute> routes, List<Job> unassignedJobList, final int updateRound, final boolean firstRun, final VehicleRoute lastModified, Map<VehicleRoute, Integer> updates) {
-        List<Callable<Boolean>> tasks = new ArrayList<Callable<Boolean>>();
+    private void updateInsertionData(final Map<String, TreeSet<VersionedInsertionData>> priorityQueues,
+            final Collection<VehicleRoute> routes, List<Job> unassignedJobList, final int updateRound,
+            final boolean firstRun, final VehicleRoute lastModified, Map<VehicleRoute, Integer> updates) {
+        List<Callable<Boolean>> tasks = new ArrayList<>();
         boolean updatedAllRoutes = false;
         for (final Job unassignedJob : unassignedJobList) {
-            if (priorityQueues[unassignedJob.getIndex()] == null) {
-                priorityQueues[unassignedJob.getIndex()] = new TreeSet<VersionedInsertionData>(InsertionDataUpdater.getComparator());
+            String unassignedJobId = unassignedJob.getId();
+            if (priorityQueues.get(unassignedJobId) == null) {
+                priorityQueues.put(unassignedJobId, new TreeSet<>(InsertionDataUpdater.getComparator()));
             }
             if (firstRun) {
                 updatedAllRoutes = true;
-                makeCallables(tasks, updatedAllRoutes, priorityQueues[unassignedJob.getIndex()], updateRound, unassignedJob, routes, lastModified);
+                makeCallables(tasks, updatedAllRoutes, priorityQueues.get(unassignedJobId), updateRound, unassignedJob,
+                        routes, lastModified);
             } else {
-                if (dependencyTypes == null || dependencyTypes[unassignedJob.getIndex()] == null) {
-                    makeCallables(tasks, updatedAllRoutes, priorityQueues[unassignedJob.getIndex()], updateRound, unassignedJob, routes, lastModified);
+                if (dependencyTypes == null || dependencyTypes.get(unassignedJobId) == null) {
+                    makeCallables(tasks, updatedAllRoutes, priorityQueues.get(unassignedJobId), updateRound,
+                            unassignedJob, routes, lastModified);
                 } else {
-                    DependencyType dependencyType = dependencyTypes[unassignedJob.getIndex()];
+                    DependencyType dependencyType = dependencyTypes.get(unassignedJobId);
                     if (dependencyType.equals(DependencyType.INTER_ROUTE) || dependencyType.equals(DependencyType.INTRA_ROUTE)) {
                         updatedAllRoutes = true;
-                        makeCallables(tasks, updatedAllRoutes, priorityQueues[unassignedJob.getIndex()], updateRound, unassignedJob, routes, lastModified);
+                        makeCallables(tasks, updatedAllRoutes, priorityQueues.get(unassignedJobId), updateRound,
+                                unassignedJob, routes, lastModified);
                     } else {
-                        makeCallables(tasks, updatedAllRoutes, priorityQueues[unassignedJob.getIndex()], updateRound, unassignedJob, routes, lastModified);
+                        makeCallables(tasks, updatedAllRoutes, priorityQueues.get(unassignedJobId), updateRound,
+                                unassignedJob, routes, lastModified);
                     }
                 }
             }
         }
         if (updatedAllRoutes) {
-            for (VehicleRoute r : routes) updates.put(r, updateRound);
+            for (VehicleRoute r : routes) {
+                updates.put(r, updateRound);
+            }
         } else {
             updates.put(lastModified, updateRound);
         }
@@ -204,19 +227,9 @@ public class RegretInsertionConcurrentFast extends AbstractInsertionStrategy {
 
     private void makeCallables(List<Callable<Boolean>> tasks, boolean updateAll, final TreeSet<VersionedInsertionData> priorityQueue, final int updateRound, final Job unassignedJob, final Collection<VehicleRoute> routes, final VehicleRoute lastModified) {
         if (updateAll) {
-            tasks.add(new Callable<Boolean>() {
-                @Override
-                public Boolean call() throws Exception {
-                    return InsertionDataUpdater.update(switchAllowed, initialVehicleIds, fleetManager, insertionCostsCalculator, priorityQueue, updateRound, unassignedJob, routes);
-                }
-            });
+            tasks.add(() -> InsertionDataUpdater.update(switchAllowed, initialVehicleIds, fleetManager, insertionCostsCalculator, priorityQueue, updateRound, unassignedJob, routes));
         } else {
-            tasks.add(new Callable<Boolean>() {
-                @Override
-                public Boolean call() throws Exception {
-                    return InsertionDataUpdater.update(switchAllowed, initialVehicleIds, fleetManager, insertionCostsCalculator, priorityQueue, updateRound, unassignedJob, Arrays.asList(lastModified));
-                }
-            });
+            tasks.add(() -> InsertionDataUpdater.update(switchAllowed, initialVehicleIds, fleetManager, insertionCostsCalculator, priorityQueue, updateRound, unassignedJob, Arrays.asList(lastModified)));
         }
     }
 

--- a/jsprit-core/src/main/java/com/graphhopper/jsprit/core/algorithm/util/QuickCompactMatrix.java
+++ b/jsprit-core/src/main/java/com/graphhopper/jsprit/core/algorithm/util/QuickCompactMatrix.java
@@ -1,0 +1,240 @@
+package com.graphhopper.jsprit.core.algorithm.util;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.function.BiFunction;
+
+import com.graphhopper.jsprit.core.problem.HasIndex;
+
+/**
+ * A quick, compact, but flexible int array based matrix.
+ *
+ * @author Balage
+ *
+ * @param <T>
+ *            The type of the items.
+ */
+public class QuickCompactMatrix<T extends HasIndex> {
+
+    // The shift in redirection array indexing: the minimum index of the items
+    private int shift;
+    // The size of the redirection array: the difference of the minimum and
+    // maximum index of the items
+    private int redirectionSize;
+    // The matrix size: the number of items
+    private int matrixSize;
+    // The redirection array: maps the item index to matrix index
+    private int[] redirection;
+    // The matrix
+    private int[][] matrix;
+
+    /**
+     * Wrapper class to avoid repeated calculation.
+     *
+     * @author Balage
+     *
+     * @param <S>
+     *            The item type.
+     */
+    private static class CopyWrapper<S extends HasIndex> implements BiFunction<S, S, Integer> {
+
+        private QuickCompactMatrix<S> source;
+        private BiFunction<S, S, Integer> valueCalculator;
+
+        public CopyWrapper(QuickCompactMatrix<S> source, BiFunction<S, S, Integer> valueCalculator) {
+            this.source = source;
+            this.valueCalculator = valueCalculator;
+        }
+
+        @Override
+        public Integer apply(S item1, S item2) {
+            if (source.contains(item1) && source.contains(item2))
+                return source.getValue(item1, item2);
+            else
+                return valueCalculator.apply(item1, item2);
+        }
+    }
+
+    /**
+     * Wraps the calculator to use an other instance of the matrix for
+     * calculating values whenever it is possible.
+     * <p>
+     * The wrapper is helpful, when creating an extended matrix from an old one
+     * and the cost of calculating the value is high.
+     * </p>
+     * <p>
+     * This class wraps the original value calculator. When it is called to
+     * calculate a value, first checks if it is available in the source matrix
+     * and returns the value from the source. Otherwise it delegates the
+     * calculation to the wrapped calculator.
+     * </p>
+     *
+     * @param source
+     *            The source matrix.
+     * @param valueCalculator
+     *            The calculator.
+     * @return A wrapped calculator.
+     */
+    public static <T extends HasIndex> BiFunction<T, T, Integer> getCopyWrapper(QuickCompactMatrix<T> source,
+            BiFunction<T, T, Integer> valueCalculator) {
+        return new CopyWrapper<>(source, valueCalculator);
+    }
+
+    /**
+     * Plain constructor.
+     * <p>
+     * It gets no other matrix to extend.
+     * </p>
+     *
+     * @param items
+     *            The list of items.
+     * @param valueCalculator
+     *            The function to calculate matrix cell values.
+     */
+    public QuickCompactMatrix(List<T> items, BiFunction<T, T, Integer> valueCalculator) {
+        calculateDimensions(items);
+        initializeRedirectionArray(items);
+        initializeMatrix();
+        calculateValues(items, valueCalculator);
+    }
+
+    /**
+     * Calculates the shift value and redirection array and the matrix size.
+     *
+     * @param items
+     *            The list of items.
+     */
+    private void calculateDimensions(List<T> items) {
+        shift = 0;
+        int min = Integer.MAX_VALUE;
+        int max = 0;
+        for (T i : items) {
+            int idx = i.getIndex();
+            if (idx < min) {
+                min = idx;
+            }
+            if (idx > max) {
+                max = idx;
+            }
+        }
+        shift = min;
+        redirectionSize = max - shift + 1;
+        matrixSize = items.size();
+    }
+
+    /**
+     * Initialize the redirection matrix.
+     *
+     * @param items
+     *            The list of items.
+     */
+    private void initializeRedirectionArray(List<T> items) {
+        // Initialize the array and fill up with -1. (Filling the values with -1
+        // ensures that IndexOutOfBounds is thrown when calling getValue with
+        // items not in this original list.)
+        redirection = new int[redirectionSize];
+        Arrays.fill(redirection, -1);
+
+        // Determine the matrix indexing for each item index
+        int counter = 0;
+        for (T i : items) {
+            redirection[i.getIndex() - shift] = counter++;
+        }
+    }
+
+    /**
+     * Initialize the matrix.
+     */
+    private void initializeMatrix() {
+        matrix = new int[matrixSize][matrixSize];
+    }
+
+    /**
+     * Calculates the matrix values.
+     * <p>
+     * It only calculates the values above the <code>from</code> index.
+     * </p>
+     *
+     * @param items
+     *            The list of items.
+     * @param valueCalculator
+     *            The value calculator to use.
+     */
+    private void calculateValues(List<T> items, BiFunction<T, T, Integer> valueCalculator) {
+        for (int row = 0; row < matrixSize; row++) {
+            T rowItem = items.get(row);
+            int rowIndex = redirection[rowItem.getIndex() - shift];
+            for (int col = 0; col < matrixSize; col++) {
+                T colItem = items.get(col);
+                int colIndex = redirection[colItem.getIndex() - shift];
+                matrix[rowIndex][colIndex] = valueCalculator.apply(rowItem, colItem);
+            }
+        }
+    }
+
+    /**
+     * Returns the value from the matrix.
+     *
+     * @param rowItem
+     *            The row item.
+     * @param colItem
+     *            The column item.
+     * @return The value from the matrix.
+     * @throws IndexOutOfBoundsException
+     *             When any of the items passed are not mapped.
+     */
+    public int getValue(T rowItem, T colItem) {
+        int rowIndex = redirection[rowItem.getIndex() - shift];
+        int colIndex = redirection[colItem.getIndex() - shift];
+        return matrix[rowIndex][colIndex];
+    }
+
+    /**
+     * Returns the internal (matrix) index of the item.
+     *
+     * @param item
+     *            The item to get the index of.
+     * @return The matrix index or -1 if the item is not mapped.
+     */
+    public int getMatrixIndex(T item) {
+        int rowItemIndex = item.getIndex() - shift;
+        if (rowItemIndex < 0 || rowItemIndex >= redirectionSize)
+            return -1;
+        else
+            return redirection[rowItemIndex];
+    }
+
+    /**
+     * Checks if the item is part of the matrix.
+     *
+     * @param item
+     *            The item to check.
+     * @return True if the item is mapped in the matrix.
+     */
+    public boolean contains(T item) {
+        return getMatrixIndex(item) != -1;
+    }
+
+    /**
+     * @return The shift in index used when addressing the redirection array by
+     *         item index.
+     */
+    public int getShift() {
+        return shift;
+    }
+
+    /**
+     * @return The size of the redirection array.
+     */
+    public int getRedirectionSize() {
+        return redirectionSize;
+    }
+
+    /**
+     * @return The matrix size.
+     */
+    public int getMatrixSize() {
+        return matrixSize;
+    }
+
+}

--- a/jsprit-core/src/main/java/com/graphhopper/jsprit/core/problem/VehicleRoutingProblem.java
+++ b/jsprit-core/src/main/java/com/graphhopper/jsprit/core/problem/VehicleRoutingProblem.java
@@ -246,7 +246,7 @@ public class VehicleRoutingProblem {
         public Builder addJob(AbstractJob job) {
             if (tentativeJobs.containsKey(job.getId()))
                 throw new IllegalArgumentException("vehicle routing problem already contains a service or shipment with id " + job.getId() + ". make sure you use unique ids for all services and shipments");
-            job.impl_setIndex(FRIENDLY_HANDSHAKE, jobIndexCounter);
+            // job.impl_setIndex(FRIENDLY_HANDSHAKE, jobIndexCounter);
             incJobIndexCounter();
             tentativeJobs.put(job.getId(), job);
             addLocationToTentativeLocations(job);

--- a/jsprit-core/src/main/java/com/graphhopper/jsprit/core/problem/constraint/ConstraintManager.java
+++ b/jsprit-core/src/main/java/com/graphhopper/jsprit/core/problem/constraint/ConstraintManager.java
@@ -17,18 +17,19 @@
  */
 package com.graphhopper.jsprit.core.problem.constraint;
 
-import com.graphhopper.jsprit.core.problem.VehicleRoutingProblem;
-import com.graphhopper.jsprit.core.problem.job.Job;
-import com.graphhopper.jsprit.core.problem.misc.JobInsertionContext;
-import com.graphhopper.jsprit.core.problem.solution.route.activity.TourActivity;
-import com.graphhopper.jsprit.core.problem.solution.route.state.RouteAndActivityStateGetter;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.graphhopper.jsprit.core.problem.VehicleRoutingProblem;
+import com.graphhopper.jsprit.core.problem.misc.JobInsertionContext;
+import com.graphhopper.jsprit.core.problem.solution.route.activity.TourActivity;
+import com.graphhopper.jsprit.core.problem.solution.route.state.RouteAndActivityStateGetter;
 
 /**
  * Manager that manage hard- and soft constraints, both on route and activity level.
@@ -61,38 +62,31 @@ public class ConstraintManager implements HardActivityConstraint, HardRouteConst
 
     private boolean skillconstraintSet = false;
 
-    private final DependencyType[] dependencyTypes;
+    private final HashMap<String, DependencyType> dependencyTypes;
 
     public ConstraintManager(VehicleRoutingProblem vrp, RouteAndActivityStateGetter stateManager) {
         this.vrp = vrp;
         this.stateManager = stateManager;
-        dependencyTypes = new DependencyType[vrp.getJobs().size() + 1];
+        dependencyTypes = new HashMap<>(vrp.getJobs().size() + 1);
     }
 
     public ConstraintManager(VehicleRoutingProblem vrp, RouteAndActivityStateGetter stateManager, Collection<Constraint> constraints) {
         this.vrp = vrp;
         this.stateManager = stateManager;
-        dependencyTypes = new DependencyType[vrp.getJobs().size() + 1];
+        dependencyTypes = new HashMap<>(vrp.getJobs().size() + 1);
         resolveConstraints(constraints);
     }
 
-    public DependencyType[] getDependencyTypes() {
+    public HashMap<String, DependencyType> getDependencyTypes() {
         return dependencyTypes;
     }
 
     public void setDependencyType(String jobId, DependencyType dependencyType) {
-        Job job = vrp.getJobs().get(jobId);
-        if (job != null) {
-            dependencyTypes[job.getIndex()] = dependencyType;
-        }
+        dependencyTypes.put(jobId, dependencyType);
     }
 
     public DependencyType getDependencyType(String jobId) {
-        Job job = vrp.getJobs().get(jobId);
-        if (job != null) {
-            return dependencyTypes[job.getIndex()];
-        }
-        return DependencyType.NO_TYPE;
+        return dependencyTypes.getOrDefault(jobId, DependencyType.NO_TYPE);
     }
 
     private void resolveConstraints(Collection<Constraint> constraints) {
@@ -145,7 +139,7 @@ public class ConstraintManager implements HardActivityConstraint, HardRouteConst
         }
     }
 
-//	public void add
+    //	public void add
 
     public void addConstraint(HardActivityConstraint actLevelConstraint, Priority priority) {
         actLevelConstraintManager.addConstraint(actLevelConstraint, priority);
@@ -174,7 +168,7 @@ public class ConstraintManager implements HardActivityConstraint, HardRouteConst
     }
 
     public Collection<Constraint> getConstraints() {
-        List<Constraint> constraints = new ArrayList<Constraint>();
+        List<Constraint> constraints = new ArrayList<>();
         constraints.addAll(actLevelConstraintManager.getAllConstraints());
         constraints.addAll(routeLevelConstraintManager.getConstraints());
         constraints.addAll(softActivityConstraintManager.getConstraints());

--- a/jsprit-core/src/main/java/com/graphhopper/jsprit/core/problem/job/AbstractJob.java
+++ b/jsprit-core/src/main/java/com/graphhopper/jsprit/core/problem/job/AbstractJob.java
@@ -27,7 +27,6 @@ import java.util.Set;
 import com.graphhopper.jsprit.core.problem.Location;
 import com.graphhopper.jsprit.core.problem.SizeDimension;
 import com.graphhopper.jsprit.core.problem.Skills;
-import com.graphhopper.jsprit.core.problem.VehicleRoutingProblem.Builder.FriendlyHandshake;
 import com.graphhopper.jsprit.core.problem.solution.route.activity.JobActivity;
 import com.graphhopper.jsprit.core.problem.solution.route.activity.TimeWindow;
 
@@ -381,27 +380,28 @@ public abstract class AbstractJob implements Job {
     AbstractJob() {
     }
 
-    @Override
-    public int getIndex() {
-        return index;
-    }
+    // @Override
+    // public int getIndex() {
+    // return index;
+    // }
 
-
-    /**
-     * Sets the index of the job within the problem.
-     * <p>
-     * <b>This method isn't part of the public API and should not be called! If
-     * it is still called, it will throw {@link IllegalStateException}.</b>
-     * </p>
-     *
-     * @param index
-     *            The index.
-     */
-    public void impl_setIndex(FriendlyHandshake handshake, int index) {
-        if (handshake == null)
-            throw new IllegalStateException();
-        this.index = index;
-    }
+    //
+    // /**
+    // * Sets the index of the job within the problem.
+    // * <p>
+    // * <b>This method isn't part of the public API and should not be called!
+    // If
+    // * it is still called, it will throw {@link IllegalStateException}.</b>
+    // * </p>
+    // *
+    // * @param index
+    // * The index.
+    // */
+    // public void impl_setIndex(FriendlyHandshake handshake, int index) {
+    // if (handshake == null)
+    // throw new IllegalStateException();
+    // this.index = index;
+    // }
 
     /**
      * @return User-specific domain data associated with the job

--- a/jsprit-core/src/main/java/com/graphhopper/jsprit/core/problem/job/AbstractJob.java
+++ b/jsprit-core/src/main/java/com/graphhopper/jsprit/core/problem/job/AbstractJob.java
@@ -27,6 +27,7 @@ import java.util.Set;
 import com.graphhopper.jsprit.core.problem.Location;
 import com.graphhopper.jsprit.core.problem.SizeDimension;
 import com.graphhopper.jsprit.core.problem.Skills;
+import com.graphhopper.jsprit.core.problem.VehicleRoutingProblem.Builder.FriendlyHandshake;
 import com.graphhopper.jsprit.core.problem.solution.route.activity.JobActivity;
 import com.graphhopper.jsprit.core.problem.solution.route.activity.TimeWindow;
 
@@ -385,16 +386,20 @@ public abstract class AbstractJob implements Job {
         return index;
     }
 
+
     /**
      * Sets the index of the job within the problem.
      * <p>
-     * <b>This method isn't part of the public API and should not be called!</b>
+     * <b>This method isn't part of the public API and should not be called! If
+     * it is still called, it will throw {@link IllegalStateException}.</b>
      * </p>
      *
      * @param index
      *            The index.
      */
-    public void impl_setIndex(int index) {
+    public void impl_setIndex(FriendlyHandshake handshake, int index) {
+        if (handshake == null)
+            throw new IllegalStateException();
         this.index = index;
     }
 

--- a/jsprit-core/src/main/java/com/graphhopper/jsprit/core/problem/job/AbstractListBackedJobActivityList.java
+++ b/jsprit-core/src/main/java/com/graphhopper/jsprit/core/problem/job/AbstractListBackedJobActivityList.java
@@ -1,10 +1,10 @@
 package com.graphhopper.jsprit.core.problem.job;
 
-import com.graphhopper.jsprit.core.problem.solution.route.activity.JobActivity;
-
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+
+import com.graphhopper.jsprit.core.problem.solution.route.activity.JobActivity;
 
 /**
  * Simple activity list implementation.
@@ -29,12 +29,35 @@ public abstract class AbstractListBackedJobActivityList extends JobActivityList 
         super(job);
     }
 
+    /**
+     * Handshake class for C++ like friend visibility behavior emulation.
+     *
+     * <p>
+     * This is not a class for the end-users. (To be frank, this class can't be
+     * instantiate outside the parent task.
+     * </p>
+     *
+     * <p>
+     * Based on
+     * {@link https://stackoverflow.com/questions/182278/is-there-a-way-to-simulate-the-c-friend-concept-in-java}
+     * </p>
+     *
+     * @author Balage
+     */
+    // C++ like friend behavior simulation
+    public final static class FriendlyHandshake {
+        private FriendlyHandshake() {
+        }
+    }
+
+    private static final FriendlyHandshake FRIENDLY_HANDSHAKE = new FriendlyHandshake();
+
     @Override
     public void addActivity(JobActivity activity) {
         validateActivity(activity);
         if (!_activities.contains(activity)) {
             _activities.add(activity);
-            activity.impl_setOrderNumber(_activities.size());
+            activity.impl_setOrderNumber(FRIENDLY_HANDSHAKE, _activities.size());
         }
     }
 
@@ -55,9 +78,8 @@ public abstract class AbstractListBackedJobActivityList extends JobActivityList 
      */
     protected int indexOf(JobActivity activity) {
         int idx = _activities.indexOf(activity);
-        if (idx == -1) {
+        if (idx == -1)
             throw new IllegalArgumentException("Activity " + activity.getName() + " is not in the list.");
-        }
         return idx;
     }
 

--- a/jsprit-core/src/main/java/com/graphhopper/jsprit/core/problem/job/Break.java
+++ b/jsprit-core/src/main/java/com/graphhopper/jsprit/core/problem/job/Break.java
@@ -31,7 +31,7 @@ public class Break extends AbstractSingleActivityJob<BreakActivity> implements I
     public static final class Builder extends ServiceJob.BuilderBase<Break, Builder> {
 
         private static final Location VARIABLE_LOCATION = Location
-                        .newInstance("@@@VARIABLE_LOCATION");
+                .newInstance("@@@VARIABLE_LOCATION");
 
         public Builder(String id) {
             super(id);
@@ -71,7 +71,7 @@ public class Break extends AbstractSingleActivityJob<BreakActivity> implements I
 
     @Override
     protected BreakActivity createActivity(
-                    BuilderBase<? extends AbstractSingleActivityJob<?>, ?> builder) {
+            BuilderBase<? extends AbstractSingleActivityJob<?>, ?> builder) {
         return BreakActivity.newInstance(this, (Builder) builder);
     }
 

--- a/jsprit-core/src/main/java/com/graphhopper/jsprit/core/problem/job/Job.java
+++ b/jsprit-core/src/main/java/com/graphhopper/jsprit/core/problem/job/Job.java
@@ -22,7 +22,6 @@ import java.util.Collection;
 import java.util.List;
 
 import com.graphhopper.jsprit.core.problem.HasId;
-import com.graphhopper.jsprit.core.problem.HasIndex;
 import com.graphhopper.jsprit.core.problem.Location;
 import com.graphhopper.jsprit.core.problem.SizeDimension;
 import com.graphhopper.jsprit.core.problem.Skills;
@@ -33,7 +32,7 @@ import com.graphhopper.jsprit.core.problem.solution.route.activity.TimeWindow;
  *
  * @author schroeder
  */
-public interface Job extends HasId, HasIndex {
+public interface Job extends HasId {
 
     /**
      * Returns the unique identifier (id) of a job.

--- a/jsprit-core/src/main/java/com/graphhopper/jsprit/core/problem/job/Service.java
+++ b/jsprit-core/src/main/java/com/graphhopper/jsprit/core/problem/job/Service.java
@@ -364,8 +364,11 @@ public class Service extends AbstractJob {
      * @return time window
      *
      */
+    @Deprecated
     public TimeWindow getTimeWindow() {
-        return theRealActivity.getSingleTimeWindow();
+        if (getTheRealActivity().getTimeWindows().size() > 1)
+            throw new IllegalArgumentException("More than one time window in. " + this);
+        return getTheRealActivity().getTimeWindows().iterator().next();
     }
 
     /**

--- a/jsprit-core/src/main/java/com/graphhopper/jsprit/core/problem/job/Service.java
+++ b/jsprit-core/src/main/java/com/graphhopper/jsprit/core/problem/job/Service.java
@@ -24,7 +24,6 @@ import com.graphhopper.jsprit.core.problem.Capacity;
 import com.graphhopper.jsprit.core.problem.Location;
 import com.graphhopper.jsprit.core.problem.SizeDimension;
 import com.graphhopper.jsprit.core.problem.Skills;
-import com.graphhopper.jsprit.core.problem.VehicleRoutingProblem.Builder.FriendlyHandshake;
 import com.graphhopper.jsprit.core.problem.job.CustomJob.BuilderBase.ActivityType;
 import com.graphhopper.jsprit.core.problem.job.CustomJob.BuilderBase.BuilderActivityInfo;
 import com.graphhopper.jsprit.core.problem.solution.route.activity.ServiceActivity;
@@ -456,15 +455,15 @@ public class Service extends AbstractJob {
         // This is unused being a legacy implementation
     }
 
-    @Override
-    public int getIndex() {
-        return theRealJob.getIndex();
-    }
-
-    @Override
-    public void impl_setIndex(FriendlyHandshake handshake, int index) {
-        theRealJob.impl_setIndex(handshake, index);
-    }
+    //    @Override
+    //    public int getIndex() {
+    //        return theRealJob.getIndex();
+    //    }
+    //
+    // @Override
+    // public void impl_setIndex(FriendlyHandshake handshake, int index) {
+    // theRealJob.impl_setIndex(handshake, index);
+    // }
 
     @Override
     public List<Location> getAllLocations() {

--- a/jsprit-core/src/main/java/com/graphhopper/jsprit/core/problem/job/Service.java
+++ b/jsprit-core/src/main/java/com/graphhopper/jsprit/core/problem/job/Service.java
@@ -24,6 +24,7 @@ import com.graphhopper.jsprit.core.problem.Capacity;
 import com.graphhopper.jsprit.core.problem.Location;
 import com.graphhopper.jsprit.core.problem.SizeDimension;
 import com.graphhopper.jsprit.core.problem.Skills;
+import com.graphhopper.jsprit.core.problem.VehicleRoutingProblem.Builder.FriendlyHandshake;
 import com.graphhopper.jsprit.core.problem.job.CustomJob.BuilderBase.ActivityType;
 import com.graphhopper.jsprit.core.problem.job.CustomJob.BuilderBase.BuilderActivityInfo;
 import com.graphhopper.jsprit.core.problem.solution.route.activity.ServiceActivity;
@@ -458,8 +459,8 @@ public class Service extends AbstractJob {
     }
 
     @Override
-    public void impl_setIndex(int index) {
-        theRealJob.impl_setIndex(index);
+    public void impl_setIndex(FriendlyHandshake handshake, int index) {
+        theRealJob.impl_setIndex(handshake, index);
     }
 
     @Override

--- a/jsprit-core/src/main/java/com/graphhopper/jsprit/core/problem/job/Service.java
+++ b/jsprit-core/src/main/java/com/graphhopper/jsprit/core/problem/job/Service.java
@@ -358,13 +358,17 @@ public class Service extends AbstractJob {
 
     /**
      * Returns the time-window a service(-operation) is allowed to start.
-     * It is recommended to use getTimeWindows() instead. If you still use this, it returns the first time window of getTimeWindows() collection.
+     *
+     * @deprecated It is recommended to use getTimeWindows() instead. If you
+     *             still use this, it returns the first time window of
+     *             getTimeWindows() collection.
      *
      * @return time window
      *
      */
+    @Deprecated
     public TimeWindow getTimeWindow() {
-        return theRealActivity.getSingleTimeWindow();
+        return theRealActivity.getTimeWindows().iterator().next();
     }
 
     /**

--- a/jsprit-core/src/main/java/com/graphhopper/jsprit/core/problem/job/Shipment.java
+++ b/jsprit-core/src/main/java/com/graphhopper/jsprit/core/problem/job/Shipment.java
@@ -24,7 +24,6 @@ import com.graphhopper.jsprit.core.problem.Capacity;
 import com.graphhopper.jsprit.core.problem.Location;
 import com.graphhopper.jsprit.core.problem.SizeDimension;
 import com.graphhopper.jsprit.core.problem.Skills;
-import com.graphhopper.jsprit.core.problem.VehicleRoutingProblem.Builder.FriendlyHandshake;
 import com.graphhopper.jsprit.core.problem.job.CustomJob.BuilderBase.ActivityType;
 import com.graphhopper.jsprit.core.problem.job.CustomJob.BuilderBase.BuilderActivityInfo;
 import com.graphhopper.jsprit.core.problem.solution.route.activity.DeliveryActivity;
@@ -517,10 +516,10 @@ public class Shipment extends AbstractJob {
         // This is unused being a legacy implementation
     }
 
-    @Override
-    public int getIndex() {
-        return theRealJob.getIndex();
-    }
+    // @Override
+    // public int getIndex() {
+    // return theRealJob.getIndex();
+    // }
 
     @Override
     public Object getUserData() {
@@ -557,10 +556,10 @@ public class Shipment extends AbstractJob {
         return theRealJob.toString();
     }
 
-    @Override
-    public void impl_setIndex(FriendlyHandshake handshake, int index) {
-        theRealJob.impl_setIndex(handshake, index);
-    }
+    // @Override
+    // public void impl_setIndex(FriendlyHandshake handshake, int index) {
+    // theRealJob.impl_setIndex(handshake, index);
+    // }
 
 
     @Override

--- a/jsprit-core/src/main/java/com/graphhopper/jsprit/core/problem/job/Shipment.java
+++ b/jsprit-core/src/main/java/com/graphhopper/jsprit/core/problem/job/Shipment.java
@@ -24,6 +24,7 @@ import com.graphhopper.jsprit.core.problem.Capacity;
 import com.graphhopper.jsprit.core.problem.Location;
 import com.graphhopper.jsprit.core.problem.SizeDimension;
 import com.graphhopper.jsprit.core.problem.Skills;
+import com.graphhopper.jsprit.core.problem.VehicleRoutingProblem.Builder.FriendlyHandshake;
 import com.graphhopper.jsprit.core.problem.job.CustomJob.BuilderBase.ActivityType;
 import com.graphhopper.jsprit.core.problem.job.CustomJob.BuilderBase.BuilderActivityInfo;
 import com.graphhopper.jsprit.core.problem.solution.route.activity.DeliveryActivity;
@@ -557,8 +558,8 @@ public class Shipment extends AbstractJob {
     }
 
     @Override
-    public void impl_setIndex(int index) {
-        theRealJob.impl_setIndex(index);
+    public void impl_setIndex(FriendlyHandshake handshake, int index) {
+        theRealJob.impl_setIndex(handshake, index);
     }
 
 

--- a/jsprit-core/src/main/java/com/graphhopper/jsprit/core/problem/solution/route/VehicleRoute.java
+++ b/jsprit-core/src/main/java/com/graphhopper/jsprit/core/problem/solution/route/VehicleRoute.java
@@ -27,6 +27,7 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
 
+import com.graphhopper.jsprit.core.problem.JobActivityFactory;
 import com.graphhopper.jsprit.core.problem.driver.Driver;
 import com.graphhopper.jsprit.core.problem.driver.DriverImpl;
 import com.graphhopper.jsprit.core.problem.job.AbstractJob;
@@ -399,6 +400,11 @@ public class VehicleRoute {
 
         }
 
+        public Builder setJobActivityFactory(JobActivityFactory copyJobActivityFactory) {
+            // TODO Does nothing and it is a problem
+            return this;
+        }
+
         /**
          * Builds the route.
          *
@@ -466,6 +472,7 @@ public class VehicleRoute {
             if (!duplicatedActivities.isEmpty() || !activityCounter.isEmpty())
                 throw new IllegalArgumentException("Invalid route. See details above.");
         }
+
     }
 
     private TourActivities tourActivities;

--- a/jsprit-core/src/main/java/com/graphhopper/jsprit/core/problem/solution/route/activity/BreakActivity.java
+++ b/jsprit-core/src/main/java/com/graphhopper/jsprit/core/problem/solution/route/activity/BreakActivity.java
@@ -116,9 +116,9 @@ public class BreakActivity extends InternalJobActivity {
     /**
      * @return The time window of the break.
      */
-    public TimeWindow getTimeWindow() {
+    public TimeWindow getBreakTimeWindow() {
         // Break has always a single time window
-        return getSingleTimeWindow();
+        return getTimeWindows().iterator().next();
     }
 
 }

--- a/jsprit-core/src/main/java/com/graphhopper/jsprit/core/problem/solution/route/activity/JobActivity.java
+++ b/jsprit-core/src/main/java/com/graphhopper/jsprit/core/problem/solution/route/activity/JobActivity.java
@@ -6,6 +6,7 @@ import java.util.HashSet;
 import com.graphhopper.jsprit.core.problem.Location;
 import com.graphhopper.jsprit.core.problem.SizeDimension;
 import com.graphhopper.jsprit.core.problem.job.AbstractJob;
+import com.graphhopper.jsprit.core.problem.job.AbstractListBackedJobActivityList.FriendlyHandshake;
 import com.graphhopper.jsprit.core.problem.job.Job;
 
 /**
@@ -148,12 +149,18 @@ public abstract class JobActivity extends AbstractActivity {
     /**
      * Sets the order number of the activity within the job.
      * <p>
-     * <b>Warning! This function is not part of the API.</b>
+     * <b>Warning! This function is not part of the API. Calling it would throw
+     * {@linkplain IllegalStateException}. </b>
      * </p>
      *
+     * @param friendLock
+     *            Internal friend handshake object.
      * @param orderNumber
+     *            The order number.
      */
-    public void impl_setOrderNumber(int orderNumber) {
+    public void impl_setOrderNumber(FriendlyHandshake hadshake, int orderNumber) {
+        if (hadshake == null)
+            throw new IllegalStateException();
         this.orderNumber = orderNumber;
     }
 

--- a/jsprit-core/src/main/java/com/graphhopper/jsprit/core/problem/solution/route/activity/JobActivity.java
+++ b/jsprit-core/src/main/java/com/graphhopper/jsprit/core/problem/solution/route/activity/JobActivity.java
@@ -98,18 +98,6 @@ public abstract class JobActivity extends AbstractActivity {
         return timeWindows;
     }
 
-    /**
-     * @return A single time window.
-     * @throws IllegalArgumentException
-     *             When more than one time window exists.
-     */
-    // TODO: Is it legacy code, should be removed later
-    @Deprecated
-    public TimeWindow getSingleTimeWindow() {
-        if (timeWindows.size() > 1)
-            throw new IllegalArgumentException("More than one time window in. " + this);
-        return timeWindows.iterator().next();
-    }
 
     @Override
     public int hashCode() {

--- a/jsprit-core/src/test/java/com/graphhopper/jsprit/core/algorithm/IgnoreBreakTimeWindowTest.java
+++ b/jsprit-core/src/test/java/com/graphhopper/jsprit/core/algorithm/IgnoreBreakTimeWindowTest.java
@@ -65,30 +65,30 @@ public class IgnoreBreakTimeWindowTest {
 
 
         ServiceJob service4 = new ServiceJob.Builder("2").setLocation(Location.newInstance(0, 0))
-                        .setServiceTime(1.).setTimeWindow(TimeWindow.newInstance(17, 17)).build();
+                .setServiceTime(1.).setTimeWindow(TimeWindow.newInstance(17, 17)).build();
 
         ServiceJob service5 = new ServiceJob.Builder("3").setLocation(Location.newInstance(0, 0))
-                        .setServiceTime(1.).setTimeWindow(TimeWindow.newInstance(18, 18)).build();
+                .setServiceTime(1.).setTimeWindow(TimeWindow.newInstance(18, 18)).build();
 
         ServiceJob service7 = new ServiceJob.Builder("4").setLocation(Location.newInstance(0, 0))
-                        .setServiceTime(1.).setTimeWindow(TimeWindow.newInstance(10, 10)).build();
+                .setServiceTime(1.).setTimeWindow(TimeWindow.newInstance(10, 10)).build();
 
         ServiceJob service8 = new ServiceJob.Builder("5").setLocation(Location.newInstance(0, 0))
-                        .setServiceTime(1.).setTimeWindow(TimeWindow.newInstance(12, 12)).build();
+                .setServiceTime(1.).setTimeWindow(TimeWindow.newInstance(12, 12)).build();
 
         ServiceJob service10 = new ServiceJob.Builder("6").setLocation(Location.newInstance(0, 0))
-                        .setServiceTime(1.).setTimeWindow(TimeWindow.newInstance(16, 16)).build();
+                .setServiceTime(1.).setTimeWindow(TimeWindow.newInstance(16, 16)).build();
 
         ServiceJob service11 = new ServiceJob.Builder("7").setLocation(Location.newInstance(0, 0))
-                        .setServiceTime(1.).setTimeWindow(TimeWindow.newInstance(13, 13)).build();
+                .setServiceTime(1.).setTimeWindow(TimeWindow.newInstance(13, 13)).build();
 
         VehicleRoutingProblem vrp = VehicleRoutingProblem.Builder.newInstance()
-                        .addVehicle(vehicle2)
-                        .addJob(service4)
-                        .addJob(service5).addJob(service7)
-                        .addJob(service8).addJob(service10).addJob(service11)
-                        .setFleetSize(VehicleRoutingProblem.FleetSize.FINITE)
-                        .build();
+                .addVehicle(vehicle2)
+                .addJob(service4)
+                .addJob(service5).addJob(service7)
+                .addJob(service8).addJob(service10).addJob(service11)
+                .setFleetSize(VehicleRoutingProblem.FleetSize.FINITE)
+                .build();
 
         VehicleRoutingAlgorithm vra = Jsprit.createAlgorithm(vrp);
         vra.setMaxIterations(50);
@@ -103,7 +103,7 @@ public class IgnoreBreakTimeWindowTest {
         boolean inTime = true;
         for (TourActivity act : solution.getRoutes().iterator().next().getActivities()) {
             if (act instanceof BreakActivity) {
-                TimeWindow timeWindow = ((BreakActivity) act).getSingleTimeWindow();
+                TimeWindow timeWindow = ((BreakActivity) act).getBreakTimeWindow();
                 if (act.getEndTime() < timeWindow.getStart()) {
                     inTime = false;
                 }

--- a/jsprit-core/src/test/java/com/graphhopper/jsprit/core/algorithm/state/UpdateVehicleDependentTimeWindowTest.java
+++ b/jsprit-core/src/test/java/com/graphhopper/jsprit/core/algorithm/state/UpdateVehicleDependentTimeWindowTest.java
@@ -90,7 +90,7 @@ public class UpdateVehicleDependentTimeWindowTest {
 
         vrpBuilder.addVehicle(vehicle).addVehicle(vehicle2).addVehicle(vehicle3).addVehicle(equivalentOf3);
 
-        Collection<Vehicle> vehicles = new ArrayList<Vehicle>();
+        Collection<Vehicle> vehicles = new ArrayList<>();
         vehicles.add(vehicle);
         vehicles.add(vehicle2);
         vehicles.add(vehicle3);
@@ -106,22 +106,17 @@ public class UpdateVehicleDependentTimeWindowTest {
         vrp = vrpBuilder.build();
 
         route = VehicleRoute.Builder.newInstance(vehicle).setJobActivityFactory(new CopyJobActivityFactory())
-                        .addService(service).addService(service2)
-                        .addService(service3).build();
+                .addService(service).addService(service2)
+                .addService(service3).build();
 
 
         stateManager = new StateManager(vrp);
         UpdateVehicleDependentPracticalTimeWindows updater = new UpdateVehicleDependentPracticalTimeWindows(stateManager, routingCosts, activityCosts);
-        updater.setVehiclesToUpdate(new UpdateVehicleDependentPracticalTimeWindows.VehiclesToUpdate() {
-
-            @Override
-            public Collection<Vehicle> get(VehicleRoute route) {
-                Collection<Vehicle> vehicles = new ArrayList<Vehicle>();
-                vehicles.add(route.getVehicle());
-                vehicles.addAll(fleetManager.getAvailableVehicles(route.getVehicle()));
-                return vehicles;
-            }
-
+        updater.setVehiclesToUpdate(route -> {
+            Collection<Vehicle> vehicles1 = new ArrayList<>();
+            vehicles1.add(route.getVehicle());
+            vehicles1.addAll(fleetManager.getAvailableVehicles(route.getVehicle()));
+            return vehicles1;
         });
         stateManager.addStateUpdater(updater);
         stateManager.informInsertionStarts(Arrays.asList(route), Collections.<Job>emptyList());
@@ -141,68 +136,68 @@ public class UpdateVehicleDependentTimeWindowTest {
     @Test
     public void stateManagerShouldHaveMemorizedCorrectLatestEndOfAct3() {
         assertEquals(70., stateManager.getActivityState(route.getActivities().get(2), vehicle,
-                        InternalStates.LATEST_OPERATION_START_TIME, Double.class), 0.01);
+                InternalStates.LATEST_OPERATION_START_TIME, Double.class), 0.01);
 
     }
 
     @Test
     public void stateManagerShouldHaveMemorizedCorrectLatestEndOfAct3_v2() {
         assertEquals(70., stateManager.getActivityState(route.getActivities().get(2), vehicle,
-                        InternalStates.LATEST_OPERATION_START_TIME, Double.class), 0.01);
+                InternalStates.LATEST_OPERATION_START_TIME, Double.class), 0.01);
     }
 
     @Test
     public void stateManagerShouldHaveMemorizedCorrectLatestEndOfAct3WithVehicle2() {
         assertEquals(30., stateManager.getActivityState(route.getActivities().get(2), vehicle2,
-                        InternalStates.LATEST_OPERATION_START_TIME, Double.class), 0.01);
+                InternalStates.LATEST_OPERATION_START_TIME, Double.class), 0.01);
     }
 
     @Test
     public void stateManagerShouldHaveMemorizedCorrectLatestEndOfAct3WithVehicle3() {
         assertEquals(90., stateManager.getActivityState(route.getActivities().get(2), vehicle3,
-                        InternalStates.LATEST_OPERATION_START_TIME, Double.class), 0.01);
+                InternalStates.LATEST_OPERATION_START_TIME, Double.class), 0.01);
     }
 
     @Test
     public void stateManagerShouldHaveMemorizedCorrectLatestEndOfAct2() {
         assertEquals(60., stateManager.getActivityState(route.getActivities().get(1), vehicle,
-                        InternalStates.LATEST_OPERATION_START_TIME, Double.class), 0.01);
+                InternalStates.LATEST_OPERATION_START_TIME, Double.class), 0.01);
     }
 
     @Test
     public void stateManagerShouldHaveMemorizedCorrectLatestEndOfAct2_v2() {
         assertEquals(60., stateManager.getActivityState(route.getActivities().get(1), vehicle,
-                        InternalStates.LATEST_OPERATION_START_TIME, Double.class), 0.01);
+                InternalStates.LATEST_OPERATION_START_TIME, Double.class), 0.01);
     }
 
     @Test
     public void stateManagerShouldHaveMemorizedCorrectLatestEndOfAct2WithVehicle2() {
         assertEquals(20., stateManager.getActivityState(route.getActivities().get(1), vehicle2,
-                        InternalStates.LATEST_OPERATION_START_TIME, Double.class), 0.01);
+                InternalStates.LATEST_OPERATION_START_TIME, Double.class), 0.01);
     }
 
     @Test
     public void stateManagerShouldHaveMemorizedCorrectLatestEndOfAct2WithVehicle3() {
         assertEquals(80., stateManager.getActivityState(route.getActivities().get(1), vehicle3,
-                        InternalStates.LATEST_OPERATION_START_TIME, Double.class), 0.01);
+                InternalStates.LATEST_OPERATION_START_TIME, Double.class), 0.01);
     }
 
     @Test
     public void stateManagerShouldHaveMemorizedCorrectLatestEndOfAct2WithEquivalentOfVehicle3() {
         assertEquals(80., stateManager.getActivityState(route.getActivities().get(1), equivalentOf3,
-                        InternalStates.LATEST_OPERATION_START_TIME, Double.class), 0.01);
+                InternalStates.LATEST_OPERATION_START_TIME, Double.class), 0.01);
     }
 
     @Test
     public void stateManagerShouldHaveMemorizedCorrectLatestEndOfAct1WithVehicle2() {
         assertEquals(10., stateManager.getActivityState(route.getActivities().get(0), vehicle2,
-                        InternalStates.LATEST_OPERATION_START_TIME, Double.class), 0.01);
+                InternalStates.LATEST_OPERATION_START_TIME, Double.class), 0.01);
     }
 
     @Test
     public void stateManagerShouldHaveMemorizedCorrectLatestEndOfAct1WithVehicle3() {
         assertEquals(70., stateManager.getActivityState(route.getActivities().get(0), vehicle3,
-                        InternalStates.LATEST_OPERATION_START_TIME, Double.class), 0.01);
+                InternalStates.LATEST_OPERATION_START_TIME, Double.class), 0.01);
     }
 
 
@@ -211,54 +206,51 @@ public class UpdateVehicleDependentTimeWindowTest {
         //
         VehicleImpl vehicle = VehicleImpl.Builder.newInstance("v").setStartLocation(Location.newInstance("0,0")).setEarliestStart(0.).setLatestArrival(100.).build();
         ServiceJob service = new ServiceJob.Builder("s1").setLocation(Location.newInstance("10,0"))
-                        .addTimeWindow(30, 40).build();
+                .addTimeWindow(30, 40).build();
         ServiceJob service2 = new ServiceJob.Builder("s2")
-                        .addTimeWindow(20, 30).addTimeWindow(40, 60).addTimeWindow(70, 80).setLocation(Location.newInstance("20,0")).build();
+                .addTimeWindow(20, 30).addTimeWindow(40, 60).addTimeWindow(70, 80).setLocation(Location.newInstance("20,0")).build();
 
         VehicleRoutingProblem vrp = VehicleRoutingProblem.Builder.newInstance().addJob(service).addJob(service2).addVehicle(vehicle)
-                        .setRoutingCost(routingCosts).build();
+                .setRoutingCost(routingCosts).build();
 
-        VehicleRoute route = VehicleRoute.Builder.newInstance(vehicle).setJobActivityFactory(vrp.getJobActivityFactory())
-                        .addService(service).addService(service2, TimeWindow.newInstance(70, 80))
-                        .build();
+        VehicleRoute route = VehicleRoute.Builder.newInstance(vehicle)
+                .setJobActivityFactory(vrp.getJobActivityFactory())
+                .addService(service)
+            .addService(service2, TimeWindow.newInstance(70, 80))
+                .build();
 
         StateManager stateManager = new StateManager(vrp);
         UpdateVehicleDependentPracticalTimeWindows updater = new UpdateVehicleDependentPracticalTimeWindows(stateManager, routingCosts, activityCosts);
-        updater.setVehiclesToUpdate(new UpdateVehicleDependentPracticalTimeWindows.VehiclesToUpdate() {
-
-            @Override
-            public Collection<Vehicle> get(VehicleRoute route) {
-                Collection<Vehicle> vehicles = new ArrayList<Vehicle>();
-                vehicles.add(route.getVehicle());
-                //                vehicles.addAll(fleetManager.getAvailableVehicles(route.getVehicle()));
-                return vehicles;
-            }
-
+        updater.setVehiclesToUpdate(route1 -> {
+            Collection<Vehicle> vehicles = new ArrayList<>();
+            vehicles.add(route1.getVehicle());
+            //                vehicles.addAll(fleetManager.getAvailableVehicles(route.getVehicle()));
+            return vehicles;
         });
         stateManager.addStateUpdater(updater);
         stateManager.informInsertionStarts(Arrays.asList(route), Collections.<Job>emptyList());
 
         assertEquals(80., stateManager.getActivityState(route.getActivities().get(1), vehicle,
-                        InternalStates.LATEST_OPERATION_START_TIME, Double.class), 0.01);
+                InternalStates.LATEST_OPERATION_START_TIME, Double.class), 0.01);
     }
 
     @Test
     public void updateOfOpenRoutesShouldBeDoneCorrectly() {
         VehicleImpl vehicle = VehicleImpl.Builder.newInstance("v")
-                        .setReturnToDepot(false)
-                        .setStartLocation(Location.Builder.newInstance().setCoordinate(Coordinate.newInstance(0, 0)).build())
-                        .setLatestArrival(51)
-                        .build();
+                .setReturnToDepot(false)
+                .setStartLocation(Location.Builder.newInstance().setCoordinate(Coordinate.newInstance(0, 0)).build())
+                .setLatestArrival(51)
+                .build();
 
         ServiceJob service = new ServiceJob.Builder("s")
-                        .setLocation(Location.Builder.newInstance().setCoordinate(Coordinate.newInstance(50, 0)).build()).build();
+                .setLocation(Location.Builder.newInstance().setCoordinate(Coordinate.newInstance(50, 0)).build()).build();
 
         VehicleRoutingProblem vrp = VehicleRoutingProblem.Builder.newInstance()
-                        .addJob(service).addVehicle(vehicle).setFleetSize(VehicleRoutingProblem.FleetSize.FINITE)
-                        .build();
+                .addJob(service).addVehicle(vehicle).setFleetSize(VehicleRoutingProblem.FleetSize.FINITE)
+                .build();
 
         VehicleRoute route = VehicleRoute.Builder.newInstance(vehicle)
-                        .setJobActivityFactory(vrp.getJobActivityFactory()).addService(service).build();
+                .setJobActivityFactory(vrp.getJobActivityFactory()).addService(service).build();
 
         stateManager = new StateManager(vrp);
         UpdateVehicleDependentPracticalTimeWindows updater = new UpdateVehicleDependentPracticalTimeWindows(stateManager, vrp.getTransportCosts(), vrp.getActivityCosts());

--- a/jsprit-core/src/test/java/com/graphhopper/jsprit/core/algorithm/util/QuickCompactMatrixTest.java
+++ b/jsprit-core/src/test/java/com/graphhopper/jsprit/core/algorithm/util/QuickCompactMatrixTest.java
@@ -1,0 +1,122 @@
+package com.graphhopper.jsprit.core.algorithm.util;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.function.BiFunction;
+
+import org.junit.Test;
+
+import com.graphhopper.jsprit.core.problem.HasIndex;
+
+public class QuickCompactMatrixTest {
+
+    public static class Item implements HasIndex {
+        private int index;
+
+        public Item(int index) {
+            this.index = index;
+        }
+
+        @Override
+        public int getIndex() {
+            return index;
+        }
+    }
+
+    private static final BiFunction<Item, Item, Integer> INDEX_DIST = (i1, i2) -> Math
+            .abs(i1.getIndex() - i2.getIndex());
+
+    private List<Item> create(int... indexes) {
+        List<Item> res = new ArrayList<>(indexes.length);
+        for (int indexe : indexes) {
+            res.add(new Item(indexe));
+        }
+        return res;
+    }
+
+    @Test
+    public void whenConstructed_correctSizesCalculated() {
+        List<Item> items = create(0, 1, 2, 3, 4);
+        QuickCompactMatrix<Item> matrix = new QuickCompactMatrix<>(items, INDEX_DIST);
+        assertEquals(0, matrix.getShift());
+        assertEquals(5, matrix.getRedirectionSize());
+        assertEquals(5, matrix.getMatrixSize());
+    }
+
+    @Test
+    public void whenConstructed_correctShiftIsCorrect() {
+        List<Item> items = create(1, 3, 5, 7, 9);
+        QuickCompactMatrix<Item> matrix = new QuickCompactMatrix<>(items, INDEX_DIST);
+        assertEquals(1, matrix.getShift());
+        assertEquals(9, matrix.getRedirectionSize());
+        assertEquals(5, matrix.getMatrixSize());
+    }
+
+    @Test
+    public void whenReadingMatrixIndex_correctValueIsReturned() {
+        List<Item> items = create(1, 3, 5, 7, 9);
+        QuickCompactMatrix<Item> matrix = new QuickCompactMatrix<>(items, INDEX_DIST);
+        assertEquals(0, matrix.getMatrixIndex(items.get(0)));
+        assertEquals(4, matrix.getMatrixIndex(items.get(4)));
+        assertEquals(-1, matrix.getMatrixIndex(new Item(0)));
+        assertEquals(-1, matrix.getMatrixIndex(new Item(10)));
+        assertEquals(-1, matrix.getMatrixIndex(new Item(2)));
+    }
+
+    @Test
+    public void whenCallingContains_correctAnswerIsReturned() {
+        List<Item> items = create(1, 3, 5, 7, 9);
+        QuickCompactMatrix<Item> matrix = new QuickCompactMatrix<>(items, INDEX_DIST);
+        assertTrue(matrix.contains(items.get(0)));
+        assertTrue(matrix.contains(items.get(4)));
+        assertFalse(matrix.contains(new Item(0)));
+        assertFalse(matrix.contains(new Item(10)));
+        assertFalse(matrix.contains(new Item(2)));
+    }
+
+    @Test
+    public void whenReadingValue_correctValueIsReturned() {
+        List<Item> items = create(1, 3, 5, 7, 9);
+        QuickCompactMatrix<Item> matrix = new QuickCompactMatrix<>(items, INDEX_DIST);
+        assertEquals(2, matrix.getValue(items.get(0), items.get(1)));
+        assertEquals(6, matrix.getValue(items.get(0), items.get(3)));
+    }
+
+    @Test(expected = IndexOutOfBoundsException.class)
+    public void whenReadingValueOfWrongItem_exceptionIsThrown() {
+        List<Item> items = create(1, 3, 5, 7, 9);
+        QuickCompactMatrix<Item> matrix = new QuickCompactMatrix<>(items, INDEX_DIST);
+        assertEquals(2, matrix.getValue(items.get(0), new Item(2)));
+    }
+
+    @Test(expected = IndexOutOfBoundsException.class)
+    public void whenReadingValueOfWrongItem_exceptionIsThrown_underflow() {
+        List<Item> items = create(1, 3, 5, 7, 9);
+        QuickCompactMatrix<Item> matrix = new QuickCompactMatrix<>(items, INDEX_DIST);
+        assertEquals(2, matrix.getValue(items.get(0), new Item(0)));
+    }
+
+    @Test(expected = IndexOutOfBoundsException.class)
+    public void whenReadingValueOfWrongItem_exceptionIsThrown_overflow() {
+        List<Item> items = create(1, 3, 5, 7, 9);
+        QuickCompactMatrix<Item> matrix = new QuickCompactMatrix<>(items, INDEX_DIST);
+        assertEquals(2, matrix.getValue(items.get(0), new Item(10)));
+    }
+
+    @Test
+    public void whenConstructedWithCopy_theValuesAreCorrect() {
+        List<Item> sourceItems = create(0, 1, 2, 3, 4);
+        QuickCompactMatrix<Item> sourceMatrix = new QuickCompactMatrix<>(sourceItems, INDEX_DIST);
+        List<Item> items = create(1, 2, 5);
+        QuickCompactMatrix<Item> matrix = new QuickCompactMatrix<>(items,
+                QuickCompactMatrix.getCopyWrapper(sourceMatrix, INDEX_DIST));
+
+        assertEquals(1, matrix.getValue(items.get(0), items.get(1)));
+        assertEquals(4, matrix.getValue(items.get(0), items.get(2)));
+    }
+
+}

--- a/jsprit-core/src/test/java/com/graphhopper/jsprit/core/problem/VehicleRoutingProblemTest.java
+++ b/jsprit-core/src/test/java/com/graphhopper/jsprit/core/problem/VehicleRoutingProblemTest.java
@@ -241,7 +241,7 @@ public class VehicleRoutingProblemTest {
         when(s2.getId()).thenReturn("s2");
         when(s2.getActivityList()).thenReturn(new SequentialJobActivityList(s2));
 
-        Collection<ServiceJob> services = new ArrayList<ServiceJob>();
+        Collection<ServiceJob> services = new ArrayList<>();
         services.add(s1);
         services.add(s2);
 
@@ -285,13 +285,13 @@ public class VehicleRoutingProblemTest {
 
             @Override
             public double getTransportTime(Location from, Location to,
-                            double departureTime, Driver driver, Vehicle vehicle) {
+                    double departureTime, Driver driver, Vehicle vehicle) {
                 return 0;
             }
 
             @Override
             public double getTransportCost(Location from, Location to,
-                            double departureTime, Driver driver, Vehicle vehicle) {
+                    double departureTime, Driver driver, Vehicle vehicle) {
                 return 4.0;
             }
         });
@@ -362,7 +362,7 @@ public class VehicleRoutingProblemTest {
     @Test
     public void whenAddingVehicleWithDiffStartAndEnd_startLocationMustBeRegisteredInLocationMap() {
         VehicleImpl vehicle = VehicleImpl.Builder.newInstance("v").setStartLocation(Location.newInstance("start"))
-                        .setEndLocation(Location.newInstance("end")).build();
+                .setEndLocation(Location.newInstance("end")).build();
 
         VehicleRoutingProblem.Builder vrpBuilder = VehicleRoutingProblem.Builder.newInstance();
         vrpBuilder.addVehicle(vehicle);
@@ -372,7 +372,7 @@ public class VehicleRoutingProblemTest {
     @Test
     public void whenAddingVehicleWithDiffStartAndEnd_endLocationMustBeRegisteredInLocationMap() {
         VehicleImpl vehicle = VehicleImpl.Builder.newInstance("v").setStartLocation(Location.newInstance("start"))
-                        .setEndLocation(Location.newInstance("end")).build();
+                .setEndLocation(Location.newInstance("end")).build();
 
         VehicleRoutingProblem.Builder vrpBuilder = VehicleRoutingProblem.Builder.newInstance();
         vrpBuilder.addVehicle(vehicle);
@@ -382,7 +382,7 @@ public class VehicleRoutingProblemTest {
     @Test
     public void whenAddingInitialRoute_itShouldBeAddedCorrectly() {
         VehicleImpl vehicle = VehicleImpl.Builder.newInstance("v")
-                        .setStartLocation(Location.newInstance("start")).setEndLocation(Location.newInstance("end")).build();
+                .setStartLocation(Location.newInstance("start")).setEndLocation(Location.newInstance("end")).build();
         VehicleRoute route = VehicleRoute.Builder.newInstance(vehicle, DriverImpl.noDriver()).build();
         VehicleRoutingProblem.Builder vrpBuilder = VehicleRoutingProblem.Builder.newInstance();
         vrpBuilder.addInitialVehicleRoute(route);
@@ -393,11 +393,11 @@ public class VehicleRoutingProblemTest {
     @Test
     public void whenAddingInitialRoutes_theyShouldBeAddedCorrectly() {
         VehicleImpl vehicle1 = VehicleImpl.Builder.newInstance("v")
-                        .setStartLocation(Location.newInstance("start")).setEndLocation(Location.newInstance("end")).build();
+                .setStartLocation(Location.newInstance("start")).setEndLocation(Location.newInstance("end")).build();
         VehicleRoute route1 = VehicleRoute.Builder.newInstance(vehicle1, DriverImpl.noDriver()).build();
 
         VehicleImpl vehicle2 = VehicleImpl.Builder.newInstance("v")
-                        .setStartLocation(Location.newInstance("start")).setEndLocation(Location.newInstance("end")).build();
+                .setStartLocation(Location.newInstance("start")).setEndLocation(Location.newInstance("end")).build();
         VehicleRoute route2 = VehicleRoute.Builder.newInstance(vehicle2, DriverImpl.noDriver()).build();
 
         VehicleRoutingProblem.Builder vrpBuilder = VehicleRoutingProblem.Builder.newInstance();
@@ -413,8 +413,8 @@ public class VehicleRoutingProblemTest {
         Location start = TestUtils.loc("start", Coordinate.newInstance(0, 1));
         Location end = Location.newInstance("end");
         VehicleImpl vehicle = VehicleImpl.Builder.newInstance("v")
-                        .setStartLocation(start)
-                        .setEndLocation(end).build();
+                .setStartLocation(start)
+                .setEndLocation(end).build();
         VehicleRoute route = VehicleRoute.Builder.newInstance(vehicle, DriverImpl.noDriver()).build();
         VehicleRoutingProblem.Builder vrpBuilder = VehicleRoutingProblem.Builder.newInstance();
         vrpBuilder.addInitialVehicleRoute(route);
@@ -429,8 +429,8 @@ public class VehicleRoutingProblemTest {
         VehicleRoutingProblem.Builder vrpBuilder = VehicleRoutingProblem.Builder.newInstance();
         vrpBuilder.addJob(service);
         VehicleImpl vehicle = VehicleImpl.Builder.newInstance("v")
-                        .setStartLocation(TestUtils.loc("start", Coordinate.newInstance(0, 1)))
-                        .setEndLocation(Location.newInstance("end")).build();
+                .setStartLocation(TestUtils.loc("start", Coordinate.newInstance(0, 1)))
+                .setEndLocation(Location.newInstance("end")).build();
         VehicleRoute initialRoute = VehicleRoute.Builder.newInstance(vehicle).addService(service).build();
         vrpBuilder.addInitialVehicleRoute(initialRoute);
         VehicleRoutingProblem vrp = vrpBuilder.build();
@@ -438,21 +438,24 @@ public class VehicleRoutingProblemTest {
         assertEquals(3, vrp.getAllLocations().size());
     }
 
-    @Test
-    public void whenAddingTwoJobs_theyShouldHaveProperIndeces() {
-        ServiceJob service = new ServiceJob.Builder("myService").setLocation(Location.newInstance("loc")).build();
-        ShipmentJob shipment = new ShipmentJob.Builder("shipment").setPickupLocation(Location.Builder.newInstance().setId("pick").build())
-                        .setDeliveryLocation(Location.newInstance("del")).build();
-        VehicleRoutingProblem.Builder vrpBuilder = VehicleRoutingProblem.Builder.newInstance();
-        vrpBuilder.addJob(service);
-        vrpBuilder.addJob(shipment);
-        VehicleRoutingProblem vrp = vrpBuilder.build();
-
-        assertEquals(1, service.getIndex());
-        assertEquals(2, shipment.getIndex());
-        assertEquals(3, vrp.getAllLocations().size());
-
-    }
+    // @Test
+    // public void whenAddingTwoJobs_theyShouldHaveProperIndeces() {
+    // ServiceJob service = new
+    // ServiceJob.Builder("myService").setLocation(Location.newInstance("loc")).build();
+    // ShipmentJob shipment = new
+    // ShipmentJob.Builder("shipment").setPickupLocation(Location.Builder.newInstance().setId("pick").build())
+    // .setDeliveryLocation(Location.newInstance("del")).build();
+    // VehicleRoutingProblem.Builder vrpBuilder =
+    // VehicleRoutingProblem.Builder.newInstance();
+    // vrpBuilder.addJob(service);
+    // vrpBuilder.addJob(shipment);
+    // VehicleRoutingProblem vrp = vrpBuilder.build();
+    //
+    // assertEquals(1, service.getIndex());
+    // assertEquals(2, shipment.getIndex());
+    // assertEquals(3, vrp.getAllLocations().size());
+    //
+    // }
 
     @Test(expected = IllegalArgumentException.class)
     public void whenAddingTwoServicesWithTheSameId_itShouldThrowException() {
@@ -467,9 +470,9 @@ public class VehicleRoutingProblemTest {
     @Test(expected = IllegalArgumentException.class)
     public void whenAddingTwoShipmentsWithTheSameId_itShouldThrowException() {
         ShipmentJob shipment1 = new ShipmentJob.Builder("shipment").setPickupLocation(Location.Builder.newInstance().setId("pick").build())
-                        .setDeliveryLocation(Location.newInstance("del")).build();
+                .setDeliveryLocation(Location.newInstance("del")).build();
         ShipmentJob shipment2 = new ShipmentJob.Builder("shipment").setPickupLocation(Location.Builder.newInstance().setId("pick").build())
-                        .setDeliveryLocation(Location.newInstance("del")).build();
+                .setDeliveryLocation(Location.newInstance("del")).build();
         VehicleRoutingProblem.Builder vrpBuilder = VehicleRoutingProblem.Builder.newInstance();
         vrpBuilder.addJob(shipment1);
         vrpBuilder.addJob(shipment2);
@@ -480,9 +483,9 @@ public class VehicleRoutingProblemTest {
     @Test
     public void whenAddingTwoVehicles_theyShouldHaveProperIndices() {
         VehicleImpl veh1 = VehicleImpl.Builder.newInstance("v1").setStartLocation(TestUtils.loc("start", Coordinate.newInstance(0, 1)))
-                        .setEndLocation(Location.newInstance("end")).build();
+                .setEndLocation(Location.newInstance("end")).build();
         VehicleImpl veh2 = VehicleImpl.Builder.newInstance("v2").setStartLocation(TestUtils.loc("start", Coordinate.newInstance(0, 1)))
-                        .setEndLocation(Location.newInstance("end")).build();
+                .setEndLocation(Location.newInstance("end")).build();
 
         VehicleRoutingProblem.Builder vrpBuilder = VehicleRoutingProblem.Builder.newInstance();
         vrpBuilder.addVehicle(veh1);
@@ -497,11 +500,11 @@ public class VehicleRoutingProblemTest {
     @Test
     public void whenAddingTwoVehiclesWithSameTypeIdentifier_typeIdentifiersShouldHaveSameIndices() {
         VehicleImpl veh1 = VehicleImpl.Builder.newInstance("v1")
-                        .setStartLocation(TestUtils.loc("start", Coordinate.newInstance(0, 1)))
-                        .setEndLocation(Location.newInstance("end")).build();
+                .setStartLocation(TestUtils.loc("start", Coordinate.newInstance(0, 1)))
+                .setEndLocation(Location.newInstance("end")).build();
         VehicleImpl veh2 = VehicleImpl.Builder.newInstance("v2")
-                        .setStartLocation(TestUtils.loc("start", Coordinate.newInstance(0, 1)))
-                        .setEndLocation(Location.newInstance("end")).build();
+                .setStartLocation(TestUtils.loc("start", Coordinate.newInstance(0, 1)))
+                .setEndLocation(Location.newInstance("end")).build();
 
         VehicleRoutingProblem.Builder vrpBuilder = VehicleRoutingProblem.Builder.newInstance();
         vrpBuilder.addVehicle(veh1);
@@ -516,11 +519,11 @@ public class VehicleRoutingProblemTest {
     @Test
     public void whenAddingTwoVehiclesDifferentTypeIdentifier_typeIdentifiersShouldHaveDifferentIndices() {
         VehicleImpl veh1 = VehicleImpl.Builder.newInstance("v1")
-                        .setStartLocation(TestUtils.loc("start", Coordinate.newInstance(0, 1)))
-                        .setEndLocation(Location.newInstance("end")).build();
+                .setStartLocation(TestUtils.loc("start", Coordinate.newInstance(0, 1)))
+                .setEndLocation(Location.newInstance("end")).build();
         VehicleImpl veh2 = VehicleImpl.Builder.newInstance("v2")
-                        .setStartLocation(TestUtils.loc("startLoc", Coordinate.newInstance(0, 1)))
-                        .setEndLocation(Location.newInstance("end")).build();
+                .setStartLocation(TestUtils.loc("startLoc", Coordinate.newInstance(0, 1)))
+                .setEndLocation(Location.newInstance("end")).build();
 
         VehicleRoutingProblem.Builder vrpBuilder = VehicleRoutingProblem.Builder.newInstance();
         vrpBuilder.addVehicle(veh1);

--- a/jsprit-core/src/test/java/com/graphhopper/jsprit/core/problem/job/ServiceJobTest.java
+++ b/jsprit-core/src/test/java/com/graphhopper/jsprit/core/problem/job/ServiceJobTest.java
@@ -54,7 +54,7 @@ public class ServiceJobTest {
 
     @Test
     public void noName() {
-        Set<ServiceJob> serviceSet = new HashSet<ServiceJob>();
+        Set<ServiceJob> serviceSet = new HashSet<>();
         ServiceJob one = new ServiceJob.Builder("service").addSizeDimension(0, 10).setLocation(Location.newInstance("foo")).build();
         ServiceJob two = new ServiceJob.Builder("service").addSizeDimension(0, 10).setLocation(Location.newInstance("fo")).build();
         serviceSet.add(one);
@@ -72,18 +72,18 @@ public class ServiceJobTest {
     @Test
     public void whenAddingTwoCapDimension_nuOfDimsShouldBeTwo() {
         ServiceJob one = new ServiceJob.Builder("s").setLocation(Location.newInstance("foofoo"))
-                        .addSizeDimension(0, 2)
-                        .addSizeDimension(1, 4)
-                        .build();
+                .addSizeDimension(0, 2)
+                .addSizeDimension(1, 4)
+                .build();
         assertEquals(2, one.getActivity().getLoadChange().getNuOfDimensions());
     }
 
     @Test
     public void sizeAtStartAndEndShouldBeCorrect() {
         ServiceJob one = new ServiceJob.Builder("s").setLocation(Location.newInstance("foofoo"))
-                        .addSizeDimension(0, 2)
-                        .addSizeDimension(1, 4)
-                        .build();
+                .addSizeDimension(0, 2)
+                .addSizeDimension(1, 4)
+                .build();
         assertTrue(one.getSizeAtEnd().equals(one.getActivity().getLoadChange()));
         assertTrue(one.getSizeAtStart().equals(SizeDimension.Builder.newInstance().addDimension(0, 0).addDimension(1, 0).build()));
     }
@@ -91,7 +91,7 @@ public class ServiceJobTest {
     @Test
     public void whenShipmentIsBuiltWithoutSpecifyingCapacity_itShouldHvCapWithOneDimAndDimValOfZero() {
         ServiceJob one = new ServiceJob.Builder("s").setLocation(Location.newInstance("foofoo"))
-                        .build();
+                .build();
         assertEquals(1, one.getActivity().getLoadChange().getNuOfDimensions());
         assertEquals(0, one.getActivity().getLoadChange().get(0));
     }
@@ -99,7 +99,7 @@ public class ServiceJobTest {
     @Test
     public void whenShipmentIsBuiltWithConstructorWhereSizeIsSpecified_capacityShouldBeSetCorrectly() {
         ServiceJob one = new ServiceJob.Builder("s").addSizeDimension(0, 1).setLocation(Location.newInstance("foofoo"))
-                        .build();
+                .build();
         assertEquals(1, one.getActivity().getLoadChange().getNuOfDimensions());
         assertEquals(1, one.getActivity().getLoadChange().get(0));
     }
@@ -167,14 +167,14 @@ public class ServiceJobTest {
     @Test
     public void whenSettingTimeWindow_itShouldBeSetCorrectly() {
         ServiceJob s = new ServiceJob.Builder("s").setLocation(Location.newInstance("loc")).setTimeWindow(TimeWindow.newInstance(1.0, 2.0)).build();
-        assertEquals(1.0, s.getActivity().getSingleTimeWindow().getStart(), 0.01);
-        assertEquals(2.0, s.getActivity().getSingleTimeWindow().getEnd(), 0.01);
+        assertEquals(1.0, s.getActivity().getTimeWindows().iterator().next().getStart(), 0.01);
+        assertEquals(2.0, s.getActivity().getTimeWindows().iterator().next().getEnd(), 0.01);
     }
 
     @Test
     public void whenAddingSkills_theyShouldBeAddedCorrectly() {
         ServiceJob s = new ServiceJob.Builder("s").setLocation(Location.newInstance("loc"))
-                        .addRequiredSkill("drill").addRequiredSkill("screwdriver").build();
+                .addRequiredSkill("drill").addRequiredSkill("screwdriver").build();
         assertTrue(s.getRequiredSkills().containsSkill("drill"));
         assertTrue(s.getRequiredSkills().containsSkill("drill"));
         assertTrue(s.getRequiredSkills().containsSkill("ScrewDriver"));
@@ -183,7 +183,7 @@ public class ServiceJobTest {
     @Test
     public void whenAddingSkillsCaseSens_theyShouldBeAddedCorrectly() {
         ServiceJob s = new ServiceJob.Builder("s").setLocation(Location.newInstance("loc"))
-                        .addRequiredSkill("DriLl").addRequiredSkill("screwDriver").build();
+                .addRequiredSkill("DriLl").addRequiredSkill("screwDriver").build();
         assertTrue(s.getRequiredSkills().containsSkill("drill"));
         assertTrue(s.getRequiredSkills().containsSkill("drilL"));
     }
@@ -193,9 +193,9 @@ public class ServiceJobTest {
         TimeWindow tw1 = TimeWindow.newInstance(1.0, 2.0);
         TimeWindow tw2 = TimeWindow.newInstance(3.0, 5.0);
         ServiceJob s = new ServiceJob.Builder("s").setLocation(Location.newInstance("loc"))
-                        .addTimeWindow(tw1)
-                        .addTimeWindow(tw2)
-                        .build();
+                .addTimeWindow(tw1)
+                .addTimeWindow(tw2)
+                .build();
         assertEquals(2, s.getActivity().getTimeWindows().size());
         assertThat(s.getActivity().getTimeWindows(), hasItem(is(tw1)));
         assertThat(s.getActivity().getTimeWindows(), hasItem(is(tw2)));
@@ -204,16 +204,16 @@ public class ServiceJobTest {
     @Test
     public void whenAddingTimeWindow_itShouldBeSetCorrectly() {
         ServiceJob s = new ServiceJob.Builder("s").setLocation(Location.newInstance("loc"))
-                        .addTimeWindow(TimeWindow.newInstance(1.0, 2.0)).build();
-        assertEquals(1.0, s.getActivity().getSingleTimeWindow().getStart(), 0.01);
-        assertEquals(2.0, s.getActivity().getSingleTimeWindow().getEnd(), 0.01);
+                .addTimeWindow(TimeWindow.newInstance(1.0, 2.0)).build();
+        assertEquals(1.0, s.getActivity().getTimeWindows().iterator().next().getStart(), 0.01);
+        assertEquals(2.0, s.getActivity().getTimeWindows().iterator().next().getEnd(), 0.01);
     }
 
 
     @Test
     public void whenAddingSkillsCaseSensV2_theyShouldBeAddedCorrectly() {
         ServiceJob s = new ServiceJob.Builder("s").setLocation(Location.newInstance("loc"))
-                        .addRequiredSkill("screwDriver").build();
+                .addRequiredSkill("screwDriver").build();
         assertFalse(s.getRequiredSkills().containsSkill("drill"));
         assertFalse(s.getRequiredSkills().containsSkill("drilL"));
     }
@@ -221,15 +221,15 @@ public class ServiceJobTest {
     @Test
     public void nameShouldBeAssigned() {
         ServiceJob s = new ServiceJob.Builder("s").setLocation(Location.newInstance("loc"))
-                        .setName("name").build();
+                .setName("name").build();
         assertEquals("name", s.getName());
     }
 
     @Test
     public void shouldKnowMultipleTimeWindows() {
         ServiceJob s = new ServiceJob.Builder("s").setLocation(Location.newInstance("loc"))
-                        .addTimeWindow(TimeWindow.newInstance(0., 10.)).addTimeWindow(TimeWindow.newInstance(20., 30.))
-                        .setName("name").build();
+                .addTimeWindow(TimeWindow.newInstance(0., 10.)).addTimeWindow(TimeWindow.newInstance(20., 30.))
+                .setName("name").build();
         assertEquals(2, s.getActivity().getTimeWindows().size());
     }
 
@@ -252,21 +252,21 @@ public class ServiceJobTest {
     @Test
     public void whenSettingPriorities_itShouldBeSetCorrectly() {
         ServiceJob s = new ServiceJob.Builder("s").setLocation(Location.newInstance("loc"))
-                        .setPriority(1).build();
+                .setPriority(1).build();
         assertEquals(1, s.getPriority());
     }
 
     @Test
     public void whenSettingPriorities_itShouldBeSetCorrectly2() {
         ServiceJob s = new ServiceJob.Builder("s").setLocation(Location.newInstance("loc"))
-                        .setPriority(3).build();
+                .setPriority(3).build();
         assertEquals(3, s.getPriority());
     }
 
     @Test
     public void whenNotSettingPriorities_defaultShouldBe2() {
         ServiceJob s = new ServiceJob.Builder("s").setLocation(Location.newInstance("loc"))
-                        .build();
+                .build();
         assertEquals(2, s.getPriority());
     }
 

--- a/jsprit-core/src/test/java/com/graphhopper/jsprit/core/problem/job/ShipmentJobTest.java
+++ b/jsprit-core/src/test/java/com/graphhopper/jsprit/core/problem/job/ShipmentJobTest.java
@@ -38,9 +38,9 @@ public class ShipmentJobTest {
     @Test
     public void whenTwoShipmentsHaveTheSameId_theyReferencesShouldBeUnEqual() {
         ShipmentJob one = new ShipmentJob.Builder("s").addSizeDimension(0, 10).setPickupLocation(Location.Builder.newInstance().setId("foo").build()).
-                        setDeliveryLocation(TestUtils.loc("foofoo")).setPickupServiceTime(10).setDeliveryServiceTime(20).build();
+                setDeliveryLocation(TestUtils.loc("foofoo")).setPickupServiceTime(10).setDeliveryServiceTime(20).build();
         ShipmentJob two = new ShipmentJob.Builder("s").addSizeDimension(0, 10).setPickupLocation(Location.Builder.newInstance().setId("foo").build()).
-                        setDeliveryLocation(TestUtils.loc("foofoo")).setPickupServiceTime(10).setDeliveryServiceTime(20).build();
+                setDeliveryLocation(TestUtils.loc("foofoo")).setPickupServiceTime(10).setDeliveryServiceTime(20).build();
 
         assertTrue(one != two);
     }
@@ -48,7 +48,7 @@ public class ShipmentJobTest {
     @Test
     public void sizeAtStartAndEndShouldBeCorrect() {
         ShipmentJob one = new ShipmentJob.Builder("s").addSizeDimension(0, 10).addSizeDimension(1, 5).setPickupLocation(Location.Builder.newInstance().setId("foo").build()).
-                        setDeliveryLocation(TestUtils.loc("foofoo")).setPickupServiceTime(10).setDeliveryServiceTime(20).build();
+                setDeliveryLocation(TestUtils.loc("foofoo")).setPickupServiceTime(10).setDeliveryServiceTime(20).build();
         SizeDimension cap = SizeDimension.Builder.newInstance().addDimension(0, 0).addDimension(1, 0).build();
         assertTrue(one.getSizeAtStart().equals(cap));
         assertTrue(one.getSizeAtEnd().equals(cap));
@@ -57,9 +57,9 @@ public class ShipmentJobTest {
     @Test
     public void whenTwoShipmentsHaveTheSameId_theyShouldBeEqual() {
         ShipmentJob one = new ShipmentJob.Builder("s").addSizeDimension(0, 10).setPickupLocation(Location.Builder.newInstance().setId("foo").build()).
-                        setDeliveryLocation(TestUtils.loc("foofoo")).setPickupServiceTime(10).setDeliveryServiceTime(20).build();
+                setDeliveryLocation(TestUtils.loc("foofoo")).setPickupServiceTime(10).setDeliveryServiceTime(20).build();
         ShipmentJob two = new ShipmentJob.Builder("s").addSizeDimension(0, 10).setPickupLocation(Location.Builder.newInstance().setId("foo").build()).
-                        setDeliveryLocation(TestUtils.loc("foofoo")).setPickupServiceTime(10).setDeliveryServiceTime(20).build();
+                setDeliveryLocation(TestUtils.loc("foofoo")).setPickupServiceTime(10).setDeliveryServiceTime(20).build();
 
         assertTrue(one.equals(two));
     }
@@ -67,7 +67,7 @@ public class ShipmentJobTest {
     @Test
     public void whenShipmentIsInstantiatedWithASizeOf10_theSizeShouldBe10() {
         ShipmentJob one = new ShipmentJob.Builder("s").addSizeDimension(0, 10).setPickupLocation(Location.Builder.newInstance().setId("foo").build()).
-                        setDeliveryLocation(TestUtils.loc("foofoo")).setPickupServiceTime(10).setDeliveryServiceTime(20).build();
+                setDeliveryLocation(TestUtils.loc("foofoo")).setPickupServiceTime(10).setDeliveryServiceTime(20).build();
         assertEquals(10, one.getSize().get(0));
     }
 
@@ -129,7 +129,7 @@ public class ShipmentJobTest {
     @Test
     public void whenPickupCoordIsSet_itShouldBeDoneCorrectly() {
         ShipmentJob s = new ShipmentJob.Builder("s")
-                        .setDeliveryLocation(TestUtils.loc("delLoc")).setPickupLocation(Location.Builder.newInstance().setId("pickLoc").setCoordinate(Coordinate.newInstance(1, 2)).build()).build();
+                .setDeliveryLocation(TestUtils.loc("delLoc")).setPickupLocation(Location.Builder.newInstance().setId("pickLoc").setCoordinate(Coordinate.newInstance(1, 2)).build()).build();
         assertEquals(1.0, s.getPickupActivity().getLocation().getCoordinate().getX(), 0.01);
         assertEquals(2.0, s.getPickupActivity().getLocation().getCoordinate().getY(), 0.01);
         assertEquals(1.0, s.getPickupActivity().getLocation().getCoordinate().getX(), 0.01);
@@ -140,7 +140,7 @@ public class ShipmentJobTest {
     @Test
     public void whenDeliveryLocationIdIsSet_itShouldBeDoneCorrectly() {
         ShipmentJob s = new ShipmentJob.Builder("s")
-                        .setDeliveryLocation(TestUtils.loc("delLoc")).setPickupLocation(Location.Builder.newInstance().setId("pickLoc").build()).build();
+                .setDeliveryLocation(TestUtils.loc("delLoc")).setPickupLocation(Location.Builder.newInstance().setId("pickLoc").build()).build();
         assertEquals("delLoc", s.getDeliveryActivity().getLocation().getId());
         assertEquals("delLoc", s.getDeliveryActivity().getLocation().getId());
     }
@@ -149,8 +149,8 @@ public class ShipmentJobTest {
     @Test
     public void whenDeliveryCoordIsSet_itShouldBeDoneCorrectly() {
         ShipmentJob s = new ShipmentJob.Builder("s").setDeliveryLocation(TestUtils.loc("delLoc", Coordinate.newInstance(1, 2)))
-                        .setPickupLocation(Location.Builder.newInstance().setId("pickLoc").build())
-                        .build();
+                .setPickupLocation(Location.Builder.newInstance().setId("pickLoc").build())
+                .build();
         assertEquals(1.0, s.getDeliveryActivity().getLocation().getCoordinate().getX(), 0.01);
         assertEquals(2.0, s.getDeliveryActivity().getLocation().getCoordinate().getY(), 0.01);
         assertEquals(1.0, s.getDeliveryActivity().getLocation().getCoordinate().getX(), 0.01);
@@ -160,22 +160,22 @@ public class ShipmentJobTest {
     @Test
     public void whenPickupServiceTimeIsNotSet_itShouldBeZero() {
         ShipmentJob s = new ShipmentJob.Builder("s")
-                        .setDeliveryLocation(TestUtils.loc("delLoc")).setPickupLocation(Location.Builder.newInstance().setId("pickLoc").build()).build();
+                .setDeliveryLocation(TestUtils.loc("delLoc")).setPickupLocation(Location.Builder.newInstance().setId("pickLoc").build()).build();
         assertEquals(0.0, s.getPickupActivity().getOperationTime(), 0.01);
     }
 
     @Test
     public void whenDeliveryServiceTimeIsNotSet_itShouldBeZero() {
         ShipmentJob s = new ShipmentJob.Builder("s")
-                        .setDeliveryLocation(TestUtils.loc("delLoc")).setPickupLocation(Location.Builder.newInstance().setId("pickLoc").build()).build();
+                .setDeliveryLocation(TestUtils.loc("delLoc")).setPickupLocation(Location.Builder.newInstance().setId("pickLoc").build()).build();
         assertEquals(0.0, s.getDeliveryActivity().getOperationTime(), 0.01);
     }
 
     @Test
     public void whenPickupServiceTimeIsSet_itShouldBeDoneCorrectly() {
         ShipmentJob s = new ShipmentJob.Builder("s")
-                        .setPickupServiceTime(2.0)
-                        .setDeliveryLocation(TestUtils.loc("delLoc")).setPickupLocation(Location.Builder.newInstance().setId("pickLoc").build()).build();
+                .setPickupServiceTime(2.0)
+                .setDeliveryLocation(TestUtils.loc("delLoc")).setPickupLocation(Location.Builder.newInstance().setId("pickLoc").build()).build();
         assertEquals(2.0, s.getPickupActivity().getOperationTime(), 0.01);
     }
 
@@ -189,7 +189,7 @@ public class ShipmentJobTest {
     @Test
     public void whenDeliveryServiceTimeIsSet_itShouldBeDoneCorrectly() {
         ShipmentJob s = new ShipmentJob.Builder("s").setDeliveryServiceTime(2.0)
-                        .setDeliveryLocation(TestUtils.loc("delLoc")).setPickupLocation(Location.Builder.newInstance().setId("pickLoc").build()).build();
+                .setDeliveryLocation(TestUtils.loc("delLoc")).setPickupLocation(Location.Builder.newInstance().setId("pickLoc").build()).build();
         assertEquals(2.0, s.getDeliveryActivity().getOperationTime(), 0.01);
     }
 
@@ -202,10 +202,10 @@ public class ShipmentJobTest {
     @Test
     public void whenPickupTimeWindowIsNotSet_itShouldBeTheDefaultOne() {
         ShipmentJob s = new ShipmentJob.Builder("s").setDeliveryLocation(TestUtils.loc("delLoc")).setPickupLocation(Location.Builder.newInstance().setId("pickLoc").build()).build();
-        assertEquals(0.0, s.getPickupActivity().getSingleTimeWindow().getStart(),
-                        0.01);
+        assertEquals(0.0, s.getPickupActivity().getTimeWindows().iterator().next().getStart(),
+                0.01);
         assertEquals(Double.MAX_VALUE,
-                        s.getPickupActivity().getSingleTimeWindow().getEnd(), 0.01);
+                s.getPickupActivity().getTimeWindows().iterator().next().getEnd(), 0.01);
     }
 
     @Test(expected = IllegalArgumentException.class)
@@ -217,19 +217,19 @@ public class ShipmentJobTest {
     @Test
     public void whenPickupTimeWindowIsSet_itShouldBeDoneCorrectly() {
         ShipmentJob s = new ShipmentJob.Builder("s").setPickupTimeWindow(TimeWindow.newInstance(1, 2))
-                        .setDeliveryLocation(TestUtils.loc("delLoc")).setPickupLocation(Location.Builder.newInstance().setId("pickLoc").build()).build();
-        assertEquals(1.0, s.getPickupActivity().getSingleTimeWindow().getStart(),
-                        0.01);
-        assertEquals(2.0, s.getPickupActivity().getSingleTimeWindow().getEnd(), 0.01);
+                .setDeliveryLocation(TestUtils.loc("delLoc")).setPickupLocation(Location.Builder.newInstance().setId("pickLoc").build()).build();
+        assertEquals(1.0, s.getPickupActivity().getTimeWindows().iterator().next().getStart(),
+                0.01);
+        assertEquals(2.0, s.getPickupActivity().getTimeWindows().iterator().next().getEnd(), 0.01);
     }
 
     @Test
     public void whenDeliveryTimeWindowIsNotSet_itShouldBeTheDefaultOne() {
         ShipmentJob s = new ShipmentJob.Builder("s").setDeliveryLocation(TestUtils.loc("delLoc")).setPickupLocation(Location.Builder.newInstance().setId("pickLoc").build()).build();
-        assertEquals(0.0, s.getDeliveryActivity().getSingleTimeWindow().getStart(),
-                        0.01);
+        assertEquals(0.0, s.getDeliveryActivity().getTimeWindows().iterator().next().getStart(),
+                0.01);
         assertEquals(Double.MAX_VALUE,
-                        s.getDeliveryActivity().getSingleTimeWindow().getEnd(), 0.01);
+                s.getDeliveryActivity().getTimeWindows().iterator().next().getEnd(), 0.01);
     }
 
     @Test(expected = IllegalArgumentException.class)
@@ -241,31 +241,31 @@ public class ShipmentJobTest {
     @Test
     public void whenDeliveryTimeWindowIsSet_itShouldBeDoneCorrectly() {
         ShipmentJob s = new ShipmentJob.Builder("s").setDeliveryTimeWindow(TimeWindow.newInstance(1, 2))
-                        .setDeliveryLocation(TestUtils.loc("delLoc")).setPickupLocation(Location.Builder.newInstance().setId("pickLoc").build()).build();
-        assertEquals(1.0, s.getDeliveryActivity().getSingleTimeWindow().getStart(),
-                        0.01);
-        assertEquals(2.0, s.getDeliveryActivity().getSingleTimeWindow().getEnd(),
-                        0.01);
+                .setDeliveryLocation(TestUtils.loc("delLoc")).setPickupLocation(Location.Builder.newInstance().setId("pickLoc").build()).build();
+        assertEquals(1.0, s.getDeliveryActivity().getTimeWindows().iterator().next().getStart(),
+                0.01);
+        assertEquals(2.0, s.getDeliveryActivity().getTimeWindows().iterator().next().getEnd(),
+                0.01);
     }
 
     @Test
     public void whenUsingAddDeliveryTimeWindow_itShouldBeDoneCorrectly() {
         ShipmentJob s = new ShipmentJob.Builder("s").addDeliveryTimeWindow(TimeWindow.newInstance(1, 2))
-                        .setDeliveryLocation(TestUtils.loc("delLoc")).setPickupLocation(Location.Builder.newInstance().setId("pickLoc").build()).build();
-        assertEquals(1.0, s.getDeliveryActivity().getSingleTimeWindow().getStart(),
-                        0.01);
-        assertEquals(2.0, s.getDeliveryActivity().getSingleTimeWindow().getEnd(),
-                        0.01);
+                .setDeliveryLocation(TestUtils.loc("delLoc")).setPickupLocation(Location.Builder.newInstance().setId("pickLoc").build()).build();
+        assertEquals(1.0, s.getDeliveryActivity().getTimeWindows().iterator().next().getStart(),
+                0.01);
+        assertEquals(2.0, s.getDeliveryActivity().getTimeWindows().iterator().next().getEnd(),
+                0.01);
     }
 
     @Test
     public void whenUsingAddDeliveryTimeWindow2_itShouldBeDoneCorrectly() {
         ShipmentJob s = new ShipmentJob.Builder("s").addDeliveryTimeWindow(1, 2)
-                        .setDeliveryLocation(TestUtils.loc("delLoc")).setPickupLocation(Location.Builder.newInstance().setId("pickLoc").build()).build();
-        assertEquals(1.0, s.getDeliveryActivity().getSingleTimeWindow().getStart(),
-                        0.01);
-        assertEquals(2.0, s.getDeliveryActivity().getSingleTimeWindow().getEnd(),
-                        0.01);
+                .setDeliveryLocation(TestUtils.loc("delLoc")).setPickupLocation(Location.Builder.newInstance().setId("pickLoc").build()).build();
+        assertEquals(1.0, s.getDeliveryActivity().getTimeWindows().iterator().next().getStart(),
+                0.01);
+        assertEquals(2.0, s.getDeliveryActivity().getTimeWindows().iterator().next().getEnd(),
+                0.01);
     }
 
     @Test
@@ -273,7 +273,7 @@ public class ShipmentJobTest {
         TimeWindow tw1 = TimeWindow.newInstance(1, 2);
         TimeWindow tw2 = TimeWindow.newInstance(4, 5);
         ShipmentJob s = new ShipmentJob.Builder("s").addDeliveryTimeWindow(tw1).addDeliveryTimeWindow(tw2)
-                        .setDeliveryLocation(TestUtils.loc("delLoc")).setPickupLocation(Location.Builder.newInstance().setId("pickLoc").build()).build();
+                .setDeliveryLocation(TestUtils.loc("delLoc")).setPickupLocation(Location.Builder.newInstance().setId("pickLoc").build()).build();
         assertEquals(s.getDeliveryActivity().getTimeWindows().size(), 2);
         assertThat(s.getDeliveryActivity().getTimeWindows(), hasItem(is(tw1)));
         assertThat(s.getDeliveryActivity().getTimeWindows(), hasItem(is(tw2)));
@@ -281,31 +281,31 @@ public class ShipmentJobTest {
 
     @Test(expected = IllegalArgumentException.class)
     public void whenAddingMultipleOverlappingDeliveryTimeWindows_itShouldThrowException() {
-        ShipmentJob s = new ShipmentJob.Builder("s").addDeliveryTimeWindow(1, 3).addDeliveryTimeWindow(2, 5)
-                        .setDeliveryLocation(TestUtils.loc("delLoc")).setPickupLocation(Location.Builder.newInstance().setId("pickLoc").build()).build();
-        assertEquals(1.0, s.getDeliveryActivity().getSingleTimeWindow().getStart(),
-                        0.01);
-        assertEquals(2.0, s.getDeliveryActivity().getSingleTimeWindow().getEnd(),
-                        0.01);
+        ShipmentJob s = new ShipmentJob.Builder("s")
+                .addDeliveryTimeWindow(1, 3)
+                .addDeliveryTimeWindow(2, 5)
+                .setDeliveryLocation(TestUtils.loc("delLoc"))
+                .setPickupLocation(Location.newInstance("pickLoc"))
+                .build();
     }
 
 
     @Test
     public void whenUsingAddPickupTimeWindow_itShouldBeDoneCorrectly() {
         ShipmentJob s = new ShipmentJob.Builder("s").addPickupTimeWindow(TimeWindow.newInstance(1, 2))
-                        .setDeliveryLocation(TestUtils.loc("delLoc")).setPickupLocation(Location.Builder.newInstance().setId("pickLoc").build()).build();
-        assertEquals(1.0, s.getPickupActivity().getSingleTimeWindow().getStart(),
-                        0.01);
-        assertEquals(2.0, s.getPickupActivity().getSingleTimeWindow().getEnd(), 0.01);
+                .setDeliveryLocation(TestUtils.loc("delLoc")).setPickupLocation(Location.Builder.newInstance().setId("pickLoc").build()).build();
+        assertEquals(1.0, s.getPickupActivity().getTimeWindows().iterator().next().getStart(),
+                0.01);
+        assertEquals(2.0, s.getPickupActivity().getTimeWindows().iterator().next().getEnd(), 0.01);
     }
 
     @Test
     public void whenUsingAddPickupTimeWindow2_itShouldBeDoneCorrectly() {
         ShipmentJob s = new ShipmentJob.Builder("s").addPickupTimeWindow(1, 2)
-                        .setDeliveryLocation(TestUtils.loc("delLoc")).setPickupLocation(Location.Builder.newInstance().setId("pickLoc").build()).build();
-        assertEquals(1.0, s.getPickupActivity().getSingleTimeWindow().getStart(),
-                        0.01);
-        assertEquals(2.0, s.getPickupActivity().getSingleTimeWindow().getEnd(), 0.01);
+                .setDeliveryLocation(TestUtils.loc("delLoc")).setPickupLocation(Location.Builder.newInstance().setId("pickLoc").build()).build();
+        assertEquals(1.0, s.getPickupActivity().getTimeWindows().iterator().next().getStart(),
+                0.01);
+        assertEquals(2.0, s.getPickupActivity().getTimeWindows().iterator().next().getEnd(), 0.01);
     }
 
     @Test
@@ -313,7 +313,7 @@ public class ShipmentJobTest {
         TimeWindow tw1 = TimeWindow.newInstance(1, 2);
         TimeWindow tw2 = TimeWindow.newInstance(4, 5);
         ShipmentJob s = new ShipmentJob.Builder("s").addPickupTimeWindow(tw1).addPickupTimeWindow(tw2)
-                        .setDeliveryLocation(TestUtils.loc("delLoc")).setPickupLocation(Location.Builder.newInstance().setId("pickLoc").build()).build();
+                .setDeliveryLocation(TestUtils.loc("delLoc")).setPickupLocation(Location.Builder.newInstance().setId("pickLoc").build()).build();
         assertEquals(s.getPickupActivity().getTimeWindows().size(), 2);
         assertThat(s.getPickupActivity().getTimeWindows(), hasItem(is(tw1)));
         assertThat(s.getPickupActivity().getTimeWindows(), hasItem(is(tw2)));
@@ -321,10 +321,11 @@ public class ShipmentJobTest {
 
     @Test(expected = IllegalArgumentException.class)
     public void whenAddingMultipleOverlappingPickupTimeWindows_itShouldThrowException() {
-        ShipmentJob s = new ShipmentJob.Builder("s").addPickupTimeWindow(1, 3).addPickupTimeWindow(2, 5)
-                        .setDeliveryLocation(TestUtils.loc("delLoc")).setPickupLocation(Location.Builder.newInstance().setId("pickLoc").build()).build();
-        assertEquals(1.0, s.getPickupActivity().getSingleTimeWindow().getStart(), 0.01);
-        assertEquals(2.0, s.getPickupActivity().getSingleTimeWindow().getEnd(), 0.01);
+        ShipmentJob s = new ShipmentJob.Builder("s")
+                .addPickupTimeWindow(1, 3)
+                .addPickupTimeWindow(2, 5)
+                .setDeliveryLocation(TestUtils.loc("delLoc"))
+                .setPickupLocation(Location.newInstance("pickLoc")).build();
     }
 
 
@@ -340,18 +341,18 @@ public class ShipmentJobTest {
     @Test
     public void whenAddingTwoCapDimension_nuOfDimsShouldBeTwo() {
         ShipmentJob one = new ShipmentJob.Builder("s").setPickupLocation(Location.Builder.newInstance().setId("foo").build())
-                        .setDeliveryLocation(TestUtils.loc("foofoo"))
-                        .addSizeDimension(0, 2)
-                        .addSizeDimension(1, 4)
-                        .build();
+                .setDeliveryLocation(TestUtils.loc("foofoo"))
+                .addSizeDimension(0, 2)
+                .addSizeDimension(1, 4)
+                .build();
         assertEquals(2, one.getSize().getNuOfDimensions());
     }
 
     @Test
     public void whenShipmentIsBuiltWithoutSpecifyingCapacity_itShouldHvCapWithOneDimAndDimValOfZero() {
         ShipmentJob one = new ShipmentJob.Builder("s")
-                        .setPickupLocation(Location.Builder.newInstance().setId("foo").setCoordinate(Coordinate.newInstance(0, 0)).build())
-                        .setDeliveryLocation(TestUtils.loc("foofoo")).build();
+                .setPickupLocation(Location.Builder.newInstance().setId("foo").setCoordinate(Coordinate.newInstance(0, 0)).build())
+                .setDeliveryLocation(TestUtils.loc("foofoo")).build();
         assertEquals(1, one.getSize().getNuOfDimensions());
         assertEquals(0, one.getSize().get(0));
     }
@@ -359,8 +360,8 @@ public class ShipmentJobTest {
     @Test
     public void whenShipmentIsBuiltWithConstructorWhereSizeIsSpecified_capacityShouldBeSetCorrectly() {
         ShipmentJob one = new ShipmentJob.Builder("s").addSizeDimension(0, 1)
-                        .setPickupLocation(Location.Builder.newInstance().setId("foo").setCoordinate(Coordinate.newInstance(0, 0)).build())
-                        .setDeliveryLocation(TestUtils.loc("foofoo")).build();
+                .setPickupLocation(Location.Builder.newInstance().setId("foo").setCoordinate(Coordinate.newInstance(0, 0)).build())
+                .setDeliveryLocation(TestUtils.loc("foofoo")).build();
         assertEquals(1, one.getSize().getNuOfDimensions());
         assertEquals(1, one.getSize().get(0));
     }
@@ -368,8 +369,8 @@ public class ShipmentJobTest {
     @Test
     public void whenAddingSkills_theyShouldBeAddedCorrectly() {
         ShipmentJob s = new ShipmentJob.Builder("s").setPickupLocation(Location.Builder.newInstance().setId("loc").build())
-                        .setDeliveryLocation(TestUtils.loc("delLoc"))
-                        .addRequiredSkill("drill").addRequiredSkill("screwdriver").build();
+                .setDeliveryLocation(TestUtils.loc("delLoc"))
+                .addRequiredSkill("drill").addRequiredSkill("screwdriver").build();
         assertTrue(s.getRequiredSkills().containsSkill("drill"));
         assertTrue(s.getRequiredSkills().containsSkill("drill"));
         assertTrue(s.getRequiredSkills().containsSkill("ScrewDriver"));
@@ -378,9 +379,9 @@ public class ShipmentJobTest {
     @Test
     public void whenAddingSkillsCaseSens_theyShouldBeAddedCorrectly() {
         ShipmentJob s = new ShipmentJob.Builder("s")
-                        .setPickupLocation(Location.Builder.newInstance().setId("pick").build())
-                        .setDeliveryLocation(TestUtils.loc("del"))
-                        .addRequiredSkill("DriLl").addRequiredSkill("screwDriver").build();
+                .setPickupLocation(Location.Builder.newInstance().setId("pick").build())
+                .setDeliveryLocation(TestUtils.loc("del"))
+                .addRequiredSkill("DriLl").addRequiredSkill("screwDriver").build();
         assertTrue(s.getRequiredSkills().containsSkill("drill"));
         assertTrue(s.getRequiredSkills().containsSkill("drilL"));
     }
@@ -388,8 +389,8 @@ public class ShipmentJobTest {
     @Test
     public void whenAddingSkillsCaseSensV2_theyShouldBeAddedCorrectly() {
         ShipmentJob s = new ShipmentJob.Builder("s").setPickupLocation(Location.Builder.newInstance().setId("loc").build())
-                        .setDeliveryLocation(TestUtils.loc("del"))
-                        .addRequiredSkill("screwDriver").build();
+                .setDeliveryLocation(TestUtils.loc("del"))
+                .addRequiredSkill("screwDriver").build();
         assertFalse(s.getRequiredSkills().containsSkill("drill"));
         assertFalse(s.getRequiredSkills().containsSkill("drilL"));
     }
@@ -397,15 +398,15 @@ public class ShipmentJobTest {
     @Test
     public void nameShouldBeAssigned() {
         ShipmentJob s = new ShipmentJob.Builder("s").setPickupLocation(Location.Builder.newInstance().setId("loc").build())
-                        .setDeliveryLocation(TestUtils.loc("del"))
-                        .setName("name").build();
+                .setDeliveryLocation(TestUtils.loc("del"))
+                .setName("name").build();
         assertEquals("name", s.getName());
     }
 
     @Test
     public void whenSettingLocation_itShouldWork() {
         ShipmentJob s = new ShipmentJob.Builder("s").setPickupLocation(Location.Builder.newInstance().setId("loc").build())
-                        .setDeliveryLocation(Location.Builder.newInstance().setId("del").build()).build();
+                .setDeliveryLocation(Location.Builder.newInstance().setId("del").build()).build();
         assertEquals("loc", s.getPickupActivity().getLocation().getId());
         assertEquals("loc", s.getPickupActivity().getLocation().getId());
         assertEquals("del", s.getDeliveryActivity().getLocation().getId());
@@ -415,24 +416,24 @@ public class ShipmentJobTest {
     @Test
     public void whenSettingPriorities_itShouldBeSetCorrectly() {
         ShipmentJob s = new ShipmentJob.Builder("s").setPickupLocation(Location.newInstance("loc"))
-                        .setDeliveryLocation(Location.newInstance("loc"))
-                        .setPriority(1).build();
+                .setDeliveryLocation(Location.newInstance("loc"))
+                .setPriority(1).build();
         assertEquals(1, s.getPriority());
     }
 
     @Test
     public void whenSettingPriorities_itShouldBeSetCorrectly2() {
         ShipmentJob s = new ShipmentJob.Builder("s").setPickupLocation(Location.newInstance("loc"))
-                        .setDeliveryLocation(Location.newInstance("loc"))
-                        .setPriority(3).build();
+                .setDeliveryLocation(Location.newInstance("loc"))
+                .setPriority(3).build();
         assertEquals(3, s.getPriority());
     }
 
     @Test
     public void whenNotSettingPriorities_defaultShouldBe2() {
         ShipmentJob s = new ShipmentJob.Builder("s").setPickupLocation(Location.newInstance("loc"))
-                        .setDeliveryLocation(Location.newInstance("loc"))
-                        .build();
+                .setDeliveryLocation(Location.newInstance("loc"))
+                .build();
         assertEquals(2, s.getPriority());
     }
 

--- a/jsprit-core/src/test/java/com/graphhopper/jsprit/core/problem/solution/route/VehicleRouteBuilderTest.java
+++ b/jsprit-core/src/test/java/com/graphhopper/jsprit/core/problem/solution/route/VehicleRouteBuilderTest.java
@@ -37,7 +37,7 @@ public class VehicleRouteBuilderTest {
     @Test(expected = IllegalArgumentException.class)
     public void whenDeliveryIsAddedBeforePickup_throwsException() {
         ShipmentJob s = new ShipmentJob.Builder("s")
-                        .setDeliveryLocation(Location.newInstance("loc1")).build();
+                .setDeliveryLocation(Location.newInstance("loc1")).build();
         VehicleRoute.Builder builder = VehicleRoute.Builder.newInstance(mock(Vehicle.class), mock(Driver.class));
         builder.addDelivery(s);
     }
@@ -92,7 +92,7 @@ public class VehicleRouteBuilderTest {
         ShipmentJob s2 = createStandardShipment("s2").build();
 
         Vehicle vehicle = VehicleImpl.Builder.newInstance("v").setStartLocation(Location.newInstance("vehLoc")).setEndLocation(Location.newInstance("vehLoc"))
-                        .build();
+                .build();
 
         VehicleRoute.Builder builder = VehicleRoute.Builder.newInstance(vehicle, mock(Driver.class));
         builder.addPickup(s);
@@ -118,7 +118,7 @@ public class VehicleRouteBuilderTest {
         builder.addDelivery(s2);
         VehicleRoute route = builder.build();
         assertEquals(route.getEnd().getLocation().getId(),
-                        s2.getDeliveryActivity().getLocation().getId());
+                s2.getDeliveryActivity().getLocation().getId());
     }
 
     private Location loc(String delLoc) {
@@ -148,11 +148,11 @@ public class VehicleRouteBuilderTest {
         Location loc = Location.Builder.newInstance().setId("delLoc").build();
         TimeWindow tw = TimeWindow.newInstance(0, 10);
         return new ShipmentJob.Builder(name)
-                        .addSizeDimension(0, 10)
-                        .setPickupTimeWindow(tw)
-                        .setDeliveryTimeWindow(tw)
-                        .setPickupLocation(loc)
-                        .setDeliveryLocation(loc);
+                .addSizeDimension(0, 10)
+                .setPickupTimeWindow(tw)
+                .setDeliveryTimeWindow(tw)
+                .setPickupLocation(loc)
+                .setDeliveryLocation(loc);
     }
 
 

--- a/jsprit-core/src/test/java/com/graphhopper/jsprit/core/problem/solution/route/activity/BreakActivityTest.java
+++ b/jsprit-core/src/test/java/com/graphhopper/jsprit/core/problem/solution/route/activity/BreakActivityTest.java
@@ -40,13 +40,13 @@ public class BreakActivityTest {
     @Before
     public void doBefore() {
         Builder breakBuilder = new Break.Builder("service")
-                        .setTimeWindow(TimeWindow.newInstance(1., 2.)).setServiceTime(3);
+                .setTimeWindow(TimeWindow.newInstance(1., 2.)).setServiceTime(3);
         service = breakBuilder.build();
         serviceActivity = BreakActivity.newInstance(service, breakBuilder);
         serviceActivity.setTheoreticalEarliestOperationStartTime(
-                        service.getActivity().getTimeWindow().getStart());
+                service.getActivity().getBreakTimeWindow().getStart());
         serviceActivity.setTheoreticalLatestOperationStartTime(
-                        service.getActivity().getTimeWindow().getEnd());
+                service.getActivity().getBreakTimeWindow().getEnd());
     }
 
     @Test
@@ -99,11 +99,11 @@ public class BreakActivityTest {
         ServiceJob s1 = new ServiceJob.Builder("s").setLocation(loc).build();
         ServiceJob s2 = new ServiceJob.Builder("s").setLocation(loc).build();
         ServiceActivity d1 = new ServiceActivity(s1, "s1",
-                        loc, 0d, SizeDimension.EMPTY,
-                        TimeWindows.ANY_TIME.getTimeWindows());
+                loc, 0d, SizeDimension.EMPTY,
+                TimeWindows.ANY_TIME.getTimeWindows());
         ServiceActivity d2 = new ServiceActivity(s2, "s2",
-                        loc, 0d, SizeDimension.EMPTY,
-                        TimeWindows.ANY_TIME.getTimeWindows());
+                loc, 0d, SizeDimension.EMPTY,
+                TimeWindows.ANY_TIME.getTimeWindows());
 
         assertTrue(d1.equals(d2));
     }
@@ -114,11 +114,11 @@ public class BreakActivityTest {
         ServiceJob s1 = new ServiceJob.Builder("s").setLocation(loc).build();
         ServiceJob s2 = new ServiceJob.Builder("s2").setLocation(loc).build();
         ServiceActivity d1 = new ServiceActivity(s1, "s1",
-                        loc, 0d, SizeDimension.EMPTY,
-                        TimeWindows.ANY_TIME.getTimeWindows());
+                loc, 0d, SizeDimension.EMPTY,
+                TimeWindows.ANY_TIME.getTimeWindows());
         ServiceActivity d2 = new ServiceActivity(s2, "s2",
-                        loc, 0d, SizeDimension.EMPTY,
-                        TimeWindows.ANY_TIME.getTimeWindows());
+                loc, 0d, SizeDimension.EMPTY,
+                TimeWindows.ANY_TIME.getTimeWindows());
 
         assertFalse(d1.equals(d2));
     }

--- a/jsprit-core/src/test/java/com/graphhopper/jsprit/core/problem/solution/route/activity/BreakActivityTest.java
+++ b/jsprit-core/src/test/java/com/graphhopper/jsprit/core/problem/solution/route/activity/BreakActivityTest.java
@@ -44,9 +44,9 @@ public class BreakActivityTest {
         service = breakBuilder.build();
         serviceActivity = BreakActivity.newInstance(service, breakBuilder);
         serviceActivity.setTheoreticalEarliestOperationStartTime(
-                        service.getActivity().getTimeWindow().getStart());
+                        service.getActivity().getBreakTimeWindow().getStart());
         serviceActivity.setTheoreticalLatestOperationStartTime(
-                        service.getActivity().getTimeWindow().getEnd());
+                        service.getActivity().getBreakTimeWindow().getEnd());
     }
 
     @Test

--- a/jsprit-core/src/test/java/com/graphhopper/jsprit/core/problem/solution/route/activity/JobActivityTest.java
+++ b/jsprit-core/src/test/java/com/graphhopper/jsprit/core/problem/solution/route/activity/JobActivityTest.java
@@ -33,9 +33,9 @@ public abstract class JobActivityTest {
         this.service = service;
         activity = service.getActivity();
         activity.setTheoreticalEarliestOperationStartTime(
-                        activity.getSingleTimeWindow().getStart());
+                activity.getTimeWindows().iterator().next().getStart());
         activity.setTheoreticalLatestOperationStartTime(
-                        activity.getSingleTimeWindow().getEnd());
+                activity.getTimeWindows().iterator().next().getEnd());
     }
 
     @Test

--- a/jsprit-core/src/test/java/com/graphhopper/jsprit/core/problem/vehicle/VehicleImplTest.java
+++ b/jsprit-core/src/test/java/com/graphhopper/jsprit/core/problem/vehicle/VehicleImplTest.java
@@ -45,10 +45,10 @@ public class VehicleImplTest {
         VehicleTypeImpl type1 = VehicleTypeImpl.Builder.newInstance("type").build();
         Break aBreak = new Break.Builder("break").setTimeWindow(TimeWindow.newInstance(100, 200)).setServiceTime(30).build();
         Vehicle v = VehicleImpl.Builder.newInstance("v").setStartLocation(Location.newInstance("start"))
-                        .setType(type1).setEndLocation(Location.newInstance("start"))
-                        .setBreak(aBreak).build();
+                .setType(type1).setEndLocation(Location.newInstance("start"))
+                .setBreak(aBreak).build();
         assertNotNull(v.getBreak());
-        TimeWindow timeWindow = v.getBreak().getActivity().getSingleTimeWindow();
+        TimeWindow timeWindow = v.getBreak().getActivity().getBreakTimeWindow();
         assertEquals(100., timeWindow.getStart(), 0.1);
         assertEquals(200., timeWindow.getEnd(), 0.1);
         assertEquals(30., v.getBreak().getActivity().getOperationTime(), 0.1);
@@ -59,7 +59,7 @@ public class VehicleImplTest {
     public void whenAddingSkills_theyShouldBeAddedCorrectly() {
         VehicleTypeImpl type1 = VehicleTypeImpl.Builder.newInstance("type").build();
         Vehicle v = VehicleImpl.Builder.newInstance("v").setStartLocation(Location.newInstance("start")).setType(type1).setEndLocation(Location.newInstance("start"))
-                        .addSkill("drill").addSkill("screwdriver").build();
+                .addSkill("drill").addSkill("screwdriver").build();
         assertTrue(v.getSkills().containsSkill("drill"));
         assertTrue(v.getSkills().containsSkill("drill"));
         assertTrue(v.getSkills().containsSkill("screwdriver"));
@@ -69,7 +69,7 @@ public class VehicleImplTest {
     public void whenAddingSkillsCaseSens_theyShouldBeAddedCorrectly() {
         VehicleTypeImpl type1 = VehicleTypeImpl.Builder.newInstance("type").build();
         Vehicle v = VehicleImpl.Builder.newInstance("v").setStartLocation(Location.newInstance("start")).setType(type1).setEndLocation(Location.newInstance("start"))
-                        .addSkill("drill").addSkill("screwdriver").build();
+                .addSkill("drill").addSkill("screwdriver").build();
         assertTrue(v.getSkills().containsSkill("drill"));
         assertTrue(v.getSkills().containsSkill("dRill"));
         assertTrue(v.getSkills().containsSkill("ScrewDriver"));
@@ -238,7 +238,7 @@ public class VehicleImplTest {
     public void whenAddingSkillsCaseSensV2_theyShouldBeAddedCorrectly() {
         VehicleTypeImpl type1 = VehicleTypeImpl.Builder.newInstance("type").build();
         Vehicle v = VehicleImpl.Builder.newInstance("v").setStartLocation(Location.newInstance("start")).setType(type1).setEndLocation(Location.newInstance("start"))
-                        .addSkill("drill").build();
+                .addSkill("drill").build();
         assertFalse(v.getSkills().containsSkill("ScrewDriver"));
     }
 

--- a/jsprit-instances/src/main/java/com/graphhopper/jsprit/instance/reader/LopezIbanezBlumReader.java
+++ b/jsprit-instances/src/main/java/com/graphhopper/jsprit/instance/reader/LopezIbanezBlumReader.java
@@ -91,6 +91,10 @@ public class LopezIbanezBlumReader {
         close(reader);
     }
 
+    private static TimeWindow getFirstTimeWindow(ServiceJob job) {
+        return job.getActivity().getTimeWindows().iterator().next();
+    }
+
     public static void main(String[] args) {
         VehicleRoutingProblem.Builder builder = VehicleRoutingProblem.Builder.newInstance();
         new LopezIbanezBlumReader(builder).read("input/Dumas/n20w20.001.txt");
@@ -99,12 +103,12 @@ public class LopezIbanezBlumReader {
         System.out.println("0->20: " + vrp.getTransportCosts().getTransportCost(Location.newInstance(0), Location.newInstance(20), 0, null, null));
         System.out.println("4->18: " + vrp.getTransportCosts().getTransportCost(Location.newInstance(4), Location.newInstance(18), 0, null, null));
         System.out.println("20->8: " + vrp.getTransportCosts().getTransportCost(Location.newInstance(20), Location.newInstance(8), 0, null, null));
-        System.out.println("18: " + ((ServiceJob) vrp.getJobs().get("" + 18)).getActivity().getSingleTimeWindow().getStart() + " "
-                + ((ServiceJob) vrp.getJobs().get("" + 18)).getActivity().getSingleTimeWindow().getEnd());
-        System.out.println("20: " + ((ServiceJob) vrp.getJobs().get("" + 20)).getActivity().getSingleTimeWindow().getStart() + " "
-                + ((ServiceJob) vrp.getJobs().get("" + 20)).getActivity().getSingleTimeWindow().getEnd());
-        System.out.println("1: " + ((ServiceJob) vrp.getJobs().get("" + 1)).getActivity().getSingleTimeWindow().getStart() + " "
-                + ((ServiceJob) vrp.getJobs().get("" + 1)).getActivity().getSingleTimeWindow().getEnd());
+        System.out.println("18: " + getFirstTimeWindow(((ServiceJob) vrp.getJobs().get("" + 18))).getStart() + " "
+                + getFirstTimeWindow(((ServiceJob) vrp.getJobs().get("" + 18))).getEnd());
+        System.out.println("20: " + getFirstTimeWindow(((ServiceJob) vrp.getJobs().get("" + 20))).getStart() + " "
+                + getFirstTimeWindow(((ServiceJob) vrp.getJobs().get("" + 20))).getEnd());
+        System.out.println("1: " + getFirstTimeWindow(((ServiceJob) vrp.getJobs().get("" + 1))).getStart() + " "
+                + getFirstTimeWindow(((ServiceJob) vrp.getJobs().get("" + 1))).getEnd());
     }
 
     private void close(BufferedReader reader) {

--- a/jsprit-instances/src/test/java/com/graphhopper/jsprit/instance/reader/SolomonReaderTest.java
+++ b/jsprit-instances/src/test/java/com/graphhopper/jsprit/instance/reader/SolomonReaderTest.java
@@ -41,9 +41,8 @@ public class SolomonReaderTest {
 
     private String getPath() {
         URL resource = getClass().getClassLoader().getResource("C101_solomon.txt");
-        if (resource == null) {
+        if (resource == null)
             throw new IllegalStateException("file C101_solomon.txt does not exist");
-        }
         return resource.getPath();
     }
 
@@ -97,7 +96,9 @@ public class SolomonReaderTest {
         VehicleRoutingProblem.Builder builder = VehicleRoutingProblem.Builder.newInstance();
         new SolomonReader(builder).read(getPath());
         VehicleRoutingProblem vrp = builder.build();
-        assertEquals(262.0, ((ServiceJob) vrp.getJobs().get("62")).getActivity().getSingleTimeWindow().getStart(), 0.1);
+        assertEquals(262.0,
+                ((ServiceJob) vrp.getJobs().get("62")).getActivity().getTimeWindows().iterator().next().getStart(),
+                0.1);
     }
 
     @Test
@@ -105,7 +106,8 @@ public class SolomonReaderTest {
         VehicleRoutingProblem.Builder builder = VehicleRoutingProblem.Builder.newInstance();
         new SolomonReader(builder).read(getPath());
         VehicleRoutingProblem vrp = builder.build();
-        assertEquals(144.0, ((ServiceJob) vrp.getJobs().get("87")).getActivity().getSingleTimeWindow().getEnd(), 0.1);
+        assertEquals(144.0,
+                ((ServiceJob) vrp.getJobs().get("87")).getActivity().getTimeWindows().iterator().next().getEnd(), 0.1);
     }
 
 

--- a/jsprit-io/src/test/java/com/graphhopper/jsprit/io/problem/VrpXMLReaderTest.java
+++ b/jsprit-io/src/test/java/com/graphhopper/jsprit/io/problem/VrpXMLReaderTest.java
@@ -146,15 +146,14 @@ public class VrpXMLReaderTest {
 
     private Vehicle getVehicle(String string, Collection<Vehicle> vehicles) {
         for (Vehicle v : vehicles) {
-            if (string.equals(v.getId())) {
+            if (string.equals(v.getId()))
                 return v;
-            }
         }
         return null;
     }
 
     private boolean idsInCollection(List<String> asList, Collection<Vehicle> vehicles) {
-        List<String> ids = new ArrayList<String>(asList);
+        List<String> ids = new ArrayList<>(asList);
         for (Vehicle v : vehicles) {
             if (ids.contains(v.getId())) {
                 ids.remove(v.getId());
@@ -311,7 +310,7 @@ public class VrpXMLReaderTest {
         new VrpXMLReader(builder, null).read(inputStream);
         VehicleRoutingProblem vrp = builder.build();
         ServiceJob s1 = (ServiceJob) vrp.getJobs().get("1");
-        TimeWindow tw = s1.getActivity().getSingleTimeWindow();
+        TimeWindow tw = s1.getActivity().getTimeWindows().iterator().next();
         assertEquals(0.0, tw.getStart(), 0.01);
         assertEquals(4000.0, tw.getEnd(), 0.01);
     }
@@ -474,7 +473,7 @@ public class VrpXMLReaderTest {
         new VrpXMLReader(builder, null).read(inputStream);
         VehicleRoutingProblem vrp = builder.build();
         ShipmentJob s = (ShipmentJob) vrp.getJobs().get("3");
-        TimeWindow tw = s.getPickupActivity().getSingleTimeWindow();
+        TimeWindow tw = s.getPickupActivity().getTimeWindows().iterator().next();
         assertEquals(1000.0, tw.getStart(), 0.01);
         assertEquals(4000.0, tw.getEnd(), 0.01);
     }
@@ -485,7 +484,7 @@ public class VrpXMLReaderTest {
         new VrpXMLReader(builder, null).read(inputStream);
         VehicleRoutingProblem vrp = builder.build();
         ShipmentJob s = (ShipmentJob) vrp.getJobs().get("3");
-        TimeWindow tw = s.getDeliveryActivity().getSingleTimeWindow();
+        TimeWindow tw = s.getDeliveryActivity().getTimeWindows().iterator().next();
         assertEquals(6000.0, tw.getStart(), 0.01);
         assertEquals(10000.0, tw.getEnd(), 0.01);
     }
@@ -624,7 +623,7 @@ public class VrpXMLReaderTest {
     @Test
     public void testRead_ifReaderIsCalled_itReadsSuccessfullyV2() {
         VehicleRoutingProblem.Builder vrpBuilder = VehicleRoutingProblem.Builder.newInstance();
-        ArrayList<VehicleRoutingProblemSolution> solutions = new ArrayList<VehicleRoutingProblemSolution>();
+        ArrayList<VehicleRoutingProblemSolution> solutions = new ArrayList<>();
         new VrpXMLReader(vrpBuilder, solutions).read(getClass().getResourceAsStream("finiteVrpWithShipmentsAndSolution.xml"));
         VehicleRoutingProblem vrp = vrpBuilder.build();
         assertEquals(4, vrp.getJobs().size());
@@ -642,7 +641,7 @@ public class VrpXMLReaderTest {
     @Test
     public void testRead_ifReaderIsCalled_itReadsSuccessfully() {
         new VrpXMLReader(VehicleRoutingProblem.Builder.newInstance(), new ArrayList<VehicleRoutingProblemSolution>())
-                .read(getClass().getResourceAsStream("lui-shen-solution.xml"));
+        .read(getClass().getResourceAsStream("lui-shen-solution.xml"));
         assertTrue(true);
     }
 
@@ -650,7 +649,7 @@ public class VrpXMLReaderTest {
     @Test
     public void unassignedJobShouldBeRead() {
         VehicleRoutingProblem.Builder vrpBuilder = VehicleRoutingProblem.Builder.newInstance();
-        ArrayList<VehicleRoutingProblemSolution> solutions = new ArrayList<VehicleRoutingProblemSolution>();
+        ArrayList<VehicleRoutingProblemSolution> solutions = new ArrayList<>();
         new VrpXMLReader(vrpBuilder, solutions).read(getClass().getResourceAsStream("finiteVrpWithShipmentsAndSolution.xml"));
 
         VehicleRoutingProblemSolution solution = Solutions.bestOf(solutions);

--- a/jsprit-io/src/test/java/com/graphhopper/jsprit/io/problem/VrpXMLWriterTest.java
+++ b/jsprit-io/src/test/java/com/graphhopper/jsprit/io/problem/VrpXMLWriterTest.java
@@ -251,7 +251,8 @@ public class VrpXMLWriterTest {
         VehicleRoutingProblem readVrp = vrpToReadBuilder.build();
         assertEquals(2, readVrp.getJobs().size());
 
-        TimeWindow tw = ((ShipmentJob) readVrp.getJobs().get("1")).getPickupActivity().getSingleTimeWindow();
+        TimeWindow tw = ((ShipmentJob) readVrp.getJobs().get("1")).getPickupActivity().getTimeWindows().iterator()
+            .next();
         assertEquals(1.0, tw.getStart(), 0.01);
         assertEquals(2.0, tw.getEnd(), 0.01);
     }
@@ -286,7 +287,8 @@ public class VrpXMLWriterTest {
         VehicleRoutingProblem readVrp = vrpToReadBuilder.build();
         assertEquals(2, readVrp.getJobs().size());
 
-        TimeWindow tw = ((ShipmentJob) readVrp.getJobs().get("1")).getDeliveryActivity().getSingleTimeWindow();
+        TimeWindow tw = ((ShipmentJob) readVrp.getJobs().get("1")).getDeliveryActivity().getTimeWindows().iterator()
+            .next();
         assertEquals(3.0, tw.getStart(), 0.01);
         assertEquals(4.0, tw.getEnd(), 0.01);
     }
@@ -455,9 +457,8 @@ public class VrpXMLWriterTest {
 
     private Vehicle getVehicle(String v1, VehicleRoutingProblem readVrp) {
         for (Vehicle v : readVrp.getVehicles()) {
-            if (v.getId().equals(v1)) {
+            if (v.getId().equals(v1))
                 return v;
-            }
         }
         return null;
     }
@@ -899,9 +900,8 @@ public class VrpXMLWriterTest {
 
     private Vehicle getVehicle(String string, Collection<Vehicle> vehicles) {
         for (Vehicle v : vehicles) {
-            if (string.equals(v.getId())) {
+            if (string.equals(v.getId()))
                 return v;
-            }
         }
         return null;
     }
@@ -920,16 +920,16 @@ public class VrpXMLWriterTest {
         VehicleRoutingProblem vrp = builder.addJob(s1).addJob(s2).build();
 
         VehicleRoute route = VehicleRoute.Builder.newInstance(v1).addService(s1).addService(s2).build();
-        List<VehicleRoute> routes = new ArrayList<VehicleRoute>();
+        List<VehicleRoute> routes = new ArrayList<>();
         routes.add(route);
         VehicleRoutingProblemSolution solution = new VehicleRoutingProblemSolution(routes, 10.);
-        List<VehicleRoutingProblemSolution> solutions = new ArrayList<VehicleRoutingProblemSolution>();
+        List<VehicleRoutingProblemSolution> solutions = new ArrayList<>();
         solutions.add(solution);
 
         new VrpXMLWriter(vrp, solutions).write(infileName);
 
         VehicleRoutingProblem.Builder vrpToReadBuilder = VehicleRoutingProblem.Builder.newInstance();
-        List<VehicleRoutingProblemSolution> solutionsToRead = new ArrayList<VehicleRoutingProblemSolution>();
+        List<VehicleRoutingProblemSolution> solutionsToRead = new ArrayList<>();
         new VrpXMLReader(vrpToReadBuilder, solutionsToRead).read(infileName);
 
         assertEquals(1, solutionsToRead.size());
@@ -951,17 +951,17 @@ public class VrpXMLWriterTest {
         VehicleRoutingProblem vrp = builder.addJob(s1).addJob(s2).build();
 
         VehicleRoute route = VehicleRoute.Builder.newInstance(v1).addService(s1).build();
-        List<VehicleRoute> routes = new ArrayList<VehicleRoute>();
+        List<VehicleRoute> routes = new ArrayList<>();
         routes.add(route);
         VehicleRoutingProblemSolution solution = new VehicleRoutingProblemSolution(routes, 10.);
         solution.getUnassignedJobs().add(s2);
-        List<VehicleRoutingProblemSolution> solutions = new ArrayList<VehicleRoutingProblemSolution>();
+        List<VehicleRoutingProblemSolution> solutions = new ArrayList<>();
         solutions.add(solution);
 
         new VrpXMLWriter(vrp, solutions).write(infileName);
 
         VehicleRoutingProblem.Builder vrpToReadBuilder = VehicleRoutingProblem.Builder.newInstance();
-        List<VehicleRoutingProblemSolution> solutionsToRead = new ArrayList<VehicleRoutingProblemSolution>();
+        List<VehicleRoutingProblemSolution> solutionsToRead = new ArrayList<>();
         new VrpXMLReader(vrpToReadBuilder, solutionsToRead).read(infileName);
 
         assertEquals(1, solutionsToRead.size());


### PR DESCRIPTION
I created this pull request to inform you about my progress. You may merge or may wait.

What has been acomplished:

* BreakActivity kept its single time window function, but with the name `getBreakTimeWindow()`
* All other `getSingleTimeWindow()` reference and the function itselt removed. Note, that not all single time window references are removed, In tests, where they sole function was to get a time window to assert, I kept it by replacing with the `getTimeWindows().iterator().next()` expression.
* The `impl_setIndex()` methods now protected by friendly handshake pattern. They are still public, but the user can't call it.
* In the `VehicleRoute.Builder`, I created new activity add functions fitting better to the new job architectures. The old ones (`addService`, `addPickup`, etc.) are kept (used by the unit tests intensly), but marked deprecated.
* In the `VehicleRoute.Builder`, the half-inserted shipments were kept into account, but no validation were made for the more general, multi-activity `CustomJobs`. It is replaced with new validation which detects if all activities of all added jobs are really inserted and if any activities are inserted more than once.

What is next:

- [x] Add Javadoc for the new acticity adding functions of the `VehicleRoute.Builder`.
- [ ] Get rid of the `JobActivityFactory` 
- [ ] Debug, why the modular objective function returns wrong cost sometimes.
