### PR TITLE
Updates job priority documentation

### DIFF
--- a/jsprit-core/src/main/java/com/graphhopper/jsprit/core/problem/job/Job.java
+++ b/jsprit-core/src/main/java/com/graphhopper/jsprit/core/problem/job/Job.java
@@ -55,9 +55,9 @@ public interface Job extends HasId, HasIndex {
     public String getName();
 
     /**
-     * Get priority of job. Only 1 = high priority, 2 = medium and 3 = low are allowed.
+     * Get priority of job. Only 1 (very high) to 10 (very low) are allowed.
      * <p>
-     * Default is 2 = medium.
+     * Default is 2.
      *
      * @return priority
      */


### PR DESCRIPTION
A docblock in the Job interface still refers to priority as being from 1 to 3.