### PR TITLE
Fix maxDistance relatedness in RuinTimeRelated

### DIFF
--- a/jsprit-core/src/main/java/com/graphhopper/jsprit/core/algorithm/ruin/RuinTimeRelated.java
+++ b/jsprit-core/src/main/java/com/graphhopper/jsprit/core/algorithm/ruin/RuinTimeRelated.java
@@ -120,7 +120,7 @@ public final class RuinTimeRelated extends AbstractRuinStrategy {
             }
         }
         final double maxT = maxTime;
-        final double maxD = maxTime;
+        final double maxD = maxDistance;
         final double timeI = 10;
         final double distanceI;
         double distanceInfluence = 1;


### PR DESCRIPTION
While reviewing the source code I noticed this strange assignment does not match with the rest of semantics