### PR TITLE
Remove unnecessary completion factor

### DIFF
--- a/jsprit-core/src/main/java/com/graphhopper/jsprit/core/algorithm/recreate/IncreasingAbsoluteFixedCosts.java
+++ b/jsprit-core/src/main/java/com/graphhopper/jsprit/core/algorithm/recreate/IncreasingAbsoluteFixedCosts.java
@@ -55,7 +55,7 @@ public final class IncreasingAbsoluteFixedCosts extends SolutionCompletenessRati
             currentFix = currentRoute.getVehicle().getType().getVehicleCostParams().fix;
         }
         double increasingAbsoluteFixedCosts = solutionCompletenessRatio * (insertionContext.getNewVehicle().getType().getVehicleCostParams().fix - currentFix);
-        return weightDeltaFixCost * solutionCompletenessRatio * increasingAbsoluteFixedCosts;
+        return weightDeltaFixCost * increasingAbsoluteFixedCosts;
     }
 
 }


### PR DESCRIPTION
Hi, 
I think `solutionCompletenessRatio` should be included in `increasingAbsoluteFixedCosts` definition (judging from the variable name) and is already included.
So, I think we can remove unnecessary `solutionCompletenessRatio` defined in the return statement.