### PR TITLE
Use powermock-api-mockito2 instead of mockito-all to fix junit tests

### DIFF
--- a/jsprit-core/src/test/java/com/graphhopper/jsprit/core/algorithm/SearchStrategyManagerTest.java
+++ b/jsprit-core/src/test/java/com/graphhopper/jsprit/core/algorithm/SearchStrategyManagerTest.java
@@ -17,21 +17,23 @@
  */
 package com.graphhopper.jsprit.core.algorithm;
 
-import com.graphhopper.jsprit.core.algorithm.acceptor.SolutionAcceptor;
-import com.graphhopper.jsprit.core.algorithm.selector.SolutionSelector;
-import com.graphhopper.jsprit.core.problem.solution.SolutionCostCalculator;
-import com.graphhopper.jsprit.core.util.RandomNumberGeneration;
-import org.junit.Assert;
-import org.junit.Test;
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Random;
 
-import static org.hamcrest.CoreMatchers.is;
-import static org.junit.Assert.assertThat;
-import static org.junit.Assert.assertTrue;
-import static org.mockito.Mockito.*;
+import org.junit.Assert;
+import org.junit.Test;
+
+import com.graphhopper.jsprit.core.algorithm.acceptor.SolutionAcceptor;
+import com.graphhopper.jsprit.core.algorithm.selector.SolutionSelector;
+import com.graphhopper.jsprit.core.problem.solution.SolutionCostCalculator;
+import com.graphhopper.jsprit.core.util.RandomNumberGeneration;
 
 
 public class SearchStrategyManagerTest {
@@ -76,7 +78,7 @@ public class SearchStrategyManagerTest {
 
         Random mockedRandom = mock(Random.class);
         manager.setRandom(mockedRandom);
-        stub(mockedRandom.nextDouble()).toReturn(0.25);
+        when(mockedRandom.nextDouble()).thenReturn(0.25);
 
         assertThat(manager.getRandomStrategy(), is(mockedStrat2));
     }
@@ -95,7 +97,7 @@ public class SearchStrategyManagerTest {
 
         Random mockedRandom = mock(Random.class);
         manager.setRandom(mockedRandom);
-        stub(mockedRandom.nextDouble()).toReturn(0.25);
+        when(mockedRandom.nextDouble()).thenReturn(0.25);
 
         assertThat(manager.getRandomStrategy(), is(mockedStrat2));
 
@@ -118,7 +120,7 @@ public class SearchStrategyManagerTest {
 
         Random mockedRandom = mock(Random.class);
         manager.setRandom(mockedRandom);
-        stub(mockedRandom.nextDouble()).toReturn(0.24);
+        when(mockedRandom.nextDouble()).thenReturn(0.24);
 
         assertThat(manager.getRandomStrategy(), is(mockedStrat1));
     }
@@ -137,7 +139,7 @@ public class SearchStrategyManagerTest {
 
         Random mockedRandom = mock(Random.class);
         managerUnderTest.setRandom(mockedRandom);
-        stub(mockedRandom.nextDouble()).toReturn(0.1);
+        when(mockedRandom.nextDouble()).thenReturn(0.1);
 
         assertThat(managerUnderTest.getRandomStrategy(), is(mockedStrategy1));
 

--- a/pom.xml
+++ b/pom.xml
@@ -74,7 +74,7 @@
         <jdkVersion>1.8</jdkVersion>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <junit.version>4.13.1</junit.version>
-        <mockito.version>1.9.5</mockito.version>
+        <mockito.version>2.0.9</mockito.version>
         <hamcrest.version>1.3</hamcrest.version>
         <logger.version>1.7.21</logger.version>
         <maven.javadoc.failOnError>false</maven.javadoc.failOnError>
@@ -82,7 +82,7 @@
     </properties>
 
     <build>
-        
+
         <sourceDirectory>src/main/java</sourceDirectory>
         <testSourceDirectory>src/test/java</testSourceDirectory>
         <directory>target</directory>
@@ -173,11 +173,12 @@
         </dependency>
 
         <dependency>
-            <groupId>org.mockito</groupId>
-            <artifactId>mockito-all</artifactId>
+            <groupId>org.powermock</groupId>
+            <artifactId>powermock-api-mockito2</artifactId>
             <version>${mockito.version}</version>
             <scope>test</scope>
         </dependency>
+
 
     </dependencies>
 


### PR DESCRIPTION
* This merge request fixes the issues with the current set of junit tests and allows them all to pass again
* For the mockito dependency in the main project is updated to powermock, which includes mockito2
* Adapt deprecated stub method in SearchStrategyManagerTest to mockito2-api