### PR TITLE
fix largest timewindow

### DIFF
--- a/jsprit-core/src/main/java/com/graphhopper/jsprit/core/algorithm/recreate/DefaultScorer.java
+++ b/jsprit-core/src/main/java/com/graphhopper/jsprit/core/algorithm/recreate/DefaultScorer.java
@@ -74,7 +74,7 @@ public class DefaultScorer implements ScoringFunction  {
             if (timeWindow == null) timeWindow = tw;
             else if (tw.larger(timeWindow)) timeWindow = tw;
         }
-        return TimeWindow.newInstance(0, Double.MAX_VALUE);
+        return timeWindow == null ? TimeWindow.newInstance(0, Double.MAX_VALUE) : timeWindow;
     }
 
 


### PR DESCRIPTION
Function getLargestTimeWindow seems not to return the largest timewindow as intended, instead it returns a default timewindow. This request is to fix the problem.