### PR TITLE
fix a bug of getLargestTimeWindow() and add a function of  failing to take different time windows of different vehicle types into account.

### DIFF
--- a/jsprit-core/src/main/java/com/graphhopper/jsprit/core/algorithm/recreate/DefaultScorer.java
+++ b/jsprit-core/src/main/java/com/graphhopper/jsprit/core/algorithm/recreate/DefaultScorer.java
@@ -74,6 +74,11 @@ public class DefaultScorer implements ScoringFunction  {
             if (timeWindow == null) timeWindow = tw;
             else if (tw.larger(timeWindow)) timeWindow = tw;
         }
+        
+        if(timeWindow!=null){
+            return TimeWindow.newInstance(timeWindow.getStart(),timeWindow.getEnd());
+        }
+        
         return TimeWindow.newInstance(0, Double.MAX_VALUE);
     }
 


### PR DESCRIPTION
fix a bug of getLargestTimeWindow()
About method of getLargestTimeWindow() , it always returns a maximize time window, and it should be a bug. I have fixed it by adding a null check of timewindow variable.