### PR TITLE
Bump slf4j-api from 1.7.32 to 2.0.17

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -71,7 +71,7 @@
         <junit.version>5.10.2</junit.version>
         <mockito.version>5.10.0</mockito.version>
         <hamcrest.version>1.3</hamcrest.version>
-        <logger.version>1.7.32</logger.version>
+        <logger.version>2.0.17</logger.version>
         <maven.javadoc.failOnError>false</maven.javadoc.failOnError>
         <maven.version>3.3.0</maven.version>
     </properties>


### PR DESCRIPTION
I would suggest to bump `slf4j-api` to 2.0 as it is backwards compatible to 1.0 and makes using jsprit within other projects more convenient. Thank you for your great work!