### PR TITLE
Changed job priorities to double instead of int

### DIFF
--- a/jsprit-core/src/main/java/com/graphhopper/jsprit/core/algorithm/recreate/AccordingToPriorities.java
+++ b/jsprit-core/src/main/java/com/graphhopper/jsprit/core/algorithm/recreate/AccordingToPriorities.java
@@ -29,7 +29,7 @@ class AccordingToPriorities implements Comparator<Job> {
 
     @Override
     public int compare(Job o1, Job o2) {
-        return o1.getPriority() - o2.getPriority();
+        return Double.compare(o2.getPriority(), o1.getPriority());
     }
 
 }

--- a/jsprit-core/src/main/java/com/graphhopper/jsprit/core/problem/job/Job.java
+++ b/jsprit-core/src/main/java/com/graphhopper/jsprit/core/problem/job/Job.java
@@ -55,13 +55,13 @@ public interface Job extends HasId, HasIndex {
     public String getName();
 
     /**
-     * Get priority of job. Only 1 = high priority, 2 = medium and 3 = low are allowed.
+     * Get priority of job. range (1 = high priority --> 10 = low priority) is allowed.
      * <p>
      * Default is 2 = medium.
      *
      * @return priority
      */
-    public int getPriority();
+    public double getPriority();
 
     public double getMaxTimeInVehicle();
 

--- a/jsprit-core/src/main/java/com/graphhopper/jsprit/core/problem/job/Service.java
+++ b/jsprit-core/src/main/java/com/graphhopper/jsprit/core/problem/job/Service.java
@@ -88,7 +88,7 @@ public class Service extends AbstractJob {
 
         private boolean twAdded = false;
 
-        private int priority = 2;
+        private double priority = 2;
         protected Object userData;
 
 		protected double maxTimeInVehicle = Double.MAX_VALUE;
@@ -247,7 +247,7 @@ public class Service extends AbstractJob {
          * @param priority
          * @return builder
          */
-        public Builder<T> setPriority(int priority) {
+        public Builder<T> setPriority(double priority) {
             if (priority < 1 || priority > 10)
                 throw new IllegalArgumentException("The priority value is not valid. Only 1 (very high) to 10 (very low) are allowed.");
             this.priority = priority;
@@ -278,7 +278,7 @@ public class Service extends AbstractJob {
 
     private final TimeWindows timeWindows;
 
-    private final int priority;
+    private final double priority;
 
     private final double maxTimeInVehicle;
 
@@ -398,14 +398,14 @@ public class Service extends AbstractJob {
     }
 
     /**
-     * Get priority of service. Only 1 = high priority, 2 = medium and 3 = low are allowed.
+     * Get priority of job. range (1 = high priority --> 10 = low priority) is allowed.
      * <p>
      * Default is 2 = medium.
      *
      * @return priority
      */
     @Override
-    public int getPriority() {
+    public double getPriority() {
         return priority;
     }
 

--- a/jsprit-core/src/main/java/com/graphhopper/jsprit/core/problem/job/Shipment.java
+++ b/jsprit-core/src/main/java/com/graphhopper/jsprit/core/problem/job/Shipment.java
@@ -83,7 +83,7 @@ public class Shipment extends AbstractJob {
 
         private TimeWindowsImpl pickupTimeWindows;
 
-        private int priority = 2;
+        private double priority = 2;
 
         public Object userData;
 
@@ -323,7 +323,7 @@ public class Shipment extends AbstractJob {
          * @param priority
          * @return builder
          */
-        public Builder setPriority(int priority) {
+        public Builder setPriority(double priority) {
             if (priority < 1 || priority > 10)
                 throw new IllegalArgumentException("The priority value is not valid. Only 1 (very high) to 10 (very low) are allowed.");
             this.priority = priority;
@@ -364,7 +364,7 @@ public class Shipment extends AbstractJob {
 
     private final TimeWindowsImpl pickupTimeWindows;
 
-    private final int priority;
+    private final double priority;
 
     private final double maxTimeInVehicle;
 
@@ -505,14 +505,14 @@ public class Shipment extends AbstractJob {
     }
 
     /**
-     * Get priority of shipment. Only 1 = high priority, 2 = medium and 3 = low are allowed.
+     * Get priority of job. range (1 = high priority --> 10 = low priority) is allowed.
      * <p>
      * Default is 2 = medium.
      *
      * @return priority
      */
     @Override
-    public int getPriority() {
+    public double getPriority() {
         return priority;
     }
 

--- a/jsprit-core/src/test/java/com/graphhopper/jsprit/core/algorithm/recreate/TestComparator.java
+++ b/jsprit-core/src/test/java/com/graphhopper/jsprit/core/algorithm/recreate/TestComparator.java
@@ -51,7 +51,7 @@ public class TestComparator {
         Collections.sort(jobs, new Comparator<Job>() {
             @Override
             public int compare(Job o1, Job o2) {
-                return o1.getPriority() - o2.getPriority();
+                return Double.compare(o2.getPriority(), o1.getPriority());
             }
         });
 

--- a/jsprit-core/src/test/java/com/graphhopper/jsprit/core/problem/job/DeliveryTest.java
+++ b/jsprit-core/src/test/java/com/graphhopper/jsprit/core/problem/job/DeliveryTest.java
@@ -96,14 +96,14 @@ public class DeliveryTest {
     public void whenSettingPriorities_itShouldBeSetCorrectly(){
         Delivery s = Delivery.Builder.newInstance("s").setLocation(Location.newInstance("loc"))
             .setPriority(3).build();
-        Assert.assertEquals(3, s.getPriority());
+        Assert.assertEquals(3, s.getPriority(), 0);
     }
 
     @Test
     public void whenNotSettingPriorities_defaultShouldBe(){
         Delivery s = Delivery.Builder.newInstance("s").setLocation(Location.newInstance("loc"))
             .build();
-        Assert.assertEquals(2, s.getPriority());
+        Assert.assertEquals(2, s.getPriority(), 0);
     }
 
     @Test

--- a/jsprit-core/src/test/java/com/graphhopper/jsprit/core/problem/job/PickupTest.java
+++ b/jsprit-core/src/test/java/com/graphhopper/jsprit/core/problem/job/PickupTest.java
@@ -98,14 +98,14 @@ public class PickupTest {
     public void whenSettingPriorities_itShouldBeSetCorrectly(){
         Pickup s = Pickup.Builder.newInstance("s").setLocation(Location.newInstance("loc"))
             .setPriority(3).build();
-        Assert.assertEquals(3, s.getPriority());
+        Assert.assertEquals(3, s.getPriority(), 0);
     }
 
     @Test
     public void whenNotSettingPriorities_defaultShouldBe(){
         Pickup s = Pickup.Builder.newInstance("s").setLocation(Location.newInstance("loc"))
             .build();
-        Assert.assertEquals(2, s.getPriority());
+        Assert.assertEquals(2, s.getPriority(), 0);
     }
 
     @Test

--- a/jsprit-core/src/test/java/com/graphhopper/jsprit/core/problem/job/ServiceTest.java
+++ b/jsprit-core/src/test/java/com/graphhopper/jsprit/core/problem/job/ServiceTest.java
@@ -262,8 +262,8 @@ public class ServiceTest {
     @Test
     public void whenSettingPriorities_itShouldBeSetCorrectly4() {
         Service s = Service.Builder.newInstance("s").setLocation(Location.newInstance("loc"))
-                .setPriority(.5).build();
-        Assert.assertEquals(.5, s.getPriority(), 0);
+                .setPriority(1.5).build();
+        Assert.assertEquals(1.5, s.getPriority(), 0);
     }
 
     @Test

--- a/jsprit-core/src/test/java/com/graphhopper/jsprit/core/problem/job/ServiceTest.java
+++ b/jsprit-core/src/test/java/com/graphhopper/jsprit/core/problem/job/ServiceTest.java
@@ -242,28 +242,35 @@ public class ServiceTest {
     public void whenSettingPriorities_itShouldBeSetCorrectly(){
         Service s = Service.Builder.newInstance("s").setLocation(Location.newInstance("loc"))
             .setPriority(1).build();
-        Assert.assertEquals(1, s.getPriority());
+        Assert.assertEquals(1, s.getPriority(), 0);
     }
 
     @Test
     public void whenSettingPriorities_itShouldBeSetCorrectly2(){
         Service s = Service.Builder.newInstance("s").setLocation(Location.newInstance("loc"))
             .setPriority(3).build();
-        Assert.assertEquals(3, s.getPriority());
+        Assert.assertEquals(3, s.getPriority(), 0);
     }
 
     @Test
     public void whenSettingPriorities_itShouldBeSetCorrectly3() {
         Service s = Service.Builder.newInstance("s").setLocation(Location.newInstance("loc"))
-            .setPriority(10).build();
-        Assert.assertEquals(10, s.getPriority());
+                .setPriority(10).build();
+        Assert.assertEquals(10, s.getPriority(), 0);
+    }
+
+    @Test
+    public void whenSettingPriorities_itShouldBeSetCorrectly4() {
+        Service s = Service.Builder.newInstance("s").setLocation(Location.newInstance("loc"))
+                .setPriority(.5).build();
+        Assert.assertEquals(.5, s.getPriority(), 0);
     }
 
     @Test
     public void whenNotSettingPriorities_defaultShouldBe2(){
         Service s = Service.Builder.newInstance("s").setLocation(Location.newInstance("loc"))
             .build();
-        Assert.assertEquals(2, s.getPriority());
+        Assert.assertEquals(2, s.getPriority(), 0);
     }
 
     @Test(expected = IllegalArgumentException.class)

--- a/jsprit-core/src/test/java/com/graphhopper/jsprit/core/problem/job/ShipmentTest.java
+++ b/jsprit-core/src/test/java/com/graphhopper/jsprit/core/problem/job/ShipmentTest.java
@@ -393,7 +393,7 @@ public class ShipmentTest {
         Shipment s = Shipment.Builder.newInstance("s").setPickupLocation(Location.newInstance("loc"))
             .setDeliveryLocation(Location.newInstance("loc"))
             .setPriority(1).build();
-        Assert.assertEquals(1, s.getPriority());
+        Assert.assertEquals(1, s.getPriority(), 0);
     }
 
     @Test
@@ -401,7 +401,7 @@ public class ShipmentTest {
         Shipment s = Shipment.Builder.newInstance("s").setPickupLocation(Location.newInstance("loc"))
             .setDeliveryLocation(Location.newInstance("loc"))
             .setPriority(3).build();
-        Assert.assertEquals(3, s.getPriority());
+        Assert.assertEquals(3, s.getPriority(), 0);
     }
 
     @Test
@@ -409,7 +409,7 @@ public class ShipmentTest {
         Shipment s = Shipment.Builder.newInstance("s").setPickupLocation(Location.newInstance("loc"))
             .setDeliveryLocation(Location.newInstance("loc"))
             .setPriority(10).build();
-        Assert.assertEquals(10, s.getPriority());
+        Assert.assertEquals(10, s.getPriority(), 0);
     }
 
     @Test
@@ -417,7 +417,7 @@ public class ShipmentTest {
         Shipment s = Shipment.Builder.newInstance("s").setPickupLocation(Location.newInstance("loc"))
             .setDeliveryLocation(Location.newInstance("loc"))
             .build();
-        Assert.assertEquals(2, s.getPriority());
+        Assert.assertEquals(2, s.getPriority(), 0);
     }
 
     @Test(expected = IllegalArgumentException.class)


### PR DESCRIPTION
Changed job priorities to double instead of int; this will allow much higher flexibility in assignments.
For example, if there are 10 jobs (set A) that must be assigned and another 500 (set B) that should be assigned if possible, but job capacity is only 20, we want to ensure that set A jobs will be served. We can set priorities for set A jobs = 1.0001 and set B jobs = 10 (smaller value = higher priority). This way there is a much higher chance of all the set A jobs being served.

also updated comparators and tests. 