### PR TITLE
fix a bug in fast regret

### DIFF
--- a/jsprit-core/src/main/java/com/graphhopper/jsprit/core/algorithm/recreate/InsertionDataUpdater.java
+++ b/jsprit-core/src/main/java/com/graphhopper/jsprit/core/algorithm/recreate/InsertionDataUpdater.java
@@ -40,19 +40,30 @@ class InsertionDataUpdater {
                     relevantVehicles.addAll(fleetManager.getAvailableVehicles(route.getVehicle()));
                 }
             } else relevantVehicles.addAll(fleetManager.getAvailableVehicles());
+            double bestCost = Double.MAX_VALUE;
+            InsertionData bestIData = new InsertionData.NoInsertionFound();
             for (Vehicle v : relevantVehicles) {
                 double depTime = v.getEarliestDeparture();
                 InsertionData iData = insertionCostsCalculator.getInsertionData(route, unassignedJob, v, depTime, route.getDriver(), Double.MAX_VALUE);
                 if (iData instanceof InsertionData.NoInsertionFound) {
                     continue;
                 }
-                insertionDataSet.add(new VersionedInsertionData(iData, updateRound, route));
+                if (iData.getInsertionCost() < bestCost) {
+                    bestIData = iData;
+                    bestCost = iData.getInsertionCost();
+                }
             }
+            Iterator<VersionedInsertionData> iterator = insertionDataSet.iterator();
+            while (iterator.hasNext()) {
+                VersionedInsertionData versionedInsertionData = iterator.next();
+                if (versionedInsertionData.getRoute() == route &&
+                    versionedInsertionData.getVersion() != updateRound)
+                    iterator.remove();
+            }
+            insertionDataSet.add(new VersionedInsertionData(bestIData, updateRound, route));
         }
         return true;
     }
-
-
 
     static VehicleRoute findRoute(Collection<VehicleRoute> routes, Job job) {
         for(VehicleRoute r : routes){
@@ -115,16 +126,13 @@ class InsertionDataUpdater {
                         } else continue;
                     }
                 }
-                int currentDataVersion = updates.get(versionedIData.getRoute());
-                if(versionedIData.getVersion() == currentDataVersion){
-                    if(best == null) {
-                        best = versionedIData.getiData();
-                        bestRoute = versionedIData.getRoute();
-                    }
-                    else {
-                        secondBest = versionedIData.getiData();
-                        break;
-                    }
+                if(best == null) {
+                    best = versionedIData.getiData();
+                    bestRoute = versionedIData.getRoute();
+                }
+                else {
+                    secondBest = versionedIData.getiData();
+                    break;
                 }
             }
             VehicleRoute emptyRoute = VehicleRoute.emptyRoute();
@@ -156,6 +164,11 @@ class InsertionDataUpdater {
             }
             else if(scoredJob.getScore() > bestScoredJob.getScore()){
                 bestScoredJob = scoredJob;
+            }
+            else if (scoredJob.getScore() == bestScoredJob.getScore()) {
+                if (scoredJob.getJob().getId().compareTo(bestScoredJob.getJob().getId()) <= 0) {
+                    bestScoredJob = scoredJob;
+                }
             }
         }
         return bestScoredJob;


### PR DESCRIPTION
the bug is reported in the forum:

https://discuss.graphhopper.com/t/questions-about-fast-regret-and-dependency-type-of-jobs/2349/2

the PR contains the following:
- fix the route version inconsistency issue (i.e., the bug); 
- add comparison of job ids when scores are equal (so that it is consistent with the regular regret).

as a matter of fact, after the changes, the version number in the VersionedInsertionData is not useful, because it is always only the latest version that is stored. actually we might not need a TreeSet to store the VersionedInsertionData's, we could just use an array (this is not included in the PR).

as reported in [this update](https://discuss.graphhopper.com/t/questions-about-fast-regret-and-dependency-type-of-jobs/2349/3):

after I have made the above changes, and if I deactivate the insertion noise maker (so that the random numbers used in each ruin and recreate process will be the same), the solution obtained by the regular regret and that obtained by the fast regret when all jobs are defined with a dependency type INTRA_ROUTE are the same for the tested problems.

however, for some problems (2 out of 7 tested), the solution obtained by the fast regret when not all jobs are defined with a dependency type INTRA_ROUTE is different. I am trying to figure out why.

Best regards,
He