### PR TITLE
added prevAct to actrivity Cost Function

### DIFF
--- a/jsprit-core/src/main/java/com/graphhopper/jsprit/core/algorithm/box/Jsprit.java
+++ b/jsprit-core/src/main/java/com/graphhopper/jsprit/core/algorithm/box/Jsprit.java
@@ -771,7 +771,7 @@ public class Jsprit {
                     for (TourActivity act : route.getActivities()) {
                         if (act instanceof BreakActivity) hasBreak = true;
                         costs += vrp.getTransportCosts().getTransportCost(prevAct.getLocation(), act.getLocation(), prevAct.getEndTime(), route.getDriver(), route.getVehicle());
-                        costs += vrp.getActivityCosts().getActivityCost(act, act.getArrTime(), route.getDriver(), route.getVehicle());
+                        costs += vrp.getActivityCosts().getActivityCost(act, act.getArrTime(), route.getDriver(), route.getVehicle(), prevAct);
                         prevAct = act;
                     }
                     costs += vrp.getTransportCosts().getTransportCost(prevAct.getLocation(), route.getEnd().getLocation(), prevAct.getEndTime(), route.getDriver(), route.getVehicle());

--- a/jsprit-core/src/main/java/com/graphhopper/jsprit/core/algorithm/recreate/AuxilliaryCostCalculator.java
+++ b/jsprit-core/src/main/java/com/graphhopper/jsprit/core/algorithm/recreate/AuxilliaryCostCalculator.java
@@ -68,8 +68,8 @@ final class AuxilliaryCostCalculator {
             double transportTime = routingCosts.getTransportTime(prevAct.getLocation(), act.getLocation(), departureTimePrevAct, driver, vehicle);
             cost += transportCost;
             double actStartTime = departureTimePrevAct + transportTime;
-            departureTimePrevAct = Math.max(actStartTime, act.getTheoreticalEarliestOperationStartTime()) + activityCosts.getActivityDuration(act,actStartTime,driver,vehicle);
-            cost += activityCosts.getActivityCost(act, actStartTime, driver, vehicle);
+            departureTimePrevAct = Math.max(actStartTime, act.getTheoreticalEarliestOperationStartTime()) + activityCosts.getActivityDuration(act,actStartTime,driver,vehicle, prevAct);
+            cost += activityCosts.getActivityCost(act, actStartTime, driver, vehicle, prevAct);
             prevAct = act;
         }
         return cost;

--- a/jsprit-core/src/main/java/com/graphhopper/jsprit/core/algorithm/recreate/BreakInsertionCalculator.java
+++ b/jsprit-core/src/main/java/com/graphhopper/jsprit/core/algorithm/recreate/BreakInsertionCalculator.java
@@ -163,7 +163,7 @@ final class BreakInsertionCalculator implements JobInsertionCostsCalculator {
                 }
             }
             double nextActArrTime = prevActStartTime + transportCosts.getTransportTime(prevAct.getLocation(), nextAct.getLocation(), prevActStartTime, newDriver, newVehicle);
-            prevActStartTime = Math.max(nextActArrTime, nextAct.getTheoreticalEarliestOperationStartTime()) + activityCosts.getActivityDuration(nextAct,nextActArrTime,newDriver,newVehicle);
+            prevActStartTime = Math.max(nextActArrTime, nextAct.getTheoreticalEarliestOperationStartTime()) + activityCosts.getActivityDuration(nextAct,nextActArrTime,newDriver,newVehicle, prevAct);
             prevAct = nextAct;
             actIndex++;
             if (breakThis) break;

--- a/jsprit-core/src/main/java/com/graphhopper/jsprit/core/algorithm/recreate/LocalActivityInsertionCostsCalculator.java
+++ b/jsprit-core/src/main/java/com/graphhopper/jsprit/core/algorithm/recreate/LocalActivityInsertionCostsCalculator.java
@@ -70,9 +70,9 @@ public class LocalActivityInsertionCostsCalculator implements ActivityInsertionC
         double tp_costs_prevAct_newAct = routingCosts.getTransportCost(prevLocation, newLocation, depTimeAtPrevAct, iFacts.getNewDriver(), iFacts.getNewVehicle());
         double tp_time_prevAct_newAct = routingCosts.getTransportTime(prevLocation, newLocation, depTimeAtPrevAct, iFacts.getNewDriver(), iFacts.getNewVehicle());
         double newAct_arrTime = depTimeAtPrevAct + tp_time_prevAct_newAct;
-        double newAct_endTime = Math.max(newAct_arrTime, newAct.getTheoreticalEarliestOperationStartTime()) + activityCosts.getActivityDuration(newAct, newAct_arrTime, iFacts.getNewDriver(), iFacts.getNewVehicle());
+        double newAct_endTime = Math.max(newAct_arrTime, newAct.getTheoreticalEarliestOperationStartTime()) + activityCosts.getActivityDuration(newAct, newAct_arrTime, iFacts.getNewDriver(), iFacts.getNewVehicle(), prevAct);
 
-        double act_costs_newAct = activityCosts.getActivityCost(newAct, newAct_arrTime, iFacts.getNewDriver(), iFacts.getNewVehicle());
+        double act_costs_newAct = activityCosts.getActivityCost(newAct, newAct_arrTime, iFacts.getNewDriver(), iFacts.getNewVehicle(), prevAct);
 
         if (isEnd(nextAct) && !toDepot(iFacts.getNewVehicle())) return tp_costs_prevAct_newAct + solutionCompletenessRatio * activityCostsWeight * act_costs_newAct;
 
@@ -80,8 +80,8 @@ public class LocalActivityInsertionCostsCalculator implements ActivityInsertionC
         double tp_costs_newAct_nextAct = routingCosts.getTransportCost(newLocation, nextLocation, newAct_endTime, iFacts.getNewDriver(), iFacts.getNewVehicle());
         double tp_time_newAct_nextAct = routingCosts.getTransportTime(newLocation, nextLocation, newAct_endTime, iFacts.getNewDriver(), iFacts.getNewVehicle());
         double nextAct_arrTime = newAct_endTime + tp_time_newAct_nextAct;
-        double endTime_nextAct_new = Math.max(nextAct_arrTime, nextAct.getTheoreticalEarliestOperationStartTime()) + activityCosts.getActivityDuration(nextAct, nextAct_arrTime, iFacts.getNewDriver(), iFacts.getNewVehicle());
-        double act_costs_nextAct = activityCosts.getActivityCost(nextAct, nextAct_arrTime, iFacts.getNewDriver(), iFacts.getNewVehicle());
+        double endTime_nextAct_new = Math.max(nextAct_arrTime, nextAct.getTheoreticalEarliestOperationStartTime()) + activityCosts.getActivityDuration(nextAct, nextAct_arrTime, iFacts.getNewDriver(), iFacts.getNewVehicle(), newAct);
+        double act_costs_nextAct = activityCosts.getActivityCost(nextAct, nextAct_arrTime, iFacts.getNewDriver(), iFacts.getNewVehicle(), newAct);
 
         double totalCosts = tp_costs_prevAct_newAct + tp_costs_newAct_nextAct + solutionCompletenessRatio * activityCostsWeight * (act_costs_newAct + act_costs_nextAct);
 
@@ -94,8 +94,8 @@ public class LocalActivityInsertionCostsCalculator implements ActivityInsertionC
         } else {
             double tp_costs_prevAct_nextAct = routingCosts.getTransportCost(prevLocation, nextLocation, prevAct.getEndTime(), iFacts.getRoute().getDriver(), iFacts.getRoute().getVehicle());
             double arrTime_nextAct = depTimeAtPrevAct + routingCosts.getTransportTime(prevLocation, nextLocation, prevAct.getEndTime(), iFacts.getRoute().getDriver(), iFacts.getRoute().getVehicle());
-            double endTime_nextAct_old = Math.max(arrTime_nextAct, nextAct.getTheoreticalEarliestOperationStartTime()) + activityCosts.getActivityDuration(nextAct, arrTime_nextAct, iFacts.getRoute().getDriver(),iFacts.getRoute().getVehicle());
-            double actCost_nextAct = activityCosts.getActivityCost(nextAct, arrTime_nextAct, iFacts.getRoute().getDriver(), iFacts.getRoute().getVehicle());
+            double endTime_nextAct_old = Math.max(arrTime_nextAct, nextAct.getTheoreticalEarliestOperationStartTime()) + activityCosts.getActivityDuration(nextAct, arrTime_nextAct, iFacts.getRoute().getDriver(),iFacts.getRoute().getVehicle(), prevAct);
+            double actCost_nextAct = activityCosts.getActivityCost(nextAct, arrTime_nextAct, iFacts.getRoute().getDriver(), iFacts.getRoute().getVehicle(), prevAct);
 
             double endTimeDelay_nextAct = Math.max(0, endTime_nextAct_new - endTime_nextAct_old);
             Double futureWaiting = stateManager.getActivityState(nextAct, iFacts.getRoute().getVehicle(), InternalStates.FUTURE_WAITING, Double.class);

--- a/jsprit-core/src/main/java/com/graphhopper/jsprit/core/algorithm/recreate/ServiceInsertionCalculator.java
+++ b/jsprit-core/src/main/java/com/graphhopper/jsprit/core/algorithm/recreate/ServiceInsertionCalculator.java
@@ -158,7 +158,7 @@ final class ServiceInsertionCalculator extends AbstractInsertionCalculator {
 			}
             if(not_fulfilled_break) break;
             double nextActArrTime = prevActStartTime + transportCosts.getTransportTime(prevAct.getLocation(), nextAct.getLocation(), prevActStartTime, newDriver, newVehicle);
-            prevActStartTime = Math.max(nextActArrTime, nextAct.getTheoreticalEarliestOperationStartTime()) + activityCosts.getActivityDuration(nextAct,nextActArrTime,newDriver,newVehicle);
+            prevActStartTime = Math.max(nextActArrTime, nextAct.getTheoreticalEarliestOperationStartTime()) + activityCosts.getActivityDuration(nextAct,nextActArrTime,newDriver,newVehicle, prevAct);
             prevAct = nextAct;
             actIndex++;
         }

--- a/jsprit-core/src/main/java/com/graphhopper/jsprit/core/algorithm/recreate/ServiceInsertionOnRouteLevelCalculator.java
+++ b/jsprit-core/src/main/java/com/graphhopper/jsprit/core/algorithm/recreate/ServiceInsertionOnRouteLevelCalculator.java
@@ -193,7 +193,7 @@ final class ServiceInsertionOnRouteLevelCalculator implements JobInsertionCostsC
             double transportCost_prevAct_nextAct_newVehicle = transportCosts.getTransportCost(prevAct.getLocation(), nextAct.getLocation(), prevActDepTime_newVehicle, newDriver, newVehicle);
             double transportTime_prevAct_nextAct_newVehicle = transportCosts.getTransportTime(prevAct.getLocation(), nextAct.getLocation(), prevActDepTime_newVehicle, newDriver, newVehicle);
             double arrTime_nextAct_newVehicle = prevActDepTime_newVehicle + transportTime_prevAct_nextAct_newVehicle;
-            double activityCost_nextAct = activityCosts.getActivityCost(nextAct, arrTime_nextAct_newVehicle, newDriver, newVehicle);
+            double activityCost_nextAct = activityCosts.getActivityCost(nextAct, arrTime_nextAct_newVehicle, newDriver, newVehicle, prevAct);
 
             /**
              * memorize transport and activity costs with new vehicle without inserting k
@@ -204,7 +204,7 @@ final class ServiceInsertionOnRouteLevelCalculator implements JobInsertionCostsC
             /**
              * departure time at nextAct with new vehicle
              */
-            double depTime_nextAct_newVehicle = Math.max(arrTime_nextAct_newVehicle, nextAct.getTheoreticalEarliestOperationStartTime()) + activityCosts.getActivityDuration(nextAct, arrTime_nextAct_newVehicle,newDriver,newVehicle);
+            double depTime_nextAct_newVehicle = Math.max(arrTime_nextAct_newVehicle, nextAct.getTheoreticalEarliestOperationStartTime()) + activityCosts.getActivityDuration(nextAct, arrTime_nextAct_newVehicle,newDriver,newVehicle, prevAct);
 
             /**
              * set previous to next

--- a/jsprit-core/src/main/java/com/graphhopper/jsprit/core/algorithm/recreate/ShipmentInsertionCalculator.java
+++ b/jsprit-core/src/main/java/com/graphhopper/jsprit/core/algorithm/recreate/ShipmentInsertionCalculator.java
@@ -161,7 +161,7 @@ final class ShipmentInsertionCalculator extends AbstractInsertionCalculator {
 
                 TourActivity prevAct_deliveryLoop = pickupShipment;
                 double shipmentPickupArrTime = prevActEndTime + transportCosts.getTransportTime(prevAct.getLocation(), pickupShipment.getLocation(), prevActEndTime, newDriver, newVehicle);
-                double shipmentPickupEndTime = Math.max(shipmentPickupArrTime, pickupShipment.getTheoreticalEarliestOperationStartTime()) + activityCosts.getActivityDuration(pickupShipment, shipmentPickupArrTime, newDriver, newVehicle);
+                double shipmentPickupEndTime = Math.max(shipmentPickupArrTime, pickupShipment.getTheoreticalEarliestOperationStartTime()) + activityCosts.getActivityDuration(pickupShipment, shipmentPickupArrTime, newDriver, newVehicle, prevAct);
 
                 pickupContext.setArrivalTime(shipmentPickupArrTime);
                 pickupContext.setEndTime(shipmentPickupEndTime);
@@ -217,7 +217,7 @@ final class ShipmentInsertionCalculator extends AbstractInsertionCalculator {
                     if (deliveryInsertionNotFulfilledBreak) break;
                     //update prevAct and endTime
                     double nextActArrTime = prevActEndTime_deliveryLoop + transportCosts.getTransportTime(prevAct_deliveryLoop.getLocation(), nextAct_deliveryLoop.getLocation(), prevActEndTime_deliveryLoop, newDriver, newVehicle);
-                    prevActEndTime_deliveryLoop = Math.max(nextActArrTime, nextAct_deliveryLoop.getTheoreticalEarliestOperationStartTime()) + activityCosts.getActivityDuration(nextAct_deliveryLoop,nextActArrTime,newDriver,newVehicle);
+                    prevActEndTime_deliveryLoop = Math.max(nextActArrTime, nextAct_deliveryLoop.getTheoreticalEarliestOperationStartTime()) + activityCosts.getActivityDuration(nextAct_deliveryLoop,nextActArrTime,newDriver,newVehicle, prevAct_deliveryLoop);
                     prevAct_deliveryLoop = nextAct_deliveryLoop;
                     j++;
                 }
@@ -227,7 +227,7 @@ final class ShipmentInsertionCalculator extends AbstractInsertionCalculator {
             }
             //update prevAct and endTime
             double nextActArrTime = prevActEndTime + transportCosts.getTransportTime(prevAct.getLocation(), nextAct.getLocation(), prevActEndTime, newDriver, newVehicle);
-            prevActEndTime = Math.max(nextActArrTime, nextAct.getTheoreticalEarliestOperationStartTime()) + activityCosts.getActivityDuration(nextAct,nextActArrTime,newDriver,newVehicle);
+            prevActEndTime = Math.max(nextActArrTime, nextAct.getTheoreticalEarliestOperationStartTime()) + activityCosts.getActivityDuration(nextAct,nextActArrTime,newDriver,newVehicle, prevAct);
             prevAct = nextAct;
             i++;
         }

--- a/jsprit-core/src/main/java/com/graphhopper/jsprit/core/algorithm/recreate/ShipmentInsertionCalculatorFlex.java
+++ b/jsprit-core/src/main/java/com/graphhopper/jsprit/core/algorithm/recreate/ShipmentInsertionCalculatorFlex.java
@@ -178,7 +178,7 @@ public final class ShipmentInsertionCalculatorFlex extends AbstractInsertionCalc
                     double pickupAIC = calculate(insertionContext, prevAct, pickupShipment, nextAct, prevActEndTime);
 
                     double shipmentPickupArrTime = prevActEndTime + transportCosts.getTransportTime(prevAct.getLocation(), pickupShipment.getLocation(), prevActEndTime, newDriver, newVehicle);
-                    double shipmentPickupEndTime = Math.max(shipmentPickupArrTime, pickupShipment.getTheoreticalEarliestOperationStartTime()) + activityCosts.getActivityDuration(pickupShipment, shipmentPickupArrTime, newDriver, newVehicle);
+                    double shipmentPickupEndTime = Math.max(shipmentPickupArrTime, pickupShipment.getTheoreticalEarliestOperationStartTime()) + activityCosts.getActivityDuration(pickupShipment, shipmentPickupArrTime, newDriver, newVehicle, prevAct);
 
                     pickupContext.setArrivalTime(shipmentPickupArrTime);
                     pickupContext.setEndTime(shipmentPickupEndTime);
@@ -238,7 +238,7 @@ public final class ShipmentInsertionCalculatorFlex extends AbstractInsertionCalc
                         }
                         //update prevAct and endTime
                         double nextActArrTime = prevActEndTimeForDeliveryLoop + transportCosts.getTransportTime(prevActForDeliveryLoop.getLocation(), nextActForDeliveryLoop.getLocation(), prevActEndTimeForDeliveryLoop, newDriver, newVehicle);
-                        prevActEndTimeForDeliveryLoop = Math.max(nextActArrTime, nextActForDeliveryLoop.getTheoreticalEarliestOperationStartTime()) + activityCosts.getActivityDuration(nextActForDeliveryLoop, nextActArrTime, newDriver, newVehicle);
+                        prevActEndTimeForDeliveryLoop = Math.max(nextActArrTime, nextActForDeliveryLoop.getTheoreticalEarliestOperationStartTime()) + activityCosts.getActivityDuration(nextActForDeliveryLoop, nextActArrTime, newDriver, newVehicle, prevActForDeliveryLoop);
                         prevActForDeliveryLoop = nextActForDeliveryLoop;
                         j++;
                     }
@@ -250,7 +250,7 @@ public final class ShipmentInsertionCalculatorFlex extends AbstractInsertionCalc
 
             //update prevAct and endTime
             double nextActArrTime = prevActEndTime + transportCosts.getTransportTime(prevAct.getLocation(), nextAct.getLocation(), prevActEndTime, newDriver, newVehicle);
-            prevActEndTime = Math.max(nextActArrTime, nextAct.getTheoreticalEarliestOperationStartTime()) + activityCosts.getActivityDuration(nextAct, nextActArrTime, newDriver, newVehicle);
+            prevActEndTime = Math.max(nextActArrTime, nextAct.getTheoreticalEarliestOperationStartTime()) + activityCosts.getActivityDuration(nextAct, nextActArrTime, newDriver, newVehicle, prevAct);
             prevAct = nextAct;
             i++;
         }

--- a/jsprit-core/src/main/java/com/graphhopper/jsprit/core/algorithm/recreate/VariableTransportCostCalculator.java
+++ b/jsprit-core/src/main/java/com/graphhopper/jsprit/core/algorithm/recreate/VariableTransportCostCalculator.java
@@ -42,7 +42,7 @@ public class VariableTransportCostCalculator implements SoftActivityConstraint {
         double tp_time_prevAct_newAct = routingCosts.getTransportTime(prevAct.getLocation(), newAct.getLocation(), depTimeAtPrevAct, iFacts.getNewDriver(), iFacts.getNewVehicle());
 
         double newAct_arrTime = depTimeAtPrevAct + tp_time_prevAct_newAct;
-        double newAct_endTime = Math.max(newAct_arrTime, newAct.getTheoreticalEarliestOperationStartTime()) + activityCosts.getActivityDuration(newAct,newAct_arrTime,iFacts.getNewDriver(),iFacts.getNewVehicle());
+        double newAct_endTime = Math.max(newAct_arrTime, newAct.getTheoreticalEarliestOperationStartTime()) + activityCosts.getActivityDuration(newAct,newAct_arrTime,iFacts.getNewDriver(),iFacts.getNewVehicle(), prevAct);
 
         //open routes
         if (nextAct instanceof End) {

--- a/jsprit-core/src/main/java/com/graphhopper/jsprit/core/algorithm/state/UpdateMaxTimeInVehicle.java
+++ b/jsprit-core/src/main/java/com/graphhopper/jsprit/core/algorithm/state/UpdateMaxTimeInVehicle.java
@@ -41,6 +41,8 @@ public class UpdateMaxTimeInVehicle implements StateUpdater, ActivityVisitor{
 
     private VehicleRoute route;
 
+    private TourActivity prevAct;
+
     private final StateManager stateManager;
 
     private final StateId minSlackId;
@@ -103,7 +105,7 @@ public class UpdateMaxTimeInVehicle implements StateUpdater, ActivityVisitor{
             double activityArrival = prevActEndTimes[v.getVehicleTypeIdentifier().getIndex()] + transportTime.getTransportTime(prevActLocation,activity.getLocation(),prevActEndTime,route.getDriver(),v);
             double activityStart = Math.max(activityArrival,activity.getTheoreticalEarliestOperationStartTime());
             memorizeActStart(activity,v,activityStart);
-            double activityEnd = activityStart + activityCosts.getActivityDuration(activity, activityArrival, route.getDriver(), v);
+            double activityEnd = activityStart + activityCosts.getActivityDuration(activity, activityArrival, route.getDriver(), v, prevAct);
             Map<Job, Double> openPickups = openPickupEndTimesPerVehicle.get(vehicleIndex);
             if (activity instanceof ServiceActivity || activity instanceof PickupActivity) {
                 openPickups.put(((TourActivity.JobActivity) activity).getJob(), activityEnd);
@@ -119,6 +121,7 @@ public class UpdateMaxTimeInVehicle implements StateUpdater, ActivityVisitor{
             }
             prevActLocations[vehicleIndex] = activity.getLocation();
             prevActEndTimes[vehicleIndex] = activityEnd;
+            prevAct = activity;
         }
 
     }

--- a/jsprit-core/src/main/java/com/graphhopper/jsprit/core/algorithm/state/UpdatePracticalTimeWindows.java
+++ b/jsprit-core/src/main/java/com/graphhopper/jsprit/core/algorithm/state/UpdatePracticalTimeWindows.java
@@ -58,7 +58,7 @@ class UpdatePracticalTimeWindows implements ReverseActivityVisitor, StateUpdater
 
     @Override
     public void visit(TourActivity activity) {
-        double potentialLatestArrivalTimeAtCurrAct = latestArrTimeAtPrevAct - transportCosts.getBackwardTransportTime(activity.getLocation(), prevAct.getLocation(), latestArrTimeAtPrevAct, route.getDriver(), route.getVehicle()) - activityCosts.getActivityDuration(activity,latestArrTimeAtPrevAct,route.getDriver(),route.getVehicle());
+        double potentialLatestArrivalTimeAtCurrAct = latestArrTimeAtPrevAct - transportCosts.getBackwardTransportTime(activity.getLocation(), prevAct.getLocation(), latestArrTimeAtPrevAct, route.getDriver(), route.getVehicle()) - activityCosts.getActivityDuration(activity,latestArrTimeAtPrevAct,route.getDriver(),route.getVehicle(), prevAct);
         double latestArrivalTime = Math.min(activity.getTheoreticalLatestOperationStartTime(), potentialLatestArrivalTimeAtCurrAct);
 
         states.putInternalTypedActivityState(activity, InternalStates.LATEST_OPERATION_START_TIME, latestArrivalTime);

--- a/jsprit-core/src/main/java/com/graphhopper/jsprit/core/algorithm/state/UpdateVariableCosts.java
+++ b/jsprit-core/src/main/java/com/graphhopper/jsprit/core/algorithm/state/UpdateVariableCosts.java
@@ -88,7 +88,7 @@ public class UpdateVariableCosts implements ActivityVisitor, StateUpdater {
         timeTracker.visit(act);
 
         double transportCost = this.transportCost.getTransportCost(prevAct.getLocation(), act.getLocation(), startTimeAtPrevAct, vehicleRoute.getDriver(), vehicleRoute.getVehicle());
-        double actCost = activityCost.getActivityCost(act, timeTracker.getActArrTime(), vehicleRoute.getDriver(), vehicleRoute.getVehicle());
+        double actCost = activityCost.getActivityCost(act, timeTracker.getActArrTime(), vehicleRoute.getDriver(), vehicleRoute.getVehicle(), prevAct);
 
         totalOperationCost += transportCost;
         totalOperationCost += actCost;
@@ -103,7 +103,7 @@ public class UpdateVariableCosts implements ActivityVisitor, StateUpdater {
     public void finish() {
         timeTracker.finish();
         double transportCost = this.transportCost.getTransportCost(prevAct.getLocation(), vehicleRoute.getEnd().getLocation(), startTimeAtPrevAct, vehicleRoute.getDriver(), vehicleRoute.getVehicle());
-        double actCost = activityCost.getActivityCost(vehicleRoute.getEnd(), timeTracker.getActEndTime(), vehicleRoute.getDriver(), vehicleRoute.getVehicle());
+        double actCost = activityCost.getActivityCost(vehicleRoute.getEnd(), timeTracker.getActEndTime(), vehicleRoute.getDriver(), vehicleRoute.getVehicle(), prevAct);
 
         totalOperationCost += transportCost;
         totalOperationCost += actCost;

--- a/jsprit-core/src/main/java/com/graphhopper/jsprit/core/algorithm/state/UpdateVehicleDependentPracticalTimeWindows.java
+++ b/jsprit-core/src/main/java/com/graphhopper/jsprit/core/algorithm/state/UpdateVehicleDependentPracticalTimeWindows.java
@@ -58,6 +58,8 @@ public class UpdateVehicleDependentPracticalTimeWindows implements RouteVisitor,
 
     private VehicleRoute route;
 
+    private TourActivity prevAct;
+
     private double[] latest_arrTimes_at_prevAct;
 
     private Location[] location_of_prevAct;
@@ -97,7 +99,7 @@ public class UpdateVehicleDependentPracticalTimeWindows implements RouteVisitor,
             double latestArrTimeAtPrevAct = latest_arrTimes_at_prevAct[vehicle.getVehicleTypeIdentifier().getIndex()];
             Location prevLocation = location_of_prevAct[vehicle.getVehicleTypeIdentifier().getIndex()];
             double potentialLatestArrivalTimeAtCurrAct = latestArrTimeAtPrevAct - transportCosts.getBackwardTransportTime(activity.getLocation(), prevLocation,
-                latestArrTimeAtPrevAct, route.getDriver(), vehicle) - activityCosts.getActivityDuration(activity, latestArrTimeAtPrevAct, route.getDriver(), route.getVehicle());
+                latestArrTimeAtPrevAct, route.getDriver(), vehicle) - activityCosts.getActivityDuration(activity, latestArrTimeAtPrevAct, route.getDriver(), route.getVehicle(), prevAct);
             double latestArrivalTime = Math.min(activity.getTheoreticalLatestOperationStartTime(), potentialLatestArrivalTimeAtCurrAct);
             if (latestArrivalTime < activity.getTheoreticalEarliestOperationStartTime()) {
                 stateManager.putTypedInternalRouteState(route, vehicle, InternalStates.SWITCH_NOT_FEASIBLE, true);
@@ -105,6 +107,7 @@ public class UpdateVehicleDependentPracticalTimeWindows implements RouteVisitor,
             stateManager.putInternalTypedActivityState(activity, vehicle, InternalStates.LATEST_OPERATION_START_TIME, latestArrivalTime);
             latest_arrTimes_at_prevAct[vehicle.getVehicleTypeIdentifier().getIndex()] = latestArrivalTime;
             location_of_prevAct[vehicle.getVehicleTypeIdentifier().getIndex()] = activity.getLocation();
+            prevAct = activity;
         }
     }
 

--- a/jsprit-core/src/main/java/com/graphhopper/jsprit/core/analysis/SolutionAnalyser.java
+++ b/jsprit-core/src/main/java/com/graphhopper/jsprit/core/analysis/SolutionAnalyser.java
@@ -231,6 +231,8 @@ public class SolutionAnalyser {
 
         private VehicleRoute route;
 
+        private TourActivity prevAct;
+
         double sum_waiting_time = 0.;
 
         double sum_transport_time = 0.;
@@ -277,9 +279,10 @@ public class SolutionAnalyser {
             sum_transport_time += transportTime;
             prevActDeparture = activity.getEndTime();
             //service time
-            sum_service_time += activityCosts.getActivityDuration(activity, activity.getArrTime(), route.getDriver(), route.getVehicle());
+            sum_service_time += activityCosts.getActivityDuration(activity, activity.getArrTime(), route.getDriver(), route.getVehicle(), prevAct);
 
             stateManager.putActivityState(activity, transport_time_id, sum_transport_time);
+            prevAct = activity;
 
         }
 

--- a/jsprit-core/src/main/java/com/graphhopper/jsprit/core/problem/constraint/AdditionalTransportationCosts.java
+++ b/jsprit-core/src/main/java/com/graphhopper/jsprit/core/problem/constraint/AdditionalTransportationCosts.java
@@ -61,7 +61,7 @@ class AdditionalTransportationCosts implements SoftActivityConstraint {
         double tp_time_prevAct_newAct = routingCosts.getTransportTime(prevAct.getLocation(), newAct.getLocation(), depTimeAtPrevAct, iFacts.getNewDriver(), iFacts.getNewVehicle());
 
         double newAct_arrTime = depTimeAtPrevAct + tp_time_prevAct_newAct;
-        double newAct_endTime = Math.max(newAct_arrTime, newAct.getTheoreticalEarliestOperationStartTime()) + activityCosts.getActivityDuration(newAct,newAct_arrTime,iFacts.getNewDriver(),iFacts.getNewVehicle());
+        double newAct_endTime = Math.max(newAct_arrTime, newAct.getTheoreticalEarliestOperationStartTime()) + activityCosts.getActivityDuration(newAct,newAct_arrTime,iFacts.getNewDriver(),iFacts.getNewVehicle(), prevAct);
 
         //open routes
         if (nextAct instanceof End) {

--- a/jsprit-core/src/main/java/com/graphhopper/jsprit/core/problem/constraint/MaxTimeInVehicleConstraint.java
+++ b/jsprit-core/src/main/java/com/graphhopper/jsprit/core/problem/constraint/MaxTimeInVehicleConstraint.java
@@ -72,7 +72,7 @@ public class MaxTimeInVehicleConstraint implements HardActivityConstraint {
         //************ 1. check whether insertion of new shipment satisfies own max-in-vehicle-constraint
         double newActArrival = prevActDepTime + transportTime.getTransportTime(prevAct.getLocation(),newAct.getLocation(),prevActDepTime,iFacts.getNewDriver(),iFacts.getNewVehicle());
         double newActStart = Math.max(newActArrival, newAct.getTheoreticalEarliestOperationStartTime());
-        double newActDeparture = newActStart + activityCosts.getActivityDuration(newAct, newActArrival, iFacts.getNewDriver(), iFacts.getNewVehicle());
+        double newActDeparture = newActStart + activityCosts.getActivityDuration(newAct, newActArrival, iFacts.getNewDriver(), iFacts.getNewVehicle(), prevAct);
         double nextActArrival = newActDeparture + transportTime.getTransportTime(newAct.getLocation(),nextAct.getLocation(),newActDeparture,iFacts.getNewDriver(),iFacts.getNewVehicle());
         double nextActStart = Math.max(nextActArrival,nextAct.getTheoreticalEarliestOperationStartTime());
         if(newAct instanceof DeliveryActivity){
@@ -92,7 +92,7 @@ public class MaxTimeInVehicleConstraint implements HardActivityConstraint {
             if(iFacts.getAssociatedActivities().size() == 1){
                 double maxTimeInVehicle = ((TourActivity.JobActivity)newAct).getJob().getMaxTimeInVehicle();
                 //ToDo - estimate in vehicle time of pickups here - This seems to trickier than I thought
-                double nextActDeparture = nextActStart + activityCosts.getActivityDuration(nextAct, nextActArrival, iFacts.getNewDriver(), iFacts.getNewVehicle());
+                double nextActDeparture = nextActStart + activityCosts.getActivityDuration(nextAct, nextActArrival, iFacts.getNewDriver(), iFacts.getNewVehicle(), newAct);
 //                if(!nextAct instanceof End)
                 double timeToEnd = 0; //newAct.end + tt(newAct,nextAct) + t@nextAct + t_to_end
                 if(timeToEnd > maxTimeInVehicle) return ConstraintsStatus.NOT_FULFILLED;
@@ -133,7 +133,7 @@ public class MaxTimeInVehicleConstraint implements HardActivityConstraint {
                     if (openJobsAtNextOfPickup.containsKey(openJob)) {
                         TourActivity pickupAct = iFacts.getAssociatedActivities().get(0);
                         double pickupActArrTime = iFacts.getRelatedActivityContext().getArrivalTime();
-                        double pickupActEndTime = startOf(pickupAct, pickupActArrTime) + activityCosts.getActivityDuration(pickupAct, pickupActArrTime, iFacts.getNewDriver(), iFacts.getNewVehicle());
+                        double pickupActEndTime = startOf(pickupAct, pickupActArrTime) + activityCosts.getActivityDuration(pickupAct, pickupActArrTime, iFacts.getNewDriver(), iFacts.getNewVehicle(), nextAfterPickup);
                         double nextAfterPickupArr = pickupActEndTime + transportTime.getTransportTime(pickupAct.getLocation(), nextAfterPickup.getLocation(), pickupActArrTime, iFacts.getNewDriver(), iFacts.getNewVehicle());
                         additionalTimeOfNewJob += startOf(nextAfterPickup, nextAfterPickupArr) - startOf(nextAfterPickup, nextAfterPickup.getArrTime());
                     }

--- a/jsprit-core/src/main/java/com/graphhopper/jsprit/core/problem/constraint/VehicleDependentTimeWindowConstraints.java
+++ b/jsprit-core/src/main/java/com/graphhopper/jsprit/core/problem/constraint/VehicleDependentTimeWindowConstraints.java
@@ -116,12 +116,12 @@ public class VehicleDependentTimeWindowConstraints implements HardActivityConstr
         }
         //			log.info("check insertion of " + newAct + " between " + prevAct + " and " + nextAct + ". prevActDepTime=" + prevActDepTime);
         double arrTimeAtNewAct = prevActDepTime + routingCosts.getTransportTime(prevLocation, newLocation, prevActDepTime, iFacts.getNewDriver(), iFacts.getNewVehicle());
-        double endTimeAtNewAct = Math.max(arrTimeAtNewAct, newAct.getTheoreticalEarliestOperationStartTime()) + activityCosts.getActivityDuration(newAct, arrTimeAtNewAct,iFacts.getNewDriver(),iFacts.getNewVehicle());
+        double endTimeAtNewAct = Math.max(arrTimeAtNewAct, newAct.getTheoreticalEarliestOperationStartTime()) + activityCosts.getActivityDuration(newAct, arrTimeAtNewAct,iFacts.getNewDriver(),iFacts.getNewVehicle(), prevAct);
         double latestArrTimeAtNewAct =
             Math.min(newAct.getTheoreticalLatestOperationStartTime(),
                 latestArrTimeAtNextAct -
                     routingCosts.getBackwardTransportTime(newLocation, nextLocation, latestArrTimeAtNextAct, iFacts.getNewDriver(), iFacts.getNewVehicle())
-                    - activityCosts.getActivityDuration(newAct, arrTimeAtNewAct, iFacts.getNewDriver(), iFacts.getNewVehicle())
+                    - activityCosts.getActivityDuration(newAct, arrTimeAtNewAct, iFacts.getNewDriver(), iFacts.getNewVehicle(), prevAct)
             );
 
 			/*

--- a/jsprit-core/src/main/java/com/graphhopper/jsprit/core/problem/cost/VehicleRoutingActivityCosts.java
+++ b/jsprit-core/src/main/java/com/graphhopper/jsprit/core/problem/cost/VehicleRoutingActivityCosts.java
@@ -57,8 +57,8 @@ public interface VehicleRoutingActivityCosts {
      * @param vehicle     if earliestStartTime > latestStartTime activity operations cannot be conducted within the given time-window.
      * @return
      */
-    public double getActivityCost(TourActivity tourAct, double arrivalTime, Driver driver, Vehicle vehicle);
+    public double getActivityCost(TourActivity tourAct, double arrivalTime, Driver driver, Vehicle vehicle, TourActivity prevAct);
 
-    public double getActivityDuration(TourActivity tourAct, double arrivalTime, Driver driver, Vehicle vehicle);
+    public double getActivityDuration(TourActivity tourAct, double arrivalTime, Driver driver, Vehicle vehicle, TourActivity prevAct);
 
 }

--- a/jsprit-core/src/main/java/com/graphhopper/jsprit/core/problem/cost/WaitingTimeCosts.java
+++ b/jsprit-core/src/main/java/com/graphhopper/jsprit/core/problem/cost/WaitingTimeCosts.java
@@ -28,17 +28,17 @@ import com.graphhopper.jsprit.core.problem.vehicle.Vehicle;
 public class WaitingTimeCosts implements VehicleRoutingActivityCosts {
 
     @Override
-    public double getActivityCost(TourActivity tourAct, double arrivalTime, Driver driver, Vehicle vehicle) {
+    public double getActivityCost(TourActivity tourAct, double arrivalTime, Driver driver, Vehicle vehicle, TourActivity prevAct) {
         if (vehicle != null) {
             double waiting = vehicle.getType().getVehicleCostParams().perWaitingTimeUnit * Math.max(0., tourAct.getTheoreticalEarliestOperationStartTime() - arrivalTime);
-            double servicing = vehicle.getType().getVehicleCostParams().perServiceTimeUnit * getActivityDuration(tourAct,arrivalTime,driver,vehicle);
+            double servicing = vehicle.getType().getVehicleCostParams().perServiceTimeUnit * getActivityDuration(tourAct,arrivalTime,driver,vehicle, prevAct);
             return waiting + servicing;
         }
         return 0;
     }
 
     @Override
-    public double getActivityDuration(TourActivity tourAct, double arrivalTime, Driver driver, Vehicle vehicle) {
+    public double getActivityDuration(TourActivity tourAct, double arrivalTime, Driver driver, Vehicle vehicle, TourActivity prevAct) {
         return tourAct.getOperationTime();
     }
 

--- a/jsprit-core/src/main/java/com/graphhopper/jsprit/core/reporting/SolutionPrinter.java
+++ b/jsprit-core/src/main/java/com/graphhopper/jsprit/core/reporting/SolutionPrinter.java
@@ -171,7 +171,7 @@ public class SolutionPrinter {
                 }
                 double c = problem.getTransportCosts().getTransportCost(prevAct.getLocation(), act.getLocation(), prevAct.getEndTime(), route.getDriver(),
                     route.getVehicle());
-                c += problem.getActivityCosts().getActivityCost(act, act.getArrTime(), route.getDriver(), route.getVehicle());
+                c += problem.getActivityCosts().getActivityCost(act, act.getArrTime(), route.getDriver(), route.getVehicle(), prevAct);
                 costs += c;
                 out.format(leftAlgin, routeNu, getVehicleString(route), act.getName(), jobId, Math.round(act.getArrTime()),
                     Math.round(act.getEndTime()), Math.round(costs));
@@ -179,7 +179,7 @@ public class SolutionPrinter {
             }
             double c = problem.getTransportCosts().getTransportCost(prevAct.getLocation(), route.getEnd().getLocation(), prevAct.getEndTime(),
                 route.getDriver(), route.getVehicle());
-            c += problem.getActivityCosts().getActivityCost(route.getEnd(), route.getEnd().getArrTime(), route.getDriver(), route.getVehicle());
+            c += problem.getActivityCosts().getActivityCost(route.getEnd(), route.getEnd().getArrTime(), route.getDriver(), route.getVehicle(), prevAct);
             costs += c;
             out.format(leftAlgin, routeNu, getVehicleString(route), route.getEnd().getName(), "-", Math.round(route.getEnd().getArrTime()), "undef",
                 Math.round(costs));

--- a/jsprit-core/src/main/java/com/graphhopper/jsprit/core/util/ActivityTimeTracker.java
+++ b/jsprit-core/src/main/java/com/graphhopper/jsprit/core/util/ActivityTimeTracker.java
@@ -94,7 +94,7 @@ public class ActivityTimeTracker implements ActivityVisitor {
             operationStartTime = actArrTime;
         } else operationStartTime = actArrTime;
 
-        double operationEndTime = operationStartTime + activityCosts.getActivityDuration(activity,actArrTime,route.getDriver(),route.getVehicle());
+        double operationEndTime = operationStartTime + activityCosts.getActivityDuration(activity,actArrTime,route.getDriver(),route.getVehicle(), prevAct);
 
         actEndTime = operationEndTime;
 

--- a/jsprit-core/src/test/java/com/graphhopper/jsprit/core/algorithm/ExampleActivityCostFunction.java
+++ b/jsprit-core/src/test/java/com/graphhopper/jsprit/core/algorithm/ExampleActivityCostFunction.java
@@ -35,12 +35,12 @@ public class ExampleActivityCostFunction implements VehicleRoutingActivityCosts 
 
 
     @Override
-    public double getActivityCost(TourActivity tourAct, double arrivalTime, Driver driver, Vehicle vehicle) {
+    public double getActivityCost(TourActivity tourAct, double arrivalTime, Driver driver, Vehicle vehicle, TourActivity prevAct) {
         if (arrivalTime == Time.TOURSTART || arrivalTime == Time.UNDEFINED) {
             return 0.0;
         } else {
             //waiting + act-time
-            double endTime = Math.max(arrivalTime, tourAct.getTheoreticalEarliestOperationStartTime()) + getActivityDuration(tourAct,arrivalTime,driver,vehicle);
+            double endTime = Math.max(arrivalTime, tourAct.getTheoreticalEarliestOperationStartTime()) + getActivityDuration(tourAct,arrivalTime,driver,vehicle, prevAct);
             double timeAtAct = endTime - arrivalTime;
 
             double totalCost = timeAtAct * parameter_timeAtAct;
@@ -58,7 +58,7 @@ public class ExampleActivityCostFunction implements VehicleRoutingActivityCosts 
     }
 
     @Override
-    public double getActivityDuration(TourActivity tourAct, double arrivalTime, Driver driver, Vehicle vehicle) {
+    public double getActivityDuration(TourActivity tourAct, double arrivalTime, Driver driver, Vehicle vehicle, TourActivity prevAct) {
         return tourAct.getOperationTime();
     }
 

--- a/jsprit-core/src/test/java/com/graphhopper/jsprit/core/algorithm/VariableDepartureAndWaitingTime_IT.java
+++ b/jsprit-core/src/test/java/com/graphhopper/jsprit/core/algorithm/VariableDepartureAndWaitingTime_IT.java
@@ -59,12 +59,12 @@ public class VariableDepartureAndWaitingTime_IT {
         activityCosts = new VehicleRoutingActivityCosts() {
 
             @Override
-            public double getActivityCost(TourActivity tourAct, double arrivalTime, Driver driver, Vehicle vehicle) {
+            public double getActivityCost(TourActivity tourAct, double arrivalTime, Driver driver, Vehicle vehicle, TourActivity prevAct) {
                 return vehicle.getType().getVehicleCostParams().perWaitingTimeUnit * Math.max(0, tourAct.getTheoreticalEarliestOperationStartTime() - arrivalTime);
             }
 
             @Override
-            public double getActivityDuration(TourActivity tourAct, double arrivalTime, Driver driver, Vehicle vehicle) {
+            public double getActivityDuration(TourActivity tourAct, double arrivalTime, Driver driver, Vehicle vehicle, TourActivity prevAct) {
                 return tourAct.getOperationTime();
             }
 

--- a/jsprit-core/src/test/java/com/graphhopper/jsprit/core/algorithm/recreate/ServiceInsertionAndLoadConstraintsTest.java
+++ b/jsprit-core/src/test/java/com/graphhopper/jsprit/core/algorithm/recreate/ServiceInsertionAndLoadConstraintsTest.java
@@ -60,12 +60,12 @@ public class ServiceInsertionAndLoadConstraintsTest {
     VehicleRoutingActivityCosts activityCosts = new VehicleRoutingActivityCosts() {
 
         @Override
-        public double getActivityCost(TourActivity tourAct, double arrivalTime, Driver driver, Vehicle vehicle) {
+        public double getActivityCost(TourActivity tourAct, double arrivalTime, Driver driver, Vehicle vehicle, TourActivity prevAct) {
             return 0;
         }
 
         @Override
-        public double getActivityDuration(TourActivity tourAct, double arrivalTime, Driver driver, Vehicle vehicle) {
+        public double getActivityDuration(TourActivity tourAct, double arrivalTime, Driver driver, Vehicle vehicle, TourActivity prevAct) {
             return tourAct.getOperationTime();
         }
 

--- a/jsprit-core/src/test/java/com/graphhopper/jsprit/core/algorithm/recreate/ShipmentInsertionCalculatorFlexTest.java
+++ b/jsprit-core/src/test/java/com/graphhopper/jsprit/core/algorithm/recreate/ShipmentInsertionCalculatorFlexTest.java
@@ -69,12 +69,12 @@ public class ShipmentInsertionCalculatorFlexTest {
     VehicleRoutingActivityCosts activityCosts = new VehicleRoutingActivityCosts() {
 
         @Override
-        public double getActivityCost(TourActivity tourAct, double arrivalTime, Driver driver, Vehicle vehicle) {
+        public double getActivityCost(TourActivity tourAct, double arrivalTime, Driver driver, Vehicle vehicle, TourActivity prevAct) {
             return 0;
         }
 
         @Override
-        public double getActivityDuration(TourActivity tourAct, double arrivalTime, Driver driver, Vehicle vehicle) {
+        public double getActivityDuration(TourActivity tourAct, double arrivalTime, Driver driver, Vehicle vehicle, TourActivity prevAct) {
             return tourAct.getOperationTime();
         }
 

--- a/jsprit-core/src/test/java/com/graphhopper/jsprit/core/algorithm/recreate/ShipmentInsertionCalculatorTest.java
+++ b/jsprit-core/src/test/java/com/graphhopper/jsprit/core/algorithm/recreate/ShipmentInsertionCalculatorTest.java
@@ -68,12 +68,12 @@ public class ShipmentInsertionCalculatorTest {
     VehicleRoutingActivityCosts activityCosts = new VehicleRoutingActivityCosts() {
 
         @Override
-        public double getActivityCost(TourActivity tourAct, double arrivalTime, Driver driver, Vehicle vehicle) {
+        public double getActivityCost(TourActivity tourAct, double arrivalTime, Driver driver, Vehicle vehicle, TourActivity prevAct) {
             return 0;
         }
 
         @Override
-        public double getActivityDuration(TourActivity tourAct, double arrivalTime, Driver driver, Vehicle vehicle) {
+        public double getActivityDuration(TourActivity tourAct, double arrivalTime, Driver driver, Vehicle vehicle, TourActivity prevAct) {
             return tourAct.getOperationTime();
         }
 

--- a/jsprit-core/src/test/java/com/graphhopper/jsprit/core/algorithm/recreate/TestRouteLevelActivityInsertionCostEstimator.java
+++ b/jsprit-core/src/test/java/com/graphhopper/jsprit/core/algorithm/recreate/TestRouteLevelActivityInsertionCostEstimator.java
@@ -68,12 +68,12 @@ public class TestRouteLevelActivityInsertionCostEstimator {
         activityCosts = new VehicleRoutingActivityCosts() {
 
             @Override
-            public double getActivityCost(TourActivity tourAct, double arrivalTime, Driver driver, Vehicle vehicle) {
+            public double getActivityCost(TourActivity tourAct, double arrivalTime, Driver driver, Vehicle vehicle, TourActivity prevAct) {
                 return Math.max(0., arrivalTime - tourAct.getTheoreticalLatestOperationStartTime());
             }
 
             @Override
-            public double getActivityDuration(TourActivity tourAct, double arrivalTime, Driver driver, Vehicle vehicle) {
+            public double getActivityDuration(TourActivity tourAct, double arrivalTime, Driver driver, Vehicle vehicle, TourActivity prevAct) {
                 return tourAct.getOperationTime();
             }
 

--- a/jsprit-core/src/test/java/com/graphhopper/jsprit/core/algorithm/recreate/TestRouteLevelServiceInsertionCostEstimator.java
+++ b/jsprit-core/src/test/java/com/graphhopper/jsprit/core/algorithm/recreate/TestRouteLevelServiceInsertionCostEstimator.java
@@ -78,12 +78,12 @@ public class TestRouteLevelServiceInsertionCostEstimator {
         activityCosts = new VehicleRoutingActivityCosts() {
 
             @Override
-            public double getActivityCost(TourActivity tourAct, double arrivalTime, Driver driver, Vehicle vehicle) {
+            public double getActivityCost(TourActivity tourAct, double arrivalTime, Driver driver, Vehicle vehicle, TourActivity prevAct) {
                 return Math.max(0., arrivalTime - tourAct.getTheoreticalLatestOperationStartTime());
             }
 
             @Override
-            public double getActivityDuration(TourActivity tourAct, double arrivalTime, Driver driver, Vehicle vehicle) {
+            public double getActivityDuration(TourActivity tourAct, double arrivalTime, Driver driver, Vehicle vehicle, TourActivity prevAct) {
                 return tourAct.getOperationTime();
             }
 

--- a/jsprit-core/src/test/java/com/graphhopper/jsprit/core/algorithm/state/UpdateActivityTimesTest.java
+++ b/jsprit-core/src/test/java/com/graphhopper/jsprit/core/algorithm/state/UpdateActivityTimesTest.java
@@ -1,0 +1,174 @@
+package com.graphhopper.jsprit.core.algorithm.state;
+
+import com.graphhopper.jsprit.core.problem.Location;
+import com.graphhopper.jsprit.core.problem.cost.ForwardTransportTime;
+import com.graphhopper.jsprit.core.problem.cost.VehicleRoutingActivityCosts;
+import com.graphhopper.jsprit.core.problem.driver.Driver;
+import com.graphhopper.jsprit.core.problem.job.Service;
+import com.graphhopper.jsprit.core.problem.solution.route.VehicleRoute;
+import com.graphhopper.jsprit.core.problem.solution.route.activity.*;
+import com.graphhopper.jsprit.core.problem.vehicle.Vehicle;
+import com.graphhopper.jsprit.core.util.Coordinate;
+import com.graphhopper.jsprit.core.util.CrowFlyCosts;
+import com.graphhopper.jsprit.core.util.Locations;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.*;
+
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import com.graphhopper.jsprit.core.problem.solution.route.activity.TourActivity;
+
+
+class ConsolidateSameStopTimeActivityCost implements VehicleRoutingActivityCosts {
+    @Override
+    public double getActivityCost(TourActivity tourAct, double arrivalTime, Driver driver, Vehicle vehicle, TourActivity prevAct) {
+        if (isSameLocation(tourAct, prevAct)) {
+            return 0.0;
+        }
+        if (vehicle != null) {
+            double waiting = vehicle.getType().getVehicleCostParams().perWaitingTimeUnit * Math.max(0., tourAct.getTheoreticalEarliestOperationStartTime() - arrivalTime);
+            double servicing = vehicle.getType().getVehicleCostParams().perServiceTimeUnit * getActivityDuration(tourAct, arrivalTime, driver, vehicle, prevAct);
+            return waiting + servicing;
+        }
+        return 0;
+    }
+
+    @Override
+    public double getActivityDuration(TourActivity tourAct, double arrivalTime, Driver driver, Vehicle vehicle, TourActivity prevAct) {
+        if (isSameLocation(tourAct, prevAct)) {
+            return 0.0;
+        }
+        return tourAct.getOperationTime();
+    }
+
+    private boolean isSameLocation(TourActivity tourAct, TourActivity prevAct) {
+        if (tourAct != null && tourAct.getLocation() != null && prevAct != null && prevAct.getLocation() != null) {
+            if (tourAct.getLocation().equals(prevAct.getLocation())) {
+                return true;
+            }
+            return false;
+        }
+        return false;
+    }
+
+}
+
+
+public class UpdateActivityTimesTest {
+    ForwardTransportTime transportTime;
+    VehicleRoutingActivityCosts activityCosts;
+    VehicleRoute route;
+    List<TourActivity> tourActivities;
+    Location startLocation;
+    Location endLocation;
+    Start start;
+    End end;
+    Map<String, Coordinate> coordinates;
+    Locations locations;
+    TourActivityFactory tourActivityFactory;
+    UpdateActivityTimes stateUpdater;
+
+    @Before
+    public void setUp() throws Exception {
+        coordinates = new HashMap<>();
+        locations = new Locations() {
+            @Override
+            public Coordinate getCoord(String id) {
+                return coordinates.get(id);
+            }
+        };
+        Coordinate startCoordinate = Coordinate.newInstance(0, 0);
+        Coordinate endCoordinate = Coordinate.newInstance(10, 0);
+        coordinates.put("start", startCoordinate);
+        coordinates.put("end", endCoordinate);
+        startLocation = Location.Builder.newInstance().setId("start").setCoordinate(startCoordinate).build();
+        endLocation = Location.Builder.newInstance().setId("end").setCoordinate(endCoordinate).build();
+        start = Start.newInstance("start", 0, 0);
+        end = End.newInstance("end", 0, 12);
+        start.setLocation(startLocation);
+        end.setLocation(endLocation);
+        transportTime = new CrowFlyCosts(locations);
+        activityCosts = new ConsolidateSameStopTimeActivityCost();
+        stateUpdater = new UpdateActivityTimes(transportTime, activityCosts);
+        tourActivityFactory = new DefaultTourActivityFactory();
+        tourActivities = new ArrayList<>();
+        route = mock(VehicleRoute.class);
+        when(route.getStart()).thenReturn(start);
+        when(route.getEnd()).thenReturn(end);
+        when(route.getActivities()).thenReturn(tourActivities);
+    }
+
+    @Test
+    public void shouldAdjustActivityTimes_WhenAllActivitiesHappenAtSameLocationAndTimeAndDifferentServiceTimes() {
+        Coordinate coordinateOne = Coordinate.newInstance(2, 0);
+        Coordinate coordinateTwo = Coordinate.newInstance(3, 0);
+        Coordinate coordinateThree = Coordinate.newInstance(4, 0);
+        Location locationOne = Location.Builder.newInstance().setId("one").setCoordinate(coordinateOne).build();
+        Location locationTwo = Location.Builder.newInstance().setId("two").setCoordinate(coordinateTwo).build();
+        Location locationThree = Location.Builder.newInstance().setId("three").setCoordinate(coordinateThree).build();
+        coordinates.put("one", coordinateOne);
+        coordinates.put("two", coordinateTwo);
+        coordinates.put("three", coordinateThree);
+        TourActivity activityOne = tourActivityFactory.createActivity(Service.Builder.newInstance("lone").setLocation(locationOne).setServiceTime(1D).build());
+        TourActivity activityTwo = tourActivityFactory.createActivity(Service.Builder.newInstance("ltwo").setLocation(locationOne).setServiceTime(1D).build());
+        TourActivity activityThree = tourActivityFactory.createActivity(Service.Builder.newInstance("lthree").setLocation(locationOne).setServiceTime(1D).build());
+        TourActivity activityFour = tourActivityFactory.createActivity(Service.Builder.newInstance("lfour").setLocation(locationOne).setServiceTime(1D).build());
+        TourActivity activityFive = tourActivityFactory.createActivity(Service.Builder.newInstance("lfive").setLocation(locationOne).setServiceTime(1D).build());
+        TourActivity activitySix = tourActivityFactory.createActivity(Service.Builder.newInstance("oone").setLocation(locationTwo).setServiceTime(1D).build());
+        TourActivity activitySeven = tourActivityFactory.createActivity(Service.Builder.newInstance("otwo").setLocation(locationTwo).setServiceTime(1D).build());
+        TourActivity activityEight = tourActivityFactory.createActivity(Service.Builder.newInstance("othree").setLocation(locationTwo).setServiceTime(1D).build());
+        TourActivity activityNine = tourActivityFactory.createActivity(Service.Builder.newInstance("ofour").setLocation(locationThree).setServiceTime(1D).build());
+        TourActivity activityTen = tourActivityFactory.createActivity(Service.Builder.newInstance("ofive").setLocation(locationThree).setServiceTime(1D).build());
+        tourActivities.addAll(Arrays.asList(
+            activityOne,
+            activityTwo,
+            activityThree,
+            activityFour,
+            activityFive,
+            activitySix,
+            activitySeven,
+            activityEight,
+            activityNine,
+            activityTen
+        ));
+        stateUpdater.begin(route);
+        stateUpdater.visit(activityOne);
+        stateUpdater.visit(activityTwo);
+        stateUpdater.visit(activityThree);
+        stateUpdater.visit(activityFour);
+        stateUpdater.visit(activityFive);
+        stateUpdater.visit(activitySix);
+        stateUpdater.visit(activitySeven);
+        stateUpdater.visit(activityEight);
+        stateUpdater.visit(activityNine);
+        stateUpdater.visit(activityTen);
+        stateUpdater.finish();
+
+        assertEquals(activityOne.getArrTime(), 2D, 0.001);
+        assertEquals(activityOne.getEndTime(), 3D, 0.001);
+        assertEquals(activityTwo.getArrTime(), 3D, 0.001);
+        assertEquals(activityTwo.getEndTime(), 3D, 0.001);
+        assertEquals(activityThree.getArrTime(), 3D, 0.001);
+        assertEquals(activityThree.getEndTime(), 3D, 0.001);
+        assertEquals(activityFour.getArrTime(), 3D, 0.001);
+        assertEquals(activityFour.getEndTime(), 3D, 0.001);
+        assertEquals(activityFive.getArrTime(), 3D, 0.001);
+        assertEquals(activitySix.getArrTime(), 4D, 0.001);
+        assertEquals(activitySix.getEndTime(), 5D, 0.001);
+        assertEquals(activitySeven.getArrTime(), 5D, 0.001);
+        assertEquals(activityEight.getArrTime(), 5D, 0.001);
+        assertEquals(activityNine.getArrTime(), 6D, 0.001);
+        assertEquals(activityNine.getEndTime(), 7D, 0.001);
+        assertEquals(activityTen.getArrTime(), 7D, 0.001);
+        assertEquals(end.getArrTime(), 13D, 0.001);
+        assertEquals(end.getEndTime(), 12D, 0.001);
+        // This needs to be constrained by an added VehicleTimeConstraint by default.
+        // assertTrue("Arrival Time must be before End Time", end.getArrTime() < end.getEndTime());
+    }
+}
+
+

--- a/jsprit-core/src/test/java/com/graphhopper/jsprit/core/problem/VehicleRoutingProblemTest.java
+++ b/jsprit-core/src/test/java/com/graphhopper/jsprit/core/problem/VehicleRoutingProblemTest.java
@@ -272,19 +272,19 @@ public class VehicleRoutingProblemTest {
         builder.setActivityCosts(new VehicleRoutingActivityCosts() {
 
             @Override
-            public double getActivityCost(TourActivity tourAct, double arrivalTime, Driver driver, Vehicle vehicle) {
+            public double getActivityCost(TourActivity tourAct, double arrivalTime, Driver driver, Vehicle vehicle, TourActivity prevAct) {
                 return 4.0;
             }
 
             @Override
-            public double getActivityDuration(TourActivity tourAct, double arrivalTime, Driver driver, Vehicle vehicle) {
+            public double getActivityDuration(TourActivity tourAct, double arrivalTime, Driver driver, Vehicle vehicle, TourActivity prevAct) {
                 return tourAct.getOperationTime();
             }
 
         });
 
         VehicleRoutingProblem problem = builder.build();
-        assertEquals(4.0, problem.getActivityCosts().getActivityCost(null, 0.0, null, null), 0.01);
+        assertEquals(4.0, problem.getActivityCosts().getActivityCost(null, 0.0, null, null, null), 0.01);
     }
 
     @Test


### PR DESCRIPTION
Adding previousActivity to the VehicleRoutingActivityCosts function set, so that I am able to access a bit more of the context around which activities were performed before the currentActivity which may influence cost or Duration. 

Current Tests are passing. 

I have noticed that other constraints on my Vehicles (setEarliestDeparture and setLatestArrival) were not honored, and I needed to create a custom constraint to check them. 