### PR TITLE
Migrate all tests from JUnit 4 to JUnit 5

### DIFF
--- a/jsprit-core/src/main/java/com/graphhopper/jsprit/core/algorithm/acceptor/ExperimentalSchrimpfAcceptance.java
+++ b/jsprit-core/src/main/java/com/graphhopper/jsprit/core/algorithm/acceptor/ExperimentalSchrimpfAcceptance.java
@@ -92,7 +92,8 @@ public class ExperimentalSchrimpfAcceptance implements SolutionAcceptor, Iterati
 
     private double getThreshold(int iteration) {
         double scheduleVariable = (double) iteration / (double) nOfTotalIterations;
-//		logger.debug("iter={} totalIter={} scheduling={}", iteration, nOfTotalIterations, scheduleVariable);
+		// logger.debug("iter={} totalIter={} scheduling={}", iteration,
+		// nOfTotalIterations, scheduleVariable);
         double currentThreshold = initialThreshold * Math.exp(-Math.log(2) * scheduleVariable / alpha);
         return currentThreshold;
     }
@@ -108,7 +109,7 @@ public class ExperimentalSchrimpfAcceptance implements SolutionAcceptor, Iterati
         this.nOfTotalIterations = algorithm.getMaxIterations();
 
 		/*
-         * randomWalk to determine standardDev
+		 * randomWalk to determine standardDev
 		 */
         final double[] results = new double[nOfRandomWalks];
 
@@ -121,7 +122,7 @@ public class ExperimentalSchrimpfAcceptance implements SolutionAcceptor, Iterati
             @Override
             public void informIterationEnds(int iteration, VehicleRoutingProblem problem, Collection<VehicleRoutingProblemSolution> solutions) {
                 double result = Solutions.bestOf(solutions).getCost();
-//				logger.info("result={}", result);
+				// logger.info("result={}", result);
                 results[iteration - 1] = result;
             }
 

--- a/jsprit-core/src/main/java/com/graphhopper/jsprit/core/algorithm/acceptor/SchrimpfInitialThresholdGenerator.java
+++ b/jsprit-core/src/main/java/com/graphhopper/jsprit/core/algorithm/acceptor/SchrimpfInitialThresholdGenerator.java
@@ -51,7 +51,7 @@ public class SchrimpfInitialThresholdGenerator implements AlgorithmStartsListene
         double now = System.currentTimeMillis();
 
 		/*
-         * randomWalk to determine standardDev
+		 * randomWalk to determine standardDev
 		 */
         final double[] results = new double[nOfRandomWalks];
 
@@ -64,7 +64,7 @@ public class SchrimpfInitialThresholdGenerator implements AlgorithmStartsListene
             @Override
             public void informIterationEnds(int iteration, VehicleRoutingProblem problem, Collection<VehicleRoutingProblemSolution> solutions) {
                 double result = Solutions.bestOf(solutions).getCost();
-//				logger.info("result={}", result);
+				// logger.info("result={}", result);
                 results[iteration - 1] = result;
             }
 

--- a/jsprit-core/src/main/java/com/graphhopper/jsprit/core/algorithm/recreate/BreakInsertionCalculator.java
+++ b/jsprit-core/src/main/java/com/graphhopper/jsprit/core/algorithm/recreate/BreakInsertionCalculator.java
@@ -121,8 +121,8 @@ final class BreakInsertionCalculator implements JobInsertionCostsCalculator {
         additionalICostsAtRouteLevel += additionalAccessEgressCalculator.getCosts(insertionContext);
 
 		/*
-        generate new start and end for new vehicle
-         */
+		 * generate new start and end for new vehicle
+		 */
         Start start = new Start(newVehicle.getStartLocation(), newVehicle.getEarliestDeparture(), Double.MAX_VALUE);
         start.setEndTime(newVehicleDepartureTime);
         End end = new End(newVehicle.getEndLocation(), 0.0, newVehicle.getLatestArrival());

--- a/jsprit-core/src/main/java/com/graphhopper/jsprit/core/algorithm/recreate/CalculatesServiceInsertionWithTimeSchedulingInSlices.java
+++ b/jsprit-core/src/main/java/com/graphhopper/jsprit/core/algorithm/recreate/CalculatesServiceInsertionWithTimeSchedulingInSlices.java
@@ -61,18 +61,18 @@ class CalculatesServiceInsertionWithTimeSchedulingInSlices implements JobInserti
         } else currentStart = currentRoute.getStart().getEndTime();
 
         vehicleDepartureTimes.add(currentStart);
-//		double earliestDeparture = newVehicle.getEarliestDeparture();
-//		double latestEnd = newVehicle.getLatestArrival();
+		// double earliestDeparture = newVehicle.getEarliestDeparture();
+		// double latestEnd = newVehicle.getLatestArrival();
 
         for (int i = 0; i < nOfDepartureTimes; i++) {
             double neighborStartTime_earlier = currentStart - (i + 1) * timeSlice;
-//			if(neighborStartTime_earlier > earliestDeparture) {
+			// if(neighborStartTime_earlier > earliestDeparture) {
             vehicleDepartureTimes.add(neighborStartTime_earlier);
-//			}
+			// }
             double neighborStartTime_later = currentStart + (i + 1) * timeSlice;
-//			if(neighborStartTime_later < latestEnd) {
+			// if(neighborStartTime_later < latestEnd) {
             vehicleDepartureTimes.add(neighborStartTime_later);
-//			}
+			// }
         }
 
         InsertionData bestIData = null;
@@ -84,7 +84,7 @@ class CalculatesServiceInsertionWithTimeSchedulingInSlices implements JobInserti
                 bestIData = iData;
             }
         }
-//		log.info(bestIData);
+		// log.info(bestIData);
         return bestIData;
     }
 

--- a/jsprit-core/src/main/java/com/graphhopper/jsprit/core/algorithm/recreate/JobInsertionCostsCalculatorBuilder.java
+++ b/jsprit-core/src/main/java/com/graphhopper/jsprit/core/algorithm/recreate/JobInsertionCostsCalculatorBuilder.java
@@ -248,7 +248,8 @@ public class JobInsertionCostsCalculatorBuilder {
 //            addInsertionListeners(withFixed.getInsertionListener());
         }
         if (timeScheduling) {
-//			baseCalculator = new CalculatesServiceInsertionWithTimeSchedulingInSlices(baseCalculator,timeSlice,neighbors);
+			// baseCalculator = new
+			// CalculatesServiceInsertionWithTimeSchedulingInSlices(baseCalculator,timeSlice,neighbors);
             CalculatesServiceInsertionWithTimeScheduling wts = new CalculatesServiceInsertionWithTimeScheduling(baseCalculator, timeSlice, neighbors);
             CalculatorPlusListeners calcPlusListeners = new CalculatorPlusListeners(wts);
             calcPlusListeners.getInsertionListener().add(new CalculatesServiceInsertionWithTimeScheduling.KnowledgeInjection(wts));

--- a/jsprit-core/src/main/java/com/graphhopper/jsprit/core/algorithm/recreate/RouteLevelActivityInsertionCostsEstimator.java
+++ b/jsprit-core/src/main/java/com/graphhopper/jsprit/core/algorithm/recreate/RouteLevelActivityInsertionCostsEstimator.java
@@ -63,7 +63,7 @@ class RouteLevelActivityInsertionCostsEstimator implements ActivityInsertionCost
         }
 
 		/*
-         * calculates the path costs with new vehicle, c(forwardPath,newVehicle).
+		 * calculates the path costs with new vehicle, c(forwardPath,newVehicle).
 		 */
         double forwardPathCost_newVehicle = auxilliaryPathCostCalculator.costOfPath(path, depTimeAtPrevAct, iFacts.getNewDriver(), iFacts.getNewVehicle());
         return forwardPathCost_newVehicle - (actCostsOld(iFacts.getRoute(), path.get(path.size() - 1)) - actCostsOld(iFacts.getRoute(), prevAct));

--- a/jsprit-core/src/main/java/com/graphhopper/jsprit/core/algorithm/recreate/ServiceInsertionCalculator.java
+++ b/jsprit-core/src/main/java/com/graphhopper/jsprit/core/algorithm/recreate/ServiceInsertionCalculator.java
@@ -136,7 +136,7 @@ final class ServiceInsertionCalculator extends AbstractInsertionCalculator {
                 tourEnd = true;
             }
             boolean not_fulfilled_break = true;
-			for(TimeWindow timeWindow : service.getTimeWindows()) {
+			for (TimeWindow timeWindow : service.getTimeWindows()) {
                 deliveryAct2Insert.setTheoreticalEarliestOperationStartTime(timeWindow.getStart());
                 deliveryAct2Insert.setTheoreticalLatestOperationStartTime(timeWindow.getEnd());
                 ActivityContext activityContext = new ActivityContext();

--- a/jsprit-core/src/main/java/com/graphhopper/jsprit/core/algorithm/recreate/ServiceInsertionOnRouteLevelCalculator.java
+++ b/jsprit-core/src/main/java/com/graphhopper/jsprit/core/algorithm/recreate/ServiceInsertionOnRouteLevelCalculator.java
@@ -130,7 +130,8 @@ final class ServiceInsertionOnRouteLevelCalculator implements JobInsertionCostsC
         /**
          * map that memorizes the costs with newVehicle, which is a cost-snapshot at tour-activities.
          */
-//		Map<TourActivity,Double> activity2costWithNewVehicle = new HashMap<TourActivity,Double>();
+		// Map<TourActivity,Double> activity2costWithNewVehicle = new
+		// HashMap<TourActivity,Double>();
 
         /**
          * priority queue that stores insertion-data by insertion-costs in ascending order.
@@ -199,7 +200,7 @@ final class ServiceInsertionOnRouteLevelCalculator implements JobInsertionCostsC
              * memorize transport and activity costs with new vehicle without inserting k
              */
             sumOf_prevCosts_newVehicle += transportCost_prevAct_nextAct_newVehicle + activityCost_nextAct;
-//			activity2costWithNewVehicle.put(nextAct, sumOf_prevCosts_newVehicle);
+			// activity2costWithNewVehicle.put(nextAct, sumOf_prevCosts_newVehicle);
 
             /**
              * departure time at nextAct with new vehicle

--- a/jsprit-core/src/main/java/com/graphhopper/jsprit/core/algorithm/recreate/ShipmentInsertionCalculator.java
+++ b/jsprit-core/src/main/java/com/graphhopper/jsprit/core/algorithm/recreate/ShipmentInsertionCalculator.java
@@ -177,9 +177,9 @@ final class ShipmentInsertionCalculator extends AbstractInsertionCalculator {
                     continue;
                 }
 
-			/*
-            --------------------------------
-			 */
+				/*
+				 * --------------------------------
+				 */
                 //deliverShipmentLoop
                 int j = i;
                 boolean tourEnd_deliveryLoop = false;

--- a/jsprit-core/src/main/java/com/graphhopper/jsprit/core/algorithm/recreate/ShipmentInsertionCalculatorFlex.java
+++ b/jsprit-core/src/main/java/com/graphhopper/jsprit/core/algorithm/recreate/ShipmentInsertionCalculatorFlex.java
@@ -192,9 +192,9 @@ public final class ShipmentInsertionCalculatorFlex extends AbstractInsertionCalc
                         continue;
                     }
 
-			/*
-            --------------------------------
-			 */
+					/*
+					 * --------------------------------
+					 */
                     //deliverShipmentLoop
                     int j = i;
                     boolean tourEndInDeliveryLoop = false;

--- a/jsprit-core/src/main/java/com/graphhopper/jsprit/core/algorithm/state/StateManager.java
+++ b/jsprit-core/src/main/java/com/graphhopper/jsprit/core/algorithm/state/StateManager.java
@@ -582,7 +582,7 @@ public class StateManager implements RouteAndActivityStateGetter, IterationStart
 
     @Override
     public void ruinEnds(Collection<VehicleRoute> routes, Collection<Job> unassignedJobs) {
-//		log.debug("ruin ends");
+		// log.debug("ruin ends");
         ruinListeners.ruinEnds(routes, unassignedJobs);
     }
 

--- a/jsprit-core/src/main/java/com/graphhopper/jsprit/core/algorithm/state/UpdateFutureWaitingTimes.java
+++ b/jsprit-core/src/main/java/com/graphhopper/jsprit/core/algorithm/state/UpdateFutureWaitingTimes.java
@@ -53,7 +53,7 @@ public class UpdateFutureWaitingTimes implements ReverseActivityVisitor, StateUp
     @Override
     public void visit(TourActivity activity) {
         states.putInternalTypedActivityState(activity, route.getVehicle(), InternalStates.FUTURE_WAITING, futureWaiting);
-		if(!(activity instanceof BreakActivity)) {
+		if (!(activity instanceof BreakActivity)) {
             futureWaiting += Math.max(activity.getTheoreticalEarliestOperationStartTime() - activity.getArrTime(), 0);
 		}
     }

--- a/jsprit-core/src/main/java/com/graphhopper/jsprit/core/problem/constraint/VehicleDependentTimeWindowConstraints.java
+++ b/jsprit-core/src/main/java/com/graphhopper/jsprit/core/problem/constraint/VehicleDependentTimeWindowConstraints.java
@@ -71,13 +71,14 @@ public class VehicleDependentTimeWindowConstraints implements HardActivityConstr
 //            nextLocation = nextAct.getLocation();
         }
 
-			/*
-             * if latest arrival of vehicle (at its end) is smaller than earliest operation start times of activities,
-			 * then vehicle can never conduct activities.
-			 *
-			 *     |--- vehicle's operation time ---|
-			 *                        					|--- prevAct or newAct or nextAct ---|
-			 */
+		/*
+		 * if latest arrival of vehicle (at its end) is smaller than earliest operation
+		 * start times of activities,
+		 * then vehicle can never conduct activities.
+		 *
+		 * |--- vehicle's operation time ---|
+		 * |--- prevAct or newAct or nextAct ---|
+		 */
         double newAct_theoreticalEarliestOperationStartTime = newAct.getTheoreticalEarliestOperationStartTime();
 
         if (latestVehicleArrival < prevAct.getTheoreticalEarliestOperationStartTime() ||
@@ -86,35 +87,37 @@ public class VehicleDependentTimeWindowConstraints implements HardActivityConstr
             return ConstraintsStatus.NOT_FULFILLED_BREAK;
         }
             /*
-             * if the latest operation start-time of new activity is smaller than the earliest start of prev. activity,
+			 * if the latest operation start-time of new activity is smaller than the
+			 * earliest start of prev. activity,
 			 * then
 			 *
-			 *                    |--- prevAct ---|
-			 *  |--- newAct ---|
+			 * |--- prevAct ---|
+			 * |--- newAct ---|
 			 */
         if (newAct.getTheoreticalLatestOperationStartTime() < prevAct.getTheoreticalEarliestOperationStartTime()) {
             return ConstraintsStatus.NOT_FULFILLED_BREAK;
         }
 
-			/*
-             *  |--- prevAct ---|
-			 *                                          |- earliest arrival of vehicle
-			 *                       |--- nextAct ---|
-			 */
+		/*
+		 * |--- prevAct ---|
+		 * |- earliest arrival of vehicle
+		 * |--- nextAct ---|
+		 */
 
         double arrTimeAtNextOnDirectRouteWithNewVehicle = prevActDepTime + routingCosts.getTransportTime(prevLocation, nextLocation, prevActDepTime, iFacts.getNewDriver(), iFacts.getNewVehicle());
         if (arrTimeAtNextOnDirectRouteWithNewVehicle > latestArrTimeAtNextAct) {
             return ConstraintsStatus.NOT_FULFILLED_BREAK;
         }
 
-			/*
-             *                     |--- newAct ---|
-			 *  |--- nextAct ---|
-			 */
+		/*
+		 * |--- newAct ---|
+		 * |--- nextAct ---|
+		 */
         if (newAct.getTheoreticalEarliestOperationStartTime() > nextAct.getTheoreticalLatestOperationStartTime()) {
             return ConstraintsStatus.NOT_FULFILLED;
         }
-        //			log.info("check insertion of " + newAct + " between " + prevAct + " and " + nextAct + ". prevActDepTime=" + prevActDepTime);
+		// log.info("check insertion of " + newAct + " between " + prevAct + " and " +
+		// nextAct + ". prevActDepTime=" + prevActDepTime);
         double arrTimeAtNewAct = prevActDepTime + routingCosts.getTransportTime(prevLocation, newLocation, prevActDepTime, iFacts.getNewDriver(), iFacts.getNewVehicle());
         double endTimeAtNewAct = Math.max(arrTimeAtNewAct, newAct.getTheoreticalEarliestOperationStartTime()) + activityCosts.getActivityDuration(newAct, arrTimeAtNewAct,iFacts.getNewDriver(),iFacts.getNewVehicle());
         double latestArrTimeAtNewAct =
@@ -124,11 +127,11 @@ public class VehicleDependentTimeWindowConstraints implements HardActivityConstr
                     - activityCosts.getActivityDuration(newAct, arrTimeAtNewAct, iFacts.getNewDriver(), iFacts.getNewVehicle())
             );
 
-			/*
-             *  |--- prevAct ---|
-			 *                       		                 |--- vehicle's arrival @newAct
-			 *        latest arrival of vehicle @newAct ---|
-			 */
+		/*
+		 * |--- prevAct ---|
+		 * |--- vehicle's arrival @newAct
+		 * latest arrival of vehicle @newAct ---|
+		 */
         if (arrTimeAtNewAct > latestArrTimeAtNewAct) {
             return ConstraintsStatus.NOT_FULFILLED;
         }
@@ -138,15 +141,15 @@ public class VehicleDependentTimeWindowConstraints implements HardActivityConstr
                 return ConstraintsStatus.FULFILLED;
             }
         }
-//			log.info(newAct + " arrTime=" + arrTimeAtNewAct);
+		// log.info(newAct + " arrTime=" + arrTimeAtNewAct);
 
         double arrTimeAtNextAct = endTimeAtNewAct + routingCosts.getTransportTime(newLocation, nextLocation, endTimeAtNewAct, iFacts.getNewDriver(), iFacts.getNewVehicle());
 
-			/*
-             *  |--- newAct ---|
-			 *                       		                 |--- vehicle's arrival @nextAct
-			 *        latest arrival of vehicle @nextAct ---|
-			 */
+		/*
+		 * |--- newAct ---|
+		 * |--- vehicle's arrival @nextAct
+		 * latest arrival of vehicle @nextAct ---|
+		 */
         if (arrTimeAtNextAct > latestArrTimeAtNextAct) {
             return ConstraintsStatus.NOT_FULFILLED;
         }

--- a/jsprit-core/src/main/java/com/graphhopper/jsprit/core/problem/job/Service.java
+++ b/jsprit-core/src/main/java/com/graphhopper/jsprit/core/problem/job/Service.java
@@ -98,7 +98,7 @@ public class Service extends AbstractJob {
 
         protected Activity activity;
 
-		Builder(String id){
+		Builder(String id) {
 			this.id = id;
 			timeWindows = new TimeWindowsImpl();
 			timeWindows.add(TimeWindow.newInstance(0.0, Double.MAX_VALUE));

--- a/jsprit-core/src/main/java/com/graphhopper/jsprit/core/problem/solution/route/activity/End.java
+++ b/jsprit-core/src/main/java/com/graphhopper/jsprit/core/problem/solution/route/activity/End.java
@@ -73,7 +73,7 @@ public final class End extends AbstractActivity implements TourActivity {
 
     public End(End end) {
         this.location = end.getLocation();
-//		this.locationId = end.getLocation().getId();
+		// this.locationId = end.getLocation().getId();
         theoretical_earliestOperationStartTime = end.getTheoreticalEarliestOperationStartTime();
         theoretical_latestOperationStartTime = end.getTheoreticalLatestOperationStartTime();
         arrTime = end.getArrTime();

--- a/jsprit-core/src/main/java/com/graphhopper/jsprit/core/problem/vehicle/InfiniteVehicles.java
+++ b/jsprit-core/src/main/java/com/graphhopper/jsprit/core/problem/vehicle/InfiniteVehicles.java
@@ -51,7 +51,7 @@ class InfiniteVehicles implements VehicleFleetManager {
         for (Vehicle v : vehicles) {
 //            VehicleTypeKey typeKey = new VehicleTypeKey(v.getType().getTypeId(), v.getStartLocation().getId(), v.getEndLocation().getId(), v.getEarliestDeparture(), v.getLatestArrival(), v.getSkills(), v.isReturnToDepot());
             types.put(v.getVehicleTypeIdentifier(), v);
-//			sortedTypes.add(typeKey);
+			// sortedTypes.add(typeKey);
         }
     }
 

--- a/jsprit-core/src/test/java/com/graphhopper/jsprit/core/algorithm/CVRPwithDeliveries_IT.java
+++ b/jsprit-core/src/test/java/com/graphhopper/jsprit/core/algorithm/CVRPwithDeliveries_IT.java
@@ -23,11 +23,10 @@ import com.graphhopper.jsprit.core.problem.solution.VehicleRoutingProblemSolutio
 import com.graphhopper.jsprit.core.util.ChristofidesReader;
 import com.graphhopper.jsprit.core.util.JobType;
 import com.graphhopper.jsprit.core.util.Solutions;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import java.util.Collection;
-
-import static org.junit.Assert.assertEquals;
 
 public class CVRPwithDeliveries_IT {
 
@@ -38,8 +37,8 @@ public class CVRPwithDeliveries_IT {
         VehicleRoutingProblem vrp = vrpBuilder.build();
         VehicleRoutingAlgorithm vra = Jsprit.createAlgorithm(vrp);
         Collection<VehicleRoutingProblemSolution> solutions = vra.searchSolutions();
-        assertEquals(530.0, Solutions.bestOf(solutions).getCost(), 50.0);
-        assertEquals(5, Solutions.bestOf(solutions).getRoutes().size());
+        Assertions.assertEquals(530.0, Solutions.bestOf(solutions).getCost(), 50.0);
+        Assertions.assertEquals(5, Solutions.bestOf(solutions).getRoutes().size());
     }
 
 }

--- a/jsprit-core/src/test/java/com/graphhopper/jsprit/core/algorithm/CVRPwithPickups_IT.java
+++ b/jsprit-core/src/test/java/com/graphhopper/jsprit/core/algorithm/CVRPwithPickups_IT.java
@@ -23,11 +23,12 @@ import com.graphhopper.jsprit.core.problem.solution.VehicleRoutingProblemSolutio
 import com.graphhopper.jsprit.core.util.ChristofidesReader;
 import com.graphhopper.jsprit.core.util.JobType;
 import com.graphhopper.jsprit.core.util.Solutions;
-import org.junit.Test;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import java.util.Collection;
 
-import static org.junit.Assert.assertEquals;
 
 public class CVRPwithPickups_IT {
 
@@ -38,8 +39,8 @@ public class CVRPwithPickups_IT {
         VehicleRoutingProblem vrp = vrpBuilder.build();
         VehicleRoutingAlgorithm vra = Jsprit.Builder.newInstance(vrp).setProperty(Jsprit.Parameter.FAST_REGRET,"true").buildAlgorithm();
         Collection<VehicleRoutingProblemSolution> solutions = vra.searchSolutions();
-        assertEquals(530.0, Solutions.bestOf(solutions).getCost(), 50.0);
-        assertEquals(5, Solutions.bestOf(solutions).getRoutes().size());
+        Assertions.assertEquals(530.0, Solutions.bestOf(solutions).getCost(), 50.0);
+        Assertions.assertEquals(5, Solutions.bestOf(solutions).getRoutes().size());
     }
 
 }

--- a/jsprit-core/src/test/java/com/graphhopper/jsprit/core/algorithm/CapacityConstraint_IT.java
+++ b/jsprit-core/src/test/java/com/graphhopper/jsprit/core/algorithm/CapacityConstraint_IT.java
@@ -17,6 +17,9 @@
  */
 package com.graphhopper.jsprit.core.algorithm;
 
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
 import com.graphhopper.jsprit.core.algorithm.box.Jsprit;
 import com.graphhopper.jsprit.core.analysis.SolutionAnalyser;
 import com.graphhopper.jsprit.core.problem.Capacity;
@@ -29,8 +32,6 @@ import com.graphhopper.jsprit.core.problem.vehicle.VehicleImpl;
 import com.graphhopper.jsprit.core.problem.vehicle.VehicleTypeImpl;
 import com.graphhopper.jsprit.core.util.ManhattanCosts;
 import com.graphhopper.jsprit.core.util.Solutions;
-import org.junit.Assert;
-import org.junit.Test;
 
 
 public class CapacityConstraint_IT {
@@ -96,11 +97,10 @@ public class CapacityConstraint_IT {
             Capacity capacityDimensions = r.getVehicle().getType().getCapacityDimensions();
 //            System.out.println(r.getVehicle().getId() + " load@beginning: "  + loadAtBeginning);
 //            System.out.println("cap: " + capacityDimensions);
-            Assert.assertTrue("capacity has been exceeded",
-            loadAtBeginning.isLessOrEqual(capacityDimensions));
+            Assertions.assertTrue(loadAtBeginning.isLessOrEqual(capacityDimensions), () -> "capacity has been exceeded");
         }
 //
-        Assert.assertTrue(solution.getRoutes().size() != 1);
+        Assertions.assertTrue(solution.getRoutes().size() != 1);
 
     }
 

--- a/jsprit-core/src/test/java/com/graphhopper/jsprit/core/algorithm/ExternalInitialSolutionIsInValidTest.java
+++ b/jsprit-core/src/test/java/com/graphhopper/jsprit/core/algorithm/ExternalInitialSolutionIsInValidTest.java
@@ -24,13 +24,13 @@ import com.graphhopper.jsprit.core.problem.job.Service;
 import com.graphhopper.jsprit.core.problem.solution.VehicleRoutingProblemSolution;
 import com.graphhopper.jsprit.core.problem.solution.route.VehicleRoute;
 import com.graphhopper.jsprit.core.problem.vehicle.VehicleImpl;
+
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
 import java.util.Arrays;
 
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 
 @DisplayName("External Initial Solution Is In Valid Test")
 class ExternalInitialSolutionIsInValidTest {
@@ -50,9 +50,9 @@ class ExternalInitialSolutionIsInValidTest {
         vra.addInitialSolution(new VehicleRoutingProblemSolution(Arrays.asList(route1), 20.));
         try {
             vra.searchSolutions();
-            assertTrue(true);
+            Assertions.assertTrue(true);
         } catch (Exception e) {
-            assertFalse(true);
+            Assertions.assertFalse(true);
         }
     }
 }

--- a/jsprit-core/src/test/java/com/graphhopper/jsprit/core/algorithm/IgnoreBreakTimeWindowTest.java
+++ b/jsprit-core/src/test/java/com/graphhopper/jsprit/core/algorithm/IgnoreBreakTimeWindowTest.java
@@ -33,7 +33,7 @@ import com.graphhopper.jsprit.core.util.Solutions;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import org.junit.jupiter.api.Assertions;
 
 /**
  * Created by schroeder on 08/01/16.
@@ -47,8 +47,9 @@ class IgnoreBreakTimeWindowTest {
         VehicleTypeImpl.Builder vehicleTypeBuilder = VehicleTypeImpl.Builder.newInstance("vehicleType");
         VehicleType vehicleType = vehicleTypeBuilder.setCostPerWaitingTime(0.8).build();
         /*
-         * get a vehicle-builder and build a vehicle located at (10,10) with type "vehicleType"
-		 */
+         * get a vehicle-builder and build a vehicle located at (10,10) with type
+         * "vehicleType"
+         */
         VehicleImpl vehicle2;
         {
             VehicleImpl.Builder vehicleBuilder = VehicleImpl.Builder.newInstance("v2");
@@ -60,7 +61,7 @@ class IgnoreBreakTimeWindowTest {
         }
         /*
          * build services at the required locations, each with a capacity-demand of 1.
-		 */
+         */
         Service service4 = Service.Builder.newInstance("2").setLocation(Location.newInstance(0, 0)).setServiceTime(1.).setTimeWindow(TimeWindow.newInstance(17, 17)).build();
         Service service5 = Service.Builder.newInstance("3").setLocation(Location.newInstance(0, 0)).setServiceTime(1.).setTimeWindow(TimeWindow.newInstance(18, 18)).build();
         Service service7 = Service.Builder.newInstance("4").setLocation(Location.newInstance(0, 0)).setServiceTime(1.).setTimeWindow(TimeWindow.newInstance(10, 10)).build();
@@ -71,7 +72,7 @@ class IgnoreBreakTimeWindowTest {
         VehicleRoutingAlgorithm vra = Jsprit.createAlgorithm(vrp);
         vra.setMaxIterations(50);
         VehicleRoutingProblemSolution solution = Solutions.bestOf(vra.searchSolutions());
-        assertTrue(breakShouldBeTime(solution));
+        Assertions.assertTrue(breakShouldBeTime(solution));
     }
 
     private boolean breakShouldBeTime(VehicleRoutingProblemSolution solution) {

--- a/jsprit-core/src/test/java/com/graphhopper/jsprit/core/algorithm/InitialRoutesTest.java
+++ b/jsprit-core/src/test/java/com/graphhopper/jsprit/core/algorithm/InitialRoutesTest.java
@@ -41,13 +41,13 @@ import com.graphhopper.jsprit.core.problem.vehicle.VehicleType;
 import com.graphhopper.jsprit.core.problem.vehicle.VehicleTypeImpl;
 import com.graphhopper.jsprit.core.util.Coordinate;
 import com.graphhopper.jsprit.core.util.Solutions;
+
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
 import java.util.Collection;
-
-import static org.junit.jupiter.api.Assertions.*;
 
 @DisplayName("Initial Routes Test")
 class InitialRoutesTest {
@@ -74,7 +74,7 @@ class InitialRoutesTest {
         VehicleRoutingAlgorithm vra = Jsprit.createAlgorithm(vrp);
         Collection<VehicleRoutingProblemSolution> solutions = vra.searchSolutions();
         VehicleRoutingProblemSolution solution = Solutions.bestOf(solutions);
-        assertEquals(2, solution.getRoutes().iterator().next().getTourActivities().getJobs().size());
+		Assertions.assertEquals(2, solution.getRoutes().iterator().next().getTourActivities().getJobs().size());
     }
 
     @Test
@@ -83,7 +83,7 @@ class InitialRoutesTest {
         VehicleRoutingAlgorithm vra = new SchrimpfFactory().createAlgorithm(vrp);
         Collection<VehicleRoutingProblemSolution> solutions = vra.searchSolutions();
         VehicleRoutingProblemSolution solution = Solutions.bestOf(solutions);
-        assertEquals(2, solution.getRoutes().iterator().next().getActivities().size());
+		Assertions.assertEquals(2, solution.getRoutes().iterator().next().getActivities().size());
     }
 
     @Test
@@ -93,7 +93,7 @@ class InitialRoutesTest {
         Collection<VehicleRoutingProblemSolution> solutions = vra.searchSolutions();
         VehicleRoutingProblemSolution solution = Solutions.bestOf(solutions);
         Job job = getInitialJob("s1", vrp);
-        assertTrue(hasActivityIn(solution, "veh1", job));
+		Assertions.assertTrue(hasActivityIn(solution, "veh1", job));
     }
 
     private Job getInitialJob(String jobId, VehicleRoutingProblem vrp) {
@@ -148,7 +148,7 @@ class InitialRoutesTest {
         VehicleRoutingAlgorithm vra = new SchrimpfFactory().createAlgorithm(vrp);
         Collection<VehicleRoutingProblemSolution> solutions = vra.searchSolutions();
         VehicleRoutingProblemSolution solution = Solutions.bestOf(solutions);
-        assertTrue(hasActivityIn(solution.getRoutes().iterator().next(), "s2"));
+		Assertions.assertTrue(hasActivityIn(solution.getRoutes().iterator().next(), "s2"));
     }
 
     @Test
@@ -163,7 +163,7 @@ class InitialRoutesTest {
         VehicleRoutingAlgorithm vra = new GreedySchrimpfFactory().createAlgorithm(vrp);
         vra.setMaxIterations(10);
         Collection<VehicleRoutingProblemSolution> solutions = vra.searchSolutions();
-        assertFalse(secondActIsPickup(solutions));
+		Assertions.assertFalse(secondActIsPickup(solutions));
     }
 
     private boolean secondActIsPickup(Collection<VehicleRoutingProblemSolution> solutions) {
@@ -182,7 +182,7 @@ class InitialRoutesTest {
         VehicleRoutingAlgorithm vra = Jsprit.createAlgorithm(vrp);
         vra.setMaxIterations(100);
         vra.searchSolutions();
-        assertTrue(true);
+		Assertions.assertTrue(true);
     }
 
     @Test
@@ -208,8 +208,9 @@ class InitialRoutesTest {
         Collection<VehicleRoutingProblemSolution> searchSolutions = vra.searchSolutions();
         VehicleRoutingProblemSolution bestOf = Solutions.bestOf(searchSolutions);
         // ensure 2 routes
-        assertEquals(2, bestOf.getRoutes().size());
+		Assertions.assertEquals(2, bestOf.getRoutes().size());
         // ensure no time information in first service of first route
-        assertEquals(0, bestOf.getRoutes().iterator().next().getActivities().iterator().next().getArrTime(), 0.001);
+		Assertions.assertEquals(0, bestOf.getRoutes().iterator().next().getActivities().iterator().next().getArrTime(),
+				0.001);
     }
 }

--- a/jsprit-core/src/test/java/com/graphhopper/jsprit/core/algorithm/MaxTimeInVehicle_IT.java
+++ b/jsprit-core/src/test/java/com/graphhopper/jsprit/core/algorithm/MaxTimeInVehicle_IT.java
@@ -31,7 +31,7 @@ import com.graphhopper.jsprit.core.problem.solution.VehicleRoutingProblemSolutio
 import com.graphhopper.jsprit.core.problem.vehicle.VehicleImpl;
 import com.graphhopper.jsprit.core.reporting.SolutionPrinter;
 import com.graphhopper.jsprit.core.util.Solutions;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  * Created by schroeder on 20/09/16.
@@ -63,7 +63,7 @@ public class MaxTimeInVehicle_IT {
         VehicleRoutingAlgorithm vra = Jsprit.Builder.newInstance(vrp).setStateAndConstraintManager(stateManager,constraintManager).buildAlgorithm();
         VehicleRoutingProblemSolution solution = Solutions.bestOf(vra.searchSolutions());
 
-//        Assert.assertEquals(400, solution.getCost(), 0.001);
+		// Assertions.assertEquals(400, solution.getCost(), 0.001);
         SolutionPrinter.print(vrp,solution, SolutionPrinter.Print.VERBOSE);
     }
 }

--- a/jsprit-core/src/test/java/com/graphhopper/jsprit/core/algorithm/MeetTimeWindowConstraint_IT.java
+++ b/jsprit-core/src/test/java/com/graphhopper/jsprit/core/algorithm/MeetTimeWindowConstraint_IT.java
@@ -35,9 +35,7 @@ import com.graphhopper.jsprit.core.problem.vehicle.VehicleType;
 import com.graphhopper.jsprit.core.problem.vehicle.VehicleTypeImpl;
 import com.graphhopper.jsprit.core.util.FastVehicleRoutingTransportCostsMatrix;
 import com.graphhopper.jsprit.core.util.Solutions;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.io.BufferedReader;
 import java.io.IOException;
@@ -46,14 +44,14 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
 
 public class MeetTimeWindowConstraint_IT {
 
     VehicleRoutingProblem vrp;
 
-    @Before
+    @BeforeEach
     public void doBefore(){
         VehicleType type1 = VehicleTypeImpl.Builder.newInstance("5").build();
         VehicleType type2 = VehicleTypeImpl.Builder.newInstance("3.5").build();
@@ -74,7 +72,7 @@ public class MeetTimeWindowConstraint_IT {
         VehicleRoutingAlgorithm vra = Jsprit.createAlgorithm(vrp);
         vra.setMaxIterations(100);
         Collection<VehicleRoutingProblemSolution> solutions = vra.searchSolutions();
-        Assert.assertEquals(2, Solutions.bestOf(solutions).getRoutes().size());
+        Assertions.assertEquals(2, Solutions.bestOf(solutions).getRoutes().size());
     }
 
     @Test
@@ -101,7 +99,7 @@ public class MeetTimeWindowConstraint_IT {
         });
         @SuppressWarnings("unused")
         Collection<VehicleRoutingProblemSolution> solutions = vra.searchSolutions();
-        assertTrue(testFailed.isEmpty());
+        Assertions.assertTrue(testFailed.isEmpty());
     }
 
     @Test
@@ -135,7 +133,7 @@ public class MeetTimeWindowConstraint_IT {
 
         @SuppressWarnings("unused")
         Collection<VehicleRoutingProblemSolution> solutions = vra.searchSolutions();
-        assertTrue(testFailed.isEmpty());
+        Assertions.assertTrue(testFailed.isEmpty());
     }
 
     @Test
@@ -144,7 +142,7 @@ public class MeetTimeWindowConstraint_IT {
         vra.setMaxIterations(100);
         Collection<VehicleRoutingProblemSolution> solutions = vra.searchSolutions();
 
-        assertEquals(2, Solutions.bestOf(solutions).getRoutes().size());
+        Assertions.assertEquals(2, Solutions.bestOf(solutions).getRoutes().size());
     }
 
     @Test
@@ -152,7 +150,7 @@ public class MeetTimeWindowConstraint_IT {
         VehicleRoutingAlgorithm vra = Jsprit.createAlgorithm(vrp);
         vra.setMaxIterations(100);
         Collection<VehicleRoutingProblemSolution> solutions = vra.searchSolutions();
-        assertTrue(containsJob(vrp.getJobs().get("1"), getRoute("21", Solutions.bestOf(solutions))));
+        Assertions.assertTrue(containsJob(vrp.getJobs().get("1"), getRoute("21", Solutions.bestOf(solutions))));
     }
 
     @Test
@@ -160,7 +158,7 @@ public class MeetTimeWindowConstraint_IT {
         VehicleRoutingAlgorithm vra = Jsprit.createAlgorithm(vrp);
         vra.setMaxIterations(100);
         Collection<VehicleRoutingProblemSolution> solutions = vra.searchSolutions();
-        assertTrue(containsJob(vrp.getJobs().get("2"), getRoute("19", Solutions.bestOf(solutions))));
+        Assertions.assertTrue(containsJob(vrp.getJobs().get("2"), getRoute("19", Solutions.bestOf(solutions))));
     }
 
 
@@ -170,7 +168,7 @@ public class MeetTimeWindowConstraint_IT {
         vra.setMaxIterations(100);
         Collection<VehicleRoutingProblemSolution> solutions = vra.searchSolutions();
 
-        assertEquals(2, Solutions.bestOf(solutions).getRoutes().size());
+        Assertions.assertEquals(2, Solutions.bestOf(solutions).getRoutes().size());
     }
 
     @Test
@@ -198,7 +196,7 @@ public class MeetTimeWindowConstraint_IT {
         @SuppressWarnings("unused")
         Collection<VehicleRoutingProblemSolution> solutions = vra.searchSolutions();
 
-        assertTrue(testFailed.isEmpty());
+        Assertions.assertTrue(testFailed.isEmpty());
     }
 
     @Test
@@ -232,7 +230,7 @@ public class MeetTimeWindowConstraint_IT {
 
         @SuppressWarnings("unused")
         Collection<VehicleRoutingProblemSolution> solutions = vra.searchSolutions();
-        assertTrue(testFailed.isEmpty());
+        Assertions.assertTrue(testFailed.isEmpty());
     }
 
     @Test
@@ -241,7 +239,7 @@ public class MeetTimeWindowConstraint_IT {
         vra.setMaxIterations(100);
         Collection<VehicleRoutingProblemSolution> solutions = vra.searchSolutions();
 
-        assertEquals(2, Solutions.bestOf(solutions).getRoutes().size());
+        Assertions.assertEquals(2, Solutions.bestOf(solutions).getRoutes().size());
     }
 
     @Test
@@ -250,8 +248,8 @@ public class MeetTimeWindowConstraint_IT {
         vra.setMaxIterations(100);
         Collection<VehicleRoutingProblemSolution> solutions = vra.searchSolutions();
 
-        assertEquals(2, Solutions.bestOf(solutions).getRoutes().size());
-        assertTrue(containsJob(vrp.getJobs().get("1"), getRoute("21", Solutions.bestOf(solutions))));
+        Assertions.assertEquals(2, Solutions.bestOf(solutions).getRoutes().size());
+        Assertions.assertTrue(containsJob(vrp.getJobs().get("1"), getRoute("21", Solutions.bestOf(solutions))));
     }
 
     @Test
@@ -260,8 +258,8 @@ public class MeetTimeWindowConstraint_IT {
         vra.setMaxIterations(100);
         Collection<VehicleRoutingProblemSolution> solutions = vra.searchSolutions();
 
-        assertEquals(2, Solutions.bestOf(solutions).getRoutes().size());
-        assertTrue(containsJob(vrp.getJobs().get("2"), getRoute("19", Solutions.bestOf(solutions))));
+        Assertions.assertEquals(2, Solutions.bestOf(solutions).getRoutes().size());
+        Assertions.assertTrue(containsJob(vrp.getJobs().get("2"), getRoute("19", Solutions.bestOf(solutions))));
     }
 
     @Test
@@ -271,8 +269,8 @@ public class MeetTimeWindowConstraint_IT {
         algorithm.setMaxIterations(1000);
         VehicleRoutingProblemSolution solution = Solutions.bestOf(algorithm.searchSolutions());
         for (VehicleRoute r : solution.getRoutes()) {
-            assertTrue(r.getVehicle().getEarliestDeparture() <= r.getDepartureTime());
-            assertTrue(r.getVehicle().getLatestArrival() >= r.getEnd().getArrTime());
+        	Assertions.assertTrue(r.getVehicle().getEarliestDeparture() <= r.getDepartureTime());
+        	Assertions.assertTrue(r.getVehicle().getLatestArrival() >= r.getEnd().getArrTime());
         }
     }
 

--- a/jsprit-core/src/test/java/com/graphhopper/jsprit/core/algorithm/MultipleTimeWindowsTest.java
+++ b/jsprit-core/src/test/java/com/graphhopper/jsprit/core/algorithm/MultipleTimeWindowsTest.java
@@ -29,6 +29,8 @@ import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
+import org.junit.jupiter.api.Assertions;
+
 /**
  * Created by schroeder on 26/05/15.
  */
@@ -45,7 +47,7 @@ class MultipleTimeWindowsTest {
         VehicleRoutingAlgorithm algorithm = Jsprit.createAlgorithm(vrp);
         algorithm.setMaxIterations(100);
         VehicleRoutingProblemSolution solution = Solutions.bestOf(algorithm.searchSolutions());
-        assertEquals(1, solution.getUnassignedJobs().size());
+        Assertions.assertEquals(1, solution.getUnassignedJobs().size());
     }
 
     @Test
@@ -59,8 +61,8 @@ class MultipleTimeWindowsTest {
         VehicleRoutingAlgorithm algorithm = Jsprit.createAlgorithm(vrp);
         algorithm.setMaxIterations(100);
         VehicleRoutingProblemSolution solution = Solutions.bestOf(algorithm.searchSolutions());
-        assertEquals(0, solution.getUnassignedJobs().size());
-        assertEquals(2, solution.getRoutes().size());
+        Assertions.assertEquals(0, solution.getUnassignedJobs().size());
+        Assertions.assertEquals(2, solution.getRoutes().size());
     }
 
     @Test
@@ -73,6 +75,6 @@ class MultipleTimeWindowsTest {
         VehicleRoutingAlgorithm algorithm = Jsprit.createAlgorithm(vrp);
         algorithm.setMaxIterations(100);
         VehicleRoutingProblemSolution solution = Solutions.bestOf(algorithm.searchSolutions());
-        assertEquals(0, solution.getUnassignedJobs().size());
+        Assertions.assertEquals(0, solution.getUnassignedJobs().size());
     }
 }

--- a/jsprit-core/src/test/java/com/graphhopper/jsprit/core/algorithm/OpenRoutesTest.java
+++ b/jsprit-core/src/test/java/com/graphhopper/jsprit/core/algorithm/OpenRoutesTest.java
@@ -55,9 +55,9 @@ class OpenRoutesTest {
         try {
             @SuppressWarnings("unused")
             Collection<VehicleRoutingProblemSolution> solutions = vra.searchSolutions();
-            assertTrue(true);
+			Assertions.assertTrue(true);
         } catch (NoSolutionFoundException e) {
-            assertFalse(true);
+			Assertions.assertFalse(true);
         }
     }
 
@@ -73,9 +73,9 @@ class OpenRoutesTest {
         try {
             @SuppressWarnings("unused")
             Collection<VehicleRoutingProblemSolution> solutions = vra.searchSolutions();
-            assertTrue(true);
+			Assertions.assertTrue(true);
         } catch (NoSolutionFoundException e) {
-            assertFalse(true);
+			Assertions.assertFalse(true);
         }
     }
 
@@ -117,9 +117,9 @@ class OpenRoutesTest {
         try {
             @SuppressWarnings("UnusedDeclaration")
             Collection<VehicleRoutingProblemSolution> solutions = vra.searchSolutions();
-            assertTrue(true);
+			Assertions.assertTrue(true);
         } catch (Exception e) {
-            assertTrue(false);
+			Assertions.assertTrue(false);
         }
     }
 }

--- a/jsprit-core/src/test/java/com/graphhopper/jsprit/core/algorithm/PickupsAndDeliveries_IT.java
+++ b/jsprit-core/src/test/java/com/graphhopper/jsprit/core/algorithm/PickupsAndDeliveries_IT.java
@@ -22,11 +22,11 @@ import com.graphhopper.jsprit.core.problem.VehicleRoutingProblem;
 import com.graphhopper.jsprit.core.problem.solution.VehicleRoutingProblemSolution;
 import com.graphhopper.jsprit.core.util.LiLimReader;
 import com.graphhopper.jsprit.core.util.Solutions;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.util.Collection;
 
-import static org.junit.Assert.assertEquals;
+import org.junit.jupiter.api.Assertions;
 
 public class PickupsAndDeliveries_IT {
 
@@ -37,8 +37,8 @@ public class PickupsAndDeliveries_IT {
         VehicleRoutingProblem vrp = vrpBuilder.build();
         VehicleRoutingAlgorithm vra = Jsprit.Builder.newInstance(vrp).setProperty(Jsprit.Parameter.FAST_REGRET,"true").buildAlgorithm();
         Collection<VehicleRoutingProblemSolution> solutions = vra.searchSolutions();
-        assertEquals(1650.8, Solutions.bestOf(solutions).getCost(), 80.);
-        assertEquals(19, Solutions.bestOf(solutions).getRoutes().size(), 1);
+		Assertions.assertEquals(1650.8, Solutions.bestOf(solutions).getCost(), 80.);
+		Assertions.assertEquals(19, Solutions.bestOf(solutions).getRoutes().size(), 1);
     }
 
 }

--- a/jsprit-core/src/test/java/com/graphhopper/jsprit/core/algorithm/RefuseCollectionWithCostsHigherThanTimesAndFiniteFleet_IT.java
+++ b/jsprit-core/src/test/java/com/graphhopper/jsprit/core/algorithm/RefuseCollectionWithCostsHigherThanTimesAndFiniteFleet_IT.java
@@ -27,7 +27,7 @@ import com.graphhopper.jsprit.core.problem.vehicle.VehicleImpl;
 import com.graphhopper.jsprit.core.problem.vehicle.VehicleTypeImpl;
 import com.graphhopper.jsprit.core.util.Solutions;
 import com.graphhopper.jsprit.core.util.VehicleRoutingTransportCostsMatrix;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.io.BufferedReader;
 import java.io.FileNotFoundException;
@@ -35,7 +35,7 @@ import java.io.IOException;
 import java.io.InputStreamReader;
 import java.util.Collection;
 
-import static org.junit.Assert.assertEquals;
+import org.junit.jupiter.api.Assertions;
 
 
 public class RefuseCollectionWithCostsHigherThanTimesAndFiniteFleet_IT {
@@ -45,7 +45,7 @@ public class RefuseCollectionWithCostsHigherThanTimesAndFiniteFleet_IT {
 
 
 		/*
-         * create vehicle-type and vehicle
+		 * create vehicle-type and vehicle
 		 */
         VehicleTypeImpl.Builder typeBuilder = VehicleTypeImpl.Builder.newInstance("vehicle-type").addCapacityDimension(0, 23);
         typeBuilder.setCostPerDistance(1.0);
@@ -58,18 +58,18 @@ public class RefuseCollectionWithCostsHigherThanTimesAndFiniteFleet_IT {
         Vehicle bigVehicle = vehicleBuilder.build();
 
 		/*
-         * start building the problem
+		 * start building the problem
 		 */
         VehicleRoutingProblem.Builder vrpBuilder = VehicleRoutingProblem.Builder.newInstance();
         vrpBuilder.setFleetSize(VehicleRoutingProblem.FleetSize.INFINITE);
         vrpBuilder.addVehicle(bigVehicle);
 
 		/*
-         * create cost-matrix
+		 * create cost-matrix
 		 */
         VehicleRoutingTransportCostsMatrix.Builder matrixBuilder = VehicleRoutingTransportCostsMatrix.Builder.newInstance(true);
         /*
-         * read demand quantities
+		 * read demand quantities
 		 */
         try {
             readDemandQuantities(vrpBuilder);
@@ -86,8 +86,8 @@ public class RefuseCollectionWithCostsHigherThanTimesAndFiniteFleet_IT {
 //        vra.setPrematureAlgorithmTermination(new IterationWithoutImprovementTermination(100));
         Collection<VehicleRoutingProblemSolution> solutions = vra.searchSolutions();
 
-        assertEquals(2. * 397., Solutions.bestOf(solutions).getCost(), 0.01);
-        assertEquals(2, Solutions.bestOf(solutions).getRoutes().size());
+		Assertions.assertEquals(2. * 397., Solutions.bestOf(solutions).getCost(), 0.01);
+		Assertions.assertEquals(2, Solutions.bestOf(solutions).getRoutes().size());
     }
 
 
@@ -102,7 +102,7 @@ public class RefuseCollectionWithCostsHigherThanTimesAndFiniteFleet_IT {
             }
             String[] lineTokens = line.split(",");
             /*
-             * build service
+			 * build service
 			 */
             Service service = Service.Builder.newInstance(lineTokens[0]).addSizeDimension(0, Integer.parseInt(lineTokens[1]))
                 .setLocation(Location.newInstance(lineTokens[0])).build();

--- a/jsprit-core/src/test/java/com/graphhopper/jsprit/core/algorithm/RefuseCollectionWithCostsHigherThanTimesAndFiniteFleet_withTimeAndDistanceCosts_IT.java
+++ b/jsprit-core/src/test/java/com/graphhopper/jsprit/core/algorithm/RefuseCollectionWithCostsHigherThanTimesAndFiniteFleet_withTimeAndDistanceCosts_IT.java
@@ -28,7 +28,7 @@ import com.graphhopper.jsprit.core.problem.vehicle.VehicleImpl;
 import com.graphhopper.jsprit.core.problem.vehicle.VehicleTypeImpl;
 import com.graphhopper.jsprit.core.util.Solutions;
 import com.graphhopper.jsprit.core.util.VehicleRoutingTransportCostsMatrix;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.io.BufferedReader;
 import java.io.FileNotFoundException;
@@ -36,7 +36,7 @@ import java.io.IOException;
 import java.io.InputStreamReader;
 import java.util.Collection;
 
-import static org.junit.Assert.assertEquals;
+import org.junit.jupiter.api.Assertions;
 
 
 public class RefuseCollectionWithCostsHigherThanTimesAndFiniteFleet_withTimeAndDistanceCosts_IT {
@@ -46,7 +46,7 @@ public class RefuseCollectionWithCostsHigherThanTimesAndFiniteFleet_withTimeAndD
 
 
 		/*
-         * create vehicle-type and vehicle
+		 * create vehicle-type and vehicle
 		 */
         VehicleTypeImpl.Builder typeBuilder = VehicleTypeImpl.Builder.newInstance("vehicle-type").addCapacityDimension(0, 23);
         typeBuilder.setCostPerDistance(1.0).setCostPerTime(1.);
@@ -59,18 +59,18 @@ public class RefuseCollectionWithCostsHigherThanTimesAndFiniteFleet_withTimeAndD
         Vehicle bigVehicle = vehicleBuilder.build();
 
 		/*
-         * start building the problem
+		 * start building the problem
 		 */
         VehicleRoutingProblem.Builder vrpBuilder = VehicleRoutingProblem.Builder.newInstance();
         vrpBuilder.setFleetSize(VehicleRoutingProblem.FleetSize.INFINITE);
         vrpBuilder.addVehicle(bigVehicle);
 
 		/*
-         * create cost-matrix
+		 * create cost-matrix
 		 */
         VehicleRoutingTransportCostsMatrix.Builder matrixBuilder = VehicleRoutingTransportCostsMatrix.Builder.newInstance(true);
         /*
-         * read demand quantities
+		 * read demand quantities
 		 */
         try {
             readDemandQuantities(vrpBuilder);
@@ -87,8 +87,8 @@ public class RefuseCollectionWithCostsHigherThanTimesAndFiniteFleet_withTimeAndD
         vra.setPrematureAlgorithmTermination(new IterationWithoutImprovementTermination(100));
         Collection<VehicleRoutingProblemSolution> solutions = vra.searchSolutions();
 
-        assertEquals(2. * 397. + 397., Solutions.bestOf(solutions).getCost(), 0.01);
-        assertEquals(2, Solutions.bestOf(solutions).getRoutes().size());
+		Assertions.assertEquals(2. * 397. + 397., Solutions.bestOf(solutions).getCost(), 0.01);
+		Assertions.assertEquals(2, Solutions.bestOf(solutions).getRoutes().size());
     }
 
 
@@ -103,7 +103,7 @@ public class RefuseCollectionWithCostsHigherThanTimesAndFiniteFleet_withTimeAndD
             }
             String[] lineTokens = line.split(",");
             /*
-             * build service
+			 * build service
 			 */
             Service service = Service.Builder.newInstance(lineTokens[0]).addSizeDimension(0, Integer.parseInt(lineTokens[1]))
                 .setLocation(Location.newInstance(lineTokens[0])).build();

--- a/jsprit-core/src/test/java/com/graphhopper/jsprit/core/algorithm/RefuseCollection_IT.java
+++ b/jsprit-core/src/test/java/com/graphhopper/jsprit/core/algorithm/RefuseCollection_IT.java
@@ -31,8 +31,8 @@ import com.graphhopper.jsprit.core.problem.vehicle.VehicleImpl;
 import com.graphhopper.jsprit.core.problem.vehicle.VehicleTypeImpl;
 import com.graphhopper.jsprit.core.util.Solutions;
 import com.graphhopper.jsprit.core.util.VehicleRoutingTransportCostsMatrix;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import java.io.BufferedReader;
 import java.io.IOException;
@@ -47,9 +47,9 @@ public class RefuseCollection_IT {
     @Test
     public void whenReadingServices_itShouldCalculateCorrectly() {
 
-		/*
+        /*
          * create vehicle-type and vehicle
-		 */
+         */
         VehicleTypeImpl.Builder typeBuilder = VehicleTypeImpl.Builder.newInstance("vehicle-type").addCapacityDimension(0, 23);
         typeBuilder.setCostPerDistance(1.0);
         VehicleTypeImpl bigType = typeBuilder.build();
@@ -59,20 +59,20 @@ public class RefuseCollection_IT {
         vehicleBuilder.setType(bigType);
         VehicleImpl bigVehicle = vehicleBuilder.build();
 
-		/*
+        /*
          * start building the problem
-		 */
+         */
         VehicleRoutingProblem.Builder vrpBuilder = VehicleRoutingProblem.Builder.newInstance();
         vrpBuilder.setFleetSize(VehicleRoutingProblem.FleetSize.INFINITE);
         vrpBuilder.addVehicle(bigVehicle);
 
-		/*
+        /*
          * create cost-matrix
-		 */
+         */
         VehicleRoutingTransportCostsMatrix.Builder matrixBuilder = VehicleRoutingTransportCostsMatrix.Builder.newInstance(true);
         /*
          * read demand quantities
-		 */
+         */
         readDemandQuantitiesAsServices(vrpBuilder);
         readDistances(matrixBuilder);
 
@@ -82,16 +82,16 @@ public class RefuseCollection_IT {
         vra.setPrematureAlgorithmTermination(new IterationWithoutImprovementTermination(100));
         Collection<VehicleRoutingProblemSolution> solutions = vra.searchSolutions();
 
-        Assert.assertEquals(397.0, Solutions.bestOf(solutions).getCost(), 40.);
-        Assert.assertEquals(2, Solutions.bestOf(solutions).getRoutes().size());
+        Assertions.assertEquals(397.0, Solutions.bestOf(solutions).getCost(), 40.);
+        Assertions.assertEquals(2, Solutions.bestOf(solutions).getRoutes().size());
     }
 
     @Test
     public void whenReadingServices_usingJsprit_itShouldCalculateCorrectly() {
 
-		/*
+        /*
          * create vehicle-type and vehicle
-		 */
+         */
         VehicleTypeImpl.Builder typeBuilder = VehicleTypeImpl.Builder.newInstance("vehicle-type").addCapacityDimension(0, 23);
         typeBuilder.setCostPerDistance(1.0);
         VehicleTypeImpl bigType = typeBuilder.build();
@@ -101,20 +101,20 @@ public class RefuseCollection_IT {
         vehicleBuilder.setType(bigType);
         VehicleImpl bigVehicle = vehicleBuilder.build();
 
-		/*
+        /*
          * start building the problem
-		 */
+         */
         VehicleRoutingProblem.Builder vrpBuilder = VehicleRoutingProblem.Builder.newInstance();
         vrpBuilder.setFleetSize(VehicleRoutingProblem.FleetSize.INFINITE);
         vrpBuilder.addVehicle(bigVehicle);
 
-		/*
+        /*
          * create cost-matrix
-		 */
+         */
         VehicleRoutingTransportCostsMatrix.Builder matrixBuilder = VehicleRoutingTransportCostsMatrix.Builder.newInstance(true);
         /*
-		 * read demand quantities
-		 */
+         * read demand quantities
+         */
         readDemandQuantitiesAsServices(vrpBuilder);
         readDistances(matrixBuilder);
 
@@ -124,16 +124,16 @@ public class RefuseCollection_IT {
         vra.setPrematureAlgorithmTermination(new IterationWithoutImprovementTermination(100));
         Collection<VehicleRoutingProblemSolution> solutions = vra.searchSolutions();
 
-        Assert.assertEquals(397.0, Solutions.bestOf(solutions).getCost(), 40.);
-        Assert.assertEquals(2, Solutions.bestOf(solutions).getRoutes().size());
+        Assertions.assertEquals(397.0, Solutions.bestOf(solutions).getCost(), 40.);
+        Assertions.assertEquals(2, Solutions.bestOf(solutions).getRoutes().size());
     }
 
     @Test
     public void whenReadingPickups_itShouldCalculateCorrectly() {
 
-		/*
-		 * create vehicle-type and vehicle
-		 */
+        /*
+         * create vehicle-type and vehicle
+         */
         VehicleTypeImpl.Builder typeBuilder = VehicleTypeImpl.Builder.newInstance("vehicle-type").addCapacityDimension(0, 23);
         typeBuilder.setCostPerDistance(1.0);
         VehicleTypeImpl bigType = typeBuilder.build();
@@ -143,20 +143,20 @@ public class RefuseCollection_IT {
         vehicleBuilder.setType(bigType);
         VehicleImpl bigVehicle = vehicleBuilder.build();
 
-		/*
-		 * start building the problem
-		 */
+        /*
+         * start building the problem
+         */
         VehicleRoutingProblem.Builder vrpBuilder = VehicleRoutingProblem.Builder.newInstance();
         vrpBuilder.setFleetSize(VehicleRoutingProblem.FleetSize.INFINITE);
         vrpBuilder.addVehicle(bigVehicle);
 
-		/*
-		 * create cost-matrix
-		 */
+        /*
+         * create cost-matrix
+         */
         VehicleRoutingTransportCostsMatrix.Builder matrixBuilder = VehicleRoutingTransportCostsMatrix.Builder.newInstance(true);
-		/*
-		 * read demand quantities
-		 */
+        /*
+         * read demand quantities
+         */
         readDemandQuantitiesAsPickups(vrpBuilder);
         readDistances(matrixBuilder);
 
@@ -166,16 +166,16 @@ public class RefuseCollection_IT {
         vra.setPrematureAlgorithmTermination(new IterationWithoutImprovementTermination(100));
         Collection<VehicleRoutingProblemSolution> solutions = vra.searchSolutions();
 
-        Assert.assertEquals(397.0, Solutions.bestOf(solutions).getCost(), 40.);
-        Assert.assertEquals(2, Solutions.bestOf(solutions).getRoutes().size());
+        Assertions.assertEquals(397.0, Solutions.bestOf(solutions).getCost(), 40.);
+        Assertions.assertEquals(2, Solutions.bestOf(solutions).getRoutes().size());
     }
 
     @Test
     public void whenReadingDeliveries_itShouldCalculateCorrectly() {
 
-		/*
-		 * create vehicle-type and vehicle
-		 */
+        /*
+         * create vehicle-type and vehicle
+         */
         VehicleTypeImpl.Builder typeBuilder = VehicleTypeImpl.Builder.newInstance("vehicle-type").addCapacityDimension(0, 23);
         typeBuilder.setCostPerDistance(1.0);
         VehicleTypeImpl bigType = typeBuilder.build();
@@ -185,20 +185,20 @@ public class RefuseCollection_IT {
         vehicleBuilder.setType(bigType);
         VehicleImpl bigVehicle = vehicleBuilder.build();
 
-		/*
-		 * start building the problem
-		 */
+        /*
+         * start building the problem
+         */
         VehicleRoutingProblem.Builder vrpBuilder = VehicleRoutingProblem.Builder.newInstance();
         vrpBuilder.setFleetSize(VehicleRoutingProblem.FleetSize.INFINITE);
         vrpBuilder.addVehicle(bigVehicle);
 
-		/*
-		 * create cost-matrix
-		 */
+        /*
+         * create cost-matrix
+         */
         VehicleRoutingTransportCostsMatrix.Builder matrixBuilder = VehicleRoutingTransportCostsMatrix.Builder.newInstance(true);
-		/*
-		 * read demand quantities
-		 */
+        /*
+         * read demand quantities
+         */
         readDemandQuantitiesAsDeliveries(vrpBuilder);
         readDistances(matrixBuilder);
 
@@ -208,8 +208,8 @@ public class RefuseCollection_IT {
         vra.setPrematureAlgorithmTermination(new IterationWithoutImprovementTermination(100));
         Collection<VehicleRoutingProblemSolution> solutions = vra.searchSolutions();
 
-        Assert.assertEquals(397.0, Solutions.bestOf(solutions).getCost(), 40.);
-        Assert.assertEquals(2, Solutions.bestOf(solutions).getRoutes().size());
+        Assertions.assertEquals(397.0, Solutions.bestOf(solutions).getCost(), 40.);
+        Assertions.assertEquals(2, Solutions.bestOf(solutions).getRoutes().size());
     }
 
 
@@ -223,14 +223,14 @@ public class RefuseCollection_IT {
                 continue;
             }
             String[] lineTokens = line.split(",");
-			/*
-			 * build service
-			 */
+            /*
+             * build service
+             */
             Service service = Service.Builder.newInstance(lineTokens[0]).addSizeDimension(0, Integer.parseInt(lineTokens[1]))
                 .setLocation(Location.newInstance(lineTokens[0])).build();
-			/*
-			 * and add it to problem
-			 */
+            /*
+             * and add it to problem
+             */
             vrpBuilder.addJob(service);
         }
         close(reader);
@@ -250,14 +250,14 @@ public class RefuseCollection_IT {
                 continue;
             }
             String[] lineTokens = line.split(",");
-			/*
-			 * build service
-			 */
+            /*
+             * build service
+             */
             Pickup service = Pickup.Builder.newInstance(lineTokens[0]).addSizeDimension(0, Integer.parseInt(lineTokens[1]))
                 .setLocation(Location.newInstance(lineTokens[0])).build();
-			/*
-			 * and add it to problem
-			 */
+            /*
+             * and add it to problem
+             */
             vrpBuilder.addJob(service);
         }
         close(reader);
@@ -273,14 +273,14 @@ public class RefuseCollection_IT {
                 continue;
             }
             String[] lineTokens = line.split(",");
-			/*
-			 * build service
-			 */
+            /*
+             * build service
+             */
             Delivery service = (Delivery) Delivery.Builder.newInstance(lineTokens[0]).addSizeDimension(0, Integer.parseInt(lineTokens[1]))
                 .setLocation(Location.newInstance(lineTokens[0])).build();
-			/*
-			 * and add it to problem
-			 */
+            /*
+             * and add it to problem
+             */
             vrpBuilder.addJob(service);
         }
         close(reader);

--- a/jsprit-core/src/test/java/com/graphhopper/jsprit/core/algorithm/SearchStrategyManagerTest.java
+++ b/jsprit-core/src/test/java/com/graphhopper/jsprit/core/algorithm/SearchStrategyManagerTest.java
@@ -29,8 +29,6 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Random;
 
-import static org.hamcrest.CoreMatchers.is;
-import static org.junit.Assert.assertThat;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.mock;
@@ -49,7 +47,7 @@ class SearchStrategyManagerTest {
         when(strat2.getId()).thenReturn("strat2");
         manager.addStrategy(strat1, 0.5);
         manager.addStrategy(strat2, 0.5);
-        assertTrue(true);
+        Assertions.assertTrue(true);
     }
 
     @Test
@@ -58,7 +56,7 @@ class SearchStrategyManagerTest {
         assertThrows(IllegalStateException.class, () -> {
             SearchStrategyManager manager = new SearchStrategyManager();
             manager.addStrategy(null, 1.0);
-            assertTrue(false);
+            Assertions.assertTrue(false);
         });
     }
 
@@ -70,7 +68,7 @@ class SearchStrategyManagerTest {
             SearchStrategy strat = mock(SearchStrategy.class);
             when(strat.getId()).thenReturn("strat1");
             manager.addStrategy(strat, -1.0);
-            assertTrue(false);
+            Assertions.assertTrue(false);
         });
     }
 
@@ -87,7 +85,7 @@ class SearchStrategyManagerTest {
         Random mockedRandom = mock(Random.class);
         manager.setRandom(mockedRandom);
         when(mockedRandom.nextDouble()).thenReturn(0.25);
-        assertThat(manager.getRandomStrategy(), is(mockedStrat2));
+        Assertions.assertSame(manager.getRandomStrategy(), mockedStrat2);
     }
 
     @Test
@@ -103,9 +101,9 @@ class SearchStrategyManagerTest {
         Random mockedRandom = mock(Random.class);
         manager.setRandom(mockedRandom);
         when(mockedRandom.nextDouble()).thenReturn(0.25);
-        assertThat(manager.getRandomStrategy(), is(mockedStrat2));
+        Assertions.assertSame(manager.getRandomStrategy(), mockedStrat2);
         manager.informStrategyWeightChanged("strat2", 1.4);
-        assertThat(manager.getRandomStrategy(), is(mockedStrat1));
+        Assertions.assertSame(manager.getRandomStrategy(), mockedStrat1);
     }
 
     @Test
@@ -121,7 +119,7 @@ class SearchStrategyManagerTest {
         Random mockedRandom = mock(Random.class);
         manager.setRandom(mockedRandom);
         when(mockedRandom.nextDouble()).thenReturn(0.24);
-        assertThat(manager.getRandomStrategy(), is(mockedStrat1));
+        Assertions.assertSame(manager.getRandomStrategy(), mockedStrat1);
     }
 
     @Test
@@ -137,7 +135,7 @@ class SearchStrategyManagerTest {
         Random mockedRandom = mock(Random.class);
         managerUnderTest.setRandom(mockedRandom);
         when(mockedRandom.nextDouble()).thenReturn(0.1);
-        assertThat(managerUnderTest.getRandomStrategy(), is(mockedStrategy1));
+        Assertions.assertSame(managerUnderTest.getRandomStrategy(), mockedStrategy1);
     }
 
     @Test
@@ -153,7 +151,7 @@ class SearchStrategyManagerTest {
         Random mockedRandom = mock(Random.class);
         managerUnderTest.setRandom(mockedRandom);
         when(mockedRandom.nextDouble()).thenReturn(0.5);
-        assertThat(managerUnderTest.getRandomStrategy(), is(mockedStrategy2));
+        Assertions.assertSame(managerUnderTest.getRandomStrategy(), mockedStrategy2);
     }
 
     @Test
@@ -169,7 +167,7 @@ class SearchStrategyManagerTest {
         Random mockedRandom = mock(Random.class);
         managerUnderTest.setRandom(mockedRandom);
         when(mockedRandom.nextDouble()).thenReturn(0.0);
-        assertThat(managerUnderTest.getRandomStrategy(), is(mockedStrategy1));
+        Assertions.assertSame(managerUnderTest.getRandomStrategy(), mockedStrategy1);
     }
 
     @Test

--- a/jsprit-core/src/test/java/com/graphhopper/jsprit/core/algorithm/SearchStrategyTest.java
+++ b/jsprit-core/src/test/java/com/graphhopper/jsprit/core/algorithm/SearchStrategyTest.java
@@ -23,6 +23,8 @@ import com.graphhopper.jsprit.core.algorithm.selector.SolutionSelector;
 import com.graphhopper.jsprit.core.problem.VehicleRoutingProblem;
 import com.graphhopper.jsprit.core.problem.solution.SolutionCostCalculator;
 import com.graphhopper.jsprit.core.problem.solution.VehicleRoutingProblemSolution;
+
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
@@ -80,7 +82,7 @@ class SearchStrategyTest {
         };
         strat.addModule(mod);
         strat.run(vrp, null);
-        assertEquals(runs.size(), 1);
+        Assertions.assertEquals(runs.size(), 1);
     }
 
     @Test
@@ -131,7 +133,7 @@ class SearchStrategyTest {
         strat.addModule(mod);
         strat.addModule(mod2);
         strat.run(vrp, null);
-        assertEquals(runs.size(), 2);
+        Assertions.assertEquals(runs.size(), 2);
     }
 
     @Test
@@ -167,7 +169,7 @@ class SearchStrategyTest {
             strat.addModule(mod);
         }
         strat.run(vrp, null);
-        assertEquals(runs.size(), N);
+        Assertions.assertEquals(runs.size(), N);
     }
 
     @Test
@@ -203,7 +205,7 @@ class SearchStrategyTest {
                 strat.addModule(mod);
             }
             strat.run(vrp, null);
-            assertEquals(runs.size(), N);
+            Assertions.assertEquals(runs.size(), N);
         });
     }
 }

--- a/jsprit-core/src/test/java/com/graphhopper/jsprit/core/algorithm/SolomonSkills_IT.java
+++ b/jsprit-core/src/test/java/com/graphhopper/jsprit/core/algorithm/SolomonSkills_IT.java
@@ -31,11 +31,11 @@ import com.graphhopper.jsprit.core.problem.vehicle.VehicleType;
 import com.graphhopper.jsprit.core.util.SolomonReader;
 import com.graphhopper.jsprit.core.util.Solutions;
 import com.graphhopper.jsprit.core.util.TestUtils;
-import org.junit.Test;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import java.util.Collection;
-
-import static org.junit.Assert.*;
 
 /**
  * to test skills with penalty vehicles
@@ -80,17 +80,17 @@ public class SolomonSkills_IT {
 
         Collection<VehicleRoutingProblemSolution> solutions = vra.searchSolutions();
         VehicleRoutingProblemSolution solution = Solutions.bestOf(solutions);
-        assertEquals(828.94, solution.getCost(), 0.01);
+        Assertions.assertEquals(828.94, solution.getCost(), 0.01);
         for (VehicleRoute route : solution.getRoutes()) {
             Skills vehicleSkill = route.getVehicle().getSkills();
             for (Job job : route.getTourActivities().getJobs()) {
                 for (String skill : job.getRequiredSkills().values()) {
                     if (!vehicleSkill.containsSkill(skill)) {
-                        assertFalse(true);
+                        Assertions.assertFalse(true);
                     }
                 }
             }
         }
-        assertTrue(true);
+        Assertions.assertTrue(true);
     }
 }

--- a/jsprit-core/src/test/java/com/graphhopper/jsprit/core/algorithm/Solomon_IT.java
+++ b/jsprit-core/src/test/java/com/graphhopper/jsprit/core/algorithm/Solomon_IT.java
@@ -23,8 +23,8 @@ import com.graphhopper.jsprit.core.problem.VehicleRoutingProblem;
 import com.graphhopper.jsprit.core.problem.solution.VehicleRoutingProblemSolution;
 import com.graphhopper.jsprit.core.util.SolomonReader;
 import com.graphhopper.jsprit.core.util.Solutions;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import java.util.Collection;
 
@@ -42,7 +42,7 @@ public class Solomon_IT {
         VehicleRoutingAlgorithm vra = Jsprit.Builder.newInstance(vrp).setProperty(Jsprit.Parameter.FAST_REGRET,"true").buildAlgorithm();
         vra.setMaxIterations(2000);
         Collection<VehicleRoutingProblemSolution> solutions = vra.searchSolutions();
-        Assert.assertEquals(828.94, Solutions.bestOf(solutions).getCost(), 0.01);
+        Assertions.assertEquals(828.94, Solutions.bestOf(solutions).getCost(), 0.01);
     }
 
 }

--- a/jsprit-core/src/test/java/com/graphhopper/jsprit/core/algorithm/UnassignedJobListTest.java
+++ b/jsprit-core/src/test/java/com/graphhopper/jsprit/core/algorithm/UnassignedJobListTest.java
@@ -26,6 +26,8 @@ import com.graphhopper.jsprit.core.problem.solution.route.activity.TimeWindow;
 import com.graphhopper.jsprit.core.problem.vehicle.VehicleImpl;
 import com.graphhopper.jsprit.core.util.Solutions;
 import com.graphhopper.jsprit.core.util.UnassignedJobReasonTracker;
+
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
@@ -53,9 +55,9 @@ class UnassignedJobListTest {
         algorithm.addListener(reasonTracker);
         Collection<VehicleRoutingProblemSolution> solutions = algorithm.searchSolutions();
         VehicleRoutingProblemSolution solution = Solutions.bestOf(solutions);
-        assertTrue(!solution.getUnassignedJobs().contains(job1));
-        assertTrue(solution.getUnassignedJobs().contains(job2));
-        assertEquals(2, reasonTracker.getMostLikelyReasonCode("job2"));
+        Assertions.assertTrue(!solution.getUnassignedJobs().contains(job1));
+        Assertions.assertTrue(solution.getUnassignedJobs().contains(job2));
+        Assertions.assertEquals(2, reasonTracker.getMostLikelyReasonCode("job2"));
     }
 
     @Test
@@ -74,8 +76,8 @@ class UnassignedJobListTest {
         algorithm.addListener(reasonTracker);
         Collection<VehicleRoutingProblemSolution> solutions = algorithm.searchSolutions();
         VehicleRoutingProblemSolution solution = Solutions.bestOf(solutions);
-        assertTrue(!solution.getUnassignedJobs().contains(job1));
-        assertTrue(solution.getUnassignedJobs().contains(job2));
-        assertEquals(3, reasonTracker.getMostLikelyReasonCode("job2"));
+        Assertions.assertTrue(!solution.getUnassignedJobs().contains(job1));
+        Assertions.assertTrue(solution.getUnassignedJobs().contains(job2));
+        Assertions.assertEquals(3, reasonTracker.getMostLikelyReasonCode("job2"));
     }
 }

--- a/jsprit-core/src/test/java/com/graphhopper/jsprit/core/algorithm/VariableDepartureAndWaitingTime_IT.java
+++ b/jsprit-core/src/test/java/com/graphhopper/jsprit/core/algorithm/VariableDepartureAndWaitingTime_IT.java
@@ -36,9 +36,9 @@ import com.graphhopper.jsprit.core.problem.vehicle.Vehicle;
 import com.graphhopper.jsprit.core.problem.vehicle.VehicleImpl;
 import com.graphhopper.jsprit.core.util.CostFactory;
 import com.graphhopper.jsprit.core.util.Solutions;
-import junit.framework.Assert;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 /**
  * Created by schroeder on 22/07/15.
@@ -53,7 +53,7 @@ public class VariableDepartureAndWaitingTime_IT {
 
     AlgorithmFactory algorithmFactory;
 
-    @Before
+    @BeforeEach
     public void doBefore() {
         activityCosts = new VehicleRoutingActivityCosts() {
 
@@ -102,7 +102,7 @@ public class VariableDepartureAndWaitingTime_IT {
             .build();
         VehicleRoutingAlgorithm vra = algorithmFactory.createAlgorithm(vrp);
         VehicleRoutingProblemSolution solution = Solutions.bestOf(vra.searchSolutions());
-        Assert.assertEquals(40., solution.getCost());
+        Assertions.assertEquals(40., solution.getCost());
     }
 
     @Test
@@ -118,7 +118,7 @@ public class VariableDepartureAndWaitingTime_IT {
             .build();
         VehicleRoutingAlgorithm vra = algorithmFactory.createAlgorithm(vrp);
         VehicleRoutingProblemSolution solution = Solutions.bestOf(vra.searchSolutions());
-        Assert.assertEquals(40. + 1000., solution.getCost());
+        Assertions.assertEquals(40. + 1000., solution.getCost());
     }
 
 

--- a/jsprit-core/src/test/java/com/graphhopper/jsprit/core/algorithm/VehicleRoutingAlgorithmTest.java
+++ b/jsprit-core/src/test/java/com/graphhopper/jsprit/core/algorithm/VehicleRoutingAlgorithmTest.java
@@ -21,6 +21,8 @@ import com.graphhopper.jsprit.core.algorithm.listener.IterationStartsListener;
 import com.graphhopper.jsprit.core.algorithm.termination.PrematureAlgorithmTermination;
 import com.graphhopper.jsprit.core.problem.VehicleRoutingProblem;
 import com.graphhopper.jsprit.core.problem.solution.VehicleRoutingProblemSolution;
+
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
@@ -39,7 +41,7 @@ class VehicleRoutingAlgorithmTest {
     void whenSettingIterations_itIsSetCorrectly() {
         VehicleRoutingAlgorithm algorithm = new VehicleRoutingAlgorithm(mock(VehicleRoutingProblem.class), mock(SearchStrategyManager.class));
         algorithm.setMaxIterations(50);
-        assertEquals(50, algorithm.getMaxIterations());
+        Assertions.assertEquals(50, algorithm.getMaxIterations());
     }
 
     @Test
@@ -47,7 +49,7 @@ class VehicleRoutingAlgorithmTest {
     void whenSettingIterationsWithMaxIterations_itIsSetCorrectly() {
         VehicleRoutingAlgorithm algorithm = new VehicleRoutingAlgorithm(mock(VehicleRoutingProblem.class), mock(SearchStrategyManager.class));
         algorithm.setMaxIterations(50);
-        assertEquals(50, algorithm.getMaxIterations());
+        Assertions.assertEquals(50, algorithm.getMaxIterations());
     }
 
     @DisplayName("Count Iterations")
@@ -76,7 +78,7 @@ class VehicleRoutingAlgorithmTest {
         CountIterations counter = new CountIterations();
         algorithm.addListener(counter);
         algorithm.searchSolutions();
-        assertEquals(1000, counter.getCountIterations());
+        Assertions.assertEquals(1000, counter.getCountIterations());
     }
 
     @Test
@@ -90,7 +92,7 @@ class VehicleRoutingAlgorithmTest {
         CountIterations counter = new CountIterations();
         algorithm.addListener(counter);
         algorithm.searchSolutions();
-        assertEquals(1000, counter.getCountIterations());
+        Assertions.assertEquals(1000, counter.getCountIterations());
     }
 
     @Test
@@ -117,7 +119,7 @@ class VehicleRoutingAlgorithmTest {
         algorithm.addListener(counter);
         algorithm.setPrematureAlgorithmTermination(termination);
         algorithm.searchSolutions();
-        assertEquals(50, counter.getCountIterations());
+        Assertions.assertEquals(50, counter.getCountIterations());
     }
 
     @Test
@@ -144,7 +146,7 @@ class VehicleRoutingAlgorithmTest {
         algorithm.addListener(counter);
         algorithm.addTerminationCriterion(termination);
         algorithm.searchSolutions();
-        assertEquals(50, counter.getCountIterations());
+        Assertions.assertEquals(50, counter.getCountIterations());
     }
 
     @Test
@@ -184,6 +186,6 @@ class VehicleRoutingAlgorithmTest {
         algorithm.addTerminationCriterion(termination);
         algorithm.addTerminationCriterion(termination2);
         algorithm.searchSolutions();
-        assertEquals(25, counter.getCountIterations());
+        Assertions.assertEquals(25, counter.getCountIterations());
     }
 }

--- a/jsprit-core/src/test/java/com/graphhopper/jsprit/core/algorithm/acceptor/GreedyAcceptanceTest.java
+++ b/jsprit-core/src/test/java/com/graphhopper/jsprit/core/algorithm/acceptor/GreedyAcceptanceTest.java
@@ -18,15 +18,14 @@
 package com.graphhopper.jsprit.core.algorithm.acceptor;
 
 import com.graphhopper.jsprit.core.problem.solution.VehicleRoutingProblemSolution;
+
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
 import java.util.ArrayList;
 import java.util.List;
 
-import static org.hamcrest.CoreMatchers.is;
-import static org.junit.Assert.assertThat;
-import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -45,7 +44,7 @@ class GreedyAcceptanceTest {
         solList.add(sol2);
         VehicleRoutingProblemSolution sol3 = mock(VehicleRoutingProblemSolution.class);
         new GreedyAcceptance(2).acceptSolution(solList, sol3);
-        assertEquals(2, solList.size());
-        assertThat(sol3, is(solList.get(1)));
+        Assertions.assertEquals(2, solList.size());
+        Assertions.assertSame(sol3, solList.get(1));
     }
 }

--- a/jsprit-core/src/test/java/com/graphhopper/jsprit/core/algorithm/acceptor/SchrimpfAcceptanceTest.java
+++ b/jsprit-core/src/test/java/com/graphhopper/jsprit/core/algorithm/acceptor/SchrimpfAcceptanceTest.java
@@ -19,6 +19,8 @@ package com.graphhopper.jsprit.core.algorithm.acceptor;
 
 import com.graphhopper.jsprit.core.problem.VehicleRoutingProblem;
 import com.graphhopper.jsprit.core.problem.solution.VehicleRoutingProblemSolution;
+
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -27,8 +29,6 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -52,25 +52,29 @@ class SchrimpfAcceptanceTest {
         // create empty memory with an initial capacity of 1
         memory = new ArrayList<VehicleRoutingProblemSolution>(1);
         // insert the initial (worst) solution, will be accepted anyway since its the first in the memory
-        assertTrue(schrimpfAcceptance.acceptSolution(memory, createSolutionWithCost(2.0)), "Solution (initial cost = 2.0) should be accepted since the memory is empty");
+        Assertions.assertTrue(schrimpfAcceptance.acceptSolution(memory, createSolutionWithCost(2.0)),
+                "Solution (initial cost = 2.0) should be accepted since the memory is empty");
     }
 
     @Test
     @DisplayName("Respects The Zero Threshold _ using Worst Cost Solution")
     void respectsTheZeroThreshold_usingWorstCostSolution() {
-        assertFalse(schrimpfAcceptance.acceptSolution(memory, createSolutionWithCost(2.1)), "Worst cost solution (2.1 > 2.0) should not be accepted");
+        Assertions.assertFalse(schrimpfAcceptance.acceptSolution(memory, createSolutionWithCost(2.1)),
+                "Worst cost solution (2.1 > 2.0) should not be accepted");
     }
 
     @Test
     @DisplayName("Respects The Zero Threshold _ using Better Cost Solution")
     void respectsTheZeroThreshold_usingBetterCostSolution() {
-        assertTrue(schrimpfAcceptance.acceptSolution(memory, createSolutionWithCost(1.9)), "Better cost solution (1.9 < 2.0) should be accepted");
+        Assertions.assertTrue(schrimpfAcceptance.acceptSolution(memory, createSolutionWithCost(1.9)),
+                "Better cost solution (1.9 < 2.0) should be accepted");
     }
 
     @Test
     @DisplayName("Respects The Zero Threshold _ using Same Cost Solution")
     void respectsTheZeroThreshold_usingSameCostSolution() {
-        assertFalse(schrimpfAcceptance.acceptSolution(memory, createSolutionWithCost(2.0)), "Same cost solution (2.0 == 2.0) should not be accepted");
+        Assertions.assertFalse(schrimpfAcceptance.acceptSolution(memory, createSolutionWithCost(2.0)),
+                "Same cost solution (2.0 == 2.0) should not be accepted");
     }
 
     @Test
@@ -78,17 +82,21 @@ class SchrimpfAcceptanceTest {
     void respectsTheNonZeroThreshold_usingWorstCostSolution() {
         schrimpfAcceptance.setInitialThreshold(0.5);
         /*
-         * it should be accepted since 2.1 < 2.0 + 0.5 (2.0 is the best solution found so far and 0.5 the ini threshold
-		 * since the threshold of 0.5 allows new solutions to be <0.5 worse than the current best solution
-		 */
-        assertTrue(schrimpfAcceptance.acceptSolution(memory, createSolutionWithCost(2.1)), "Worst cost solution (2.1 > 2.0) should be accepted");
+         * it should be accepted since 2.1 < 2.0 + 0.5 (2.0 is the best solution found
+         * so far and 0.5 the ini threshold
+         * since the threshold of 0.5 allows new solutions to be <0.5 worse than the
+         * current best solution
+         */
+        Assertions.assertTrue(schrimpfAcceptance.acceptSolution(memory, createSolutionWithCost(2.1)),
+                "Worst cost solution (2.1 > 2.0) should be accepted");
     }
 
     @Test
     @DisplayName("Respects The Non Zero Threshold _ using Better Cost Solution")
     void respectsTheNonZeroThreshold_usingBetterCostSolution() {
         schrimpfAcceptance.setInitialThreshold(0.5);
-        assertTrue(schrimpfAcceptance.acceptSolution(memory, createSolutionWithCost(1.0)), "Better cost solution (1.0 < 2.0) should be accepted since the better cost bust the threshold");
+        Assertions.assertTrue(schrimpfAcceptance.acceptSolution(memory, createSolutionWithCost(1.0)),
+                "Better cost solution (1.0 < 2.0) should be accepted since the better cost bust the threshold");
     }
 
     @Test
@@ -96,14 +104,16 @@ class SchrimpfAcceptanceTest {
     void respectsTheNonZeroThreshold_usingBetterButBelowTheThresholdCostSolution() {
         schrimpfAcceptance.setInitialThreshold(0.5);
         // new solution can also be in between 2.0 and 2.5, but it is even better than 2.0 --> thus true
-        assertTrue(schrimpfAcceptance.acceptSolution(memory, createSolutionWithCost(1.9)), "Better cost solution (1.9 < 2.0) should not be accepted since the better cost is still below the threshold");
+        Assertions.assertTrue(schrimpfAcceptance.acceptSolution(memory, createSolutionWithCost(1.9)),
+                "Better cost solution (1.9 < 2.0) should not be accepted since the better cost is still below the threshold");
     }
 
     @Test
     @DisplayName("Respects The Non Zero Threshold _ using Same Cost Solution")
     void respectsTheNonZeroThreshold_usingSameCostSolution() {
         schrimpfAcceptance.setInitialThreshold(0.5);
-        assertTrue(schrimpfAcceptance.acceptSolution(memory, createSolutionWithCost(2.0)), "Same cost solution (2.0 == 2.0) should not be accepted");
+        Assertions.assertTrue(schrimpfAcceptance.acceptSolution(memory, createSolutionWithCost(2.0)),
+                "Same cost solution (2.0 == 2.0) should not be accepted");
     }
 
     @Test
@@ -112,7 +122,7 @@ class SchrimpfAcceptanceTest {
         schrimpfAcceptance.setInitialThreshold(0.5);
         schrimpfAcceptance.informIterationStarts(0, mock(VehicleRoutingProblem.class), Collections.<VehicleRoutingProblemSolution>emptyList());
         boolean accepted = schrimpfAcceptance.acceptSolution(memory, createSolutionWithCost(2.499999));
-        assertTrue(accepted);
+        Assertions.assertTrue(accepted);
     }
 
     @Test
@@ -124,7 +134,7 @@ class SchrimpfAcceptanceTest {
         // according to the acceptance-function, it should just accept every solution less than 2.0 + 0.15749013123
         // threshold(500) = 0.15749013123
         boolean accepted = schrimpfAcceptance.acceptSolution(memory, createSolutionWithCost(2.15748));
-        assertTrue(accepted);
+        Assertions.assertTrue(accepted);
     }
 
     @Test
@@ -136,7 +146,7 @@ class SchrimpfAcceptanceTest {
         // according to the acceptance-function, it should just accept every solution less than 2.0 + 0.15749013123
         // threshold(500) = 0.15749013123
         boolean accepted = schrimpfAcceptance.acceptSolution(memory, createSolutionWithCost(2.1575));
-        assertFalse(accepted);
+        Assertions.assertFalse(accepted);
     }
 
     @Test
@@ -148,7 +158,7 @@ class SchrimpfAcceptanceTest {
         // according to the acceptance-function, it should just accept every solution less than 2.0 + 0.04960628287
         // threshold(1000)= 0.04960628287
         boolean accepted = schrimpfAcceptance.acceptSolution(memory, createSolutionWithCost(2.0496));
-        assertTrue(accepted);
+        Assertions.assertTrue(accepted);
     }
 
     @Test
@@ -160,6 +170,6 @@ class SchrimpfAcceptanceTest {
         // according to the acceptance-function, it should just accept every solution less than 2.0 + 0.04960628287
         // threshold(1000)=0.04960628287
         boolean accepted = schrimpfAcceptance.acceptSolution(memory, createSolutionWithCost(2.0497));
-        assertFalse(accepted);
+        Assertions.assertFalse(accepted);
     }
 }

--- a/jsprit-core/src/test/java/com/graphhopper/jsprit/core/algorithm/box/JspritTest.java
+++ b/jsprit-core/src/test/java/com/graphhopper/jsprit/core/algorithm/box/JspritTest.java
@@ -32,6 +32,8 @@ import com.graphhopper.jsprit.core.problem.solution.VehicleRoutingProblemSolutio
 import com.graphhopper.jsprit.core.problem.solution.route.VehicleRoute;
 import com.graphhopper.jsprit.core.problem.vehicle.VehicleImpl;
 import com.graphhopper.jsprit.core.util.RandomNumberGeneration;
+
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
@@ -69,7 +71,7 @@ class JspritTest {
         });
         try {
             vra.searchSolutions();
-            assertTrue(true);
+            Assertions.assertTrue(true);
         } catch (Exception e) {
             fail();
         }
@@ -100,7 +102,7 @@ class JspritTest {
             }
         });
         vra.searchSolutions();
-        assertTrue(counts.containsKey(Jsprit.Strategy.RADIAL_BEST.toString()));
+        Assertions.assertTrue(counts.containsKey(Jsprit.Strategy.RADIAL_BEST.toString()));
     }
 
     @Test
@@ -128,7 +130,7 @@ class JspritTest {
             }
         });
         vra.searchSolutions();
-        assertTrue(!counts.containsKey(Jsprit.Strategy.RADIAL_BEST));
+        Assertions.assertTrue(!counts.containsKey(Jsprit.Strategy.RADIAL_BEST));
     }
 
     @Test
@@ -157,7 +159,7 @@ class JspritTest {
             }
         });
         vra.searchSolutions();
-        assertTrue(!counts.containsKey(Jsprit.Strategy.RADIAL_BEST));
+        Assertions.assertTrue(!counts.containsKey(Jsprit.Strategy.RADIAL_BEST));
     }
 
     @Test
@@ -194,10 +196,10 @@ class JspritTest {
         second.searchSolutions();
         for (int i = 0; i < 100; i++) {
             if (!firstRecord.get(i).equals(secondRecord.get(i))) {
-                assertFalse(true);
+                Assertions.assertFalse(true);
             }
         }
-        assertTrue(true);
+        Assertions.assertTrue(true);
     }
 
     @Test
@@ -234,10 +236,10 @@ class JspritTest {
         second.searchSolutions();
         for (int i = 0; i < 100; i++) {
             if (!firstRecord.get(i).equals(secondRecord.get(i))) {
-                assertFalse(true);
+                Assertions.assertFalse(true);
             }
         }
-        assertTrue(true);
+        Assertions.assertTrue(true);
     }
 
     @Test
@@ -287,13 +289,13 @@ class JspritTest {
             }
         });
         second.searchSolutions();
-        assertEquals(secondRecord.size(), firstRecord.size());
+        Assertions.assertEquals(secondRecord.size(), firstRecord.size());
         for (int i = 0; i < firstRecord.size(); i++) {
             if (!firstRecord.get(i).equals(secondRecord.get(i))) {
-                assertFalse(true);
+                Assertions.assertFalse(true);
             }
         }
-        assertTrue(true);
+        Assertions.assertTrue(true);
     }
 
     @Test
@@ -343,13 +345,13 @@ class JspritTest {
             }
         });
         second.searchSolutions();
-        assertEquals(secondRecord.size(), firstRecord.size());
+        Assertions.assertEquals(secondRecord.size(), firstRecord.size());
         for (int i = 0; i < firstRecord.size(); i++) {
             if (!firstRecord.get(i).equals(secondRecord.get(i))) {
-                assertFalse(true);
+                Assertions.assertFalse(true);
             }
         }
-        assertTrue(true);
+        Assertions.assertTrue(true);
     }
 
     @Test
@@ -383,13 +385,13 @@ class JspritTest {
             }
         });
         second.searchSolutions();
-        assertEquals(secondRecord.size(), firstRecord.size());
+        Assertions.assertEquals(secondRecord.size(), firstRecord.size());
         for (int i = 0; i < firstRecord.size(); i++) {
             if (!firstRecord.get(i).equals(secondRecord.get(i))) {
-                assertFalse(true);
+                Assertions.assertFalse(true);
             }
         }
-        assertTrue(true);
+        Assertions.assertTrue(true);
     }
 
     @Test
@@ -435,13 +437,13 @@ class JspritTest {
         // for(int i=0;i<secondRecord.size();i++){
         // System.out.print(secondRecord.get(i) + " (" + ((int)(firstRecordCosts.get(i)*100.))/100. + "), ");
         // }
-        assertEquals(secondRecord.size(), firstRecord.size());
+        Assertions.assertEquals(secondRecord.size(), firstRecord.size());
         for (int i = 0; i < firstRecord.size(); i++) {
             if (!firstRecord.get(i).equals(secondRecord.get(i))) {
-                assertFalse(true);
+                Assertions.assertFalse(true);
             }
         }
-        assertTrue(true);
+        Assertions.assertTrue(true);
     }
 
     @Test
@@ -450,6 +452,6 @@ class JspritTest {
         String s1 = "s2234";
         String s2 = "s1";
         int c = s1.compareTo(s2);
-        assertEquals(1, c);
+        Assertions.assertEquals(1, c);
     }
 }

--- a/jsprit-core/src/test/java/com/graphhopper/jsprit/core/algorithm/recreate/CalcVehicleTypeDependentServiceInsertionTest.java
+++ b/jsprit-core/src/test/java/com/graphhopper/jsprit/core/algorithm/recreate/CalcVehicleTypeDependentServiceInsertionTest.java
@@ -24,6 +24,8 @@ import com.graphhopper.jsprit.core.problem.job.Service;
 import com.graphhopper.jsprit.core.problem.solution.route.VehicleRoute;
 import com.graphhopper.jsprit.core.problem.solution.route.activity.TimeWindow;
 import com.graphhopper.jsprit.core.problem.vehicle.*;
+
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -31,8 +33,6 @@ import org.junit.jupiter.api.Test;
 import java.util.Arrays;
 import java.util.Collections;
 
-import static org.hamcrest.CoreMatchers.is;
-import static org.junit.Assert.assertThat;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -84,7 +84,7 @@ class CalcVehicleTypeDependentServiceInsertionTest {
         when(vrp.getInitialVehicleRoutes()).thenReturn(Collections.<VehicleRoute>emptyList());
         VehicleTypeDependentJobInsertionCalculator insertion = new VehicleTypeDependentJobInsertionCalculator(vrp, fleetManager, calc);
         InsertionData iData = insertion.getInsertionData(vehicleRoute, service, null, 0.0, null, Double.MAX_VALUE);
-        assertThat(iData.getSelectedVehicle(), is(veh1));
+        Assertions.assertSame(iData.getSelectedVehicle(), veh1);
     }
 
     @Test
@@ -100,6 +100,6 @@ class CalcVehicleTypeDependentServiceInsertionTest {
         when(vrp.getInitialVehicleRoutes()).thenReturn(Collections.<VehicleRoute>emptyList());
         VehicleTypeDependentJobInsertionCalculator insertion = new VehicleTypeDependentJobInsertionCalculator(vrp, fleetManager, calc);
         InsertionData iData = insertion.getInsertionData(vehicleRoute, service, null, 0.0, null, Double.MAX_VALUE);
-        assertThat(iData.getSelectedVehicle(), is(veh2));
+        Assertions.assertSame(iData.getSelectedVehicle(), veh2);
     }
 }

--- a/jsprit-core/src/test/java/com/graphhopper/jsprit/core/algorithm/recreate/JobInsertionConsideringFixCostsCalculatorTest.java
+++ b/jsprit-core/src/test/java/com/graphhopper/jsprit/core/algorithm/recreate/JobInsertionConsideringFixCostsCalculatorTest.java
@@ -26,6 +26,8 @@ import com.graphhopper.jsprit.core.problem.solution.route.state.RouteAndActivity
 import com.graphhopper.jsprit.core.problem.vehicle.Vehicle;
 import com.graphhopper.jsprit.core.problem.vehicle.VehicleType;
 import com.graphhopper.jsprit.core.problem.vehicle.VehicleTypeImpl;
+
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -86,7 +88,7 @@ class JobInsertionConsideringFixCostsCalculatorTest {
         relFixedCosts.setWeightOfFixCost(1.0);
         // (1.*absFix + 0.*relFix) * completeness * weight  = (1.*100. + 0.*50.) * 1. * 1. = 100.
         JobInsertionContext context = new JobInsertionContext(route, job, medium, null, 0d);
-        assertEquals(100., absFixedCosts.getCosts(context) + relFixedCosts.getCosts(context), 0.01);
+        Assertions.assertEquals(100., absFixedCosts.getCosts(context) + relFixedCosts.getCosts(context), 0.01);
     }
 
     @Test
@@ -98,7 +100,7 @@ class JobInsertionConsideringFixCostsCalculatorTest {
         relFixedCosts.setWeightOfFixCost(1.0);
         // (0.*absFix + 1.*relFix) * completeness * weight = 0.
         JobInsertionContext context = new JobInsertionContext(route, job, medium, null, 0d);
-        assertEquals(0., absFixedCosts.getCosts(context) + relFixedCosts.getCosts(context), 0.1);
+        Assertions.assertEquals(0., absFixedCosts.getCosts(context) + relFixedCosts.getCosts(context), 0.1);
     }
 
     @Test
@@ -110,7 +112,7 @@ class JobInsertionConsideringFixCostsCalculatorTest {
         relFixedCosts.setWeightOfFixCost(1.0);
         JobInsertionContext context = new JobInsertionContext(route, job, medium, null, 0d);
         // (0.5*absFix + 0.5*relFix) * 0.5 * 1. = (0.5*100+0.5*50)*0.5*1. = 37.5
-        assertEquals(37.5, absFixedCosts.getCosts(context) + relFixedCosts.getCosts(context), 0.01);
+        Assertions.assertEquals(37.5, absFixedCosts.getCosts(context) + relFixedCosts.getCosts(context), 0.01);
     }
 
     @Test
@@ -122,7 +124,7 @@ class JobInsertionConsideringFixCostsCalculatorTest {
         relFixedCosts.setWeightOfFixCost(1.0);
         JobInsertionContext context = new JobInsertionContext(route, job, medium, null, 0d);
         // (0.75*absFix + 0.25*relFix) * 0.75 * 1.= (0.75*100.+0.25*50.)*0.75*1. = 65.625
-        assertEquals(65.625, absFixedCosts.getCosts(context) + relFixedCosts.getCosts(context), 0.01);
+        Assertions.assertEquals(65.625, absFixedCosts.getCosts(context) + relFixedCosts.getCosts(context), 0.01);
     }
 
     @Test
@@ -134,7 +136,7 @@ class JobInsertionConsideringFixCostsCalculatorTest {
         relFixedCosts.setWeightOfFixCost(.5);
         JobInsertionContext context = new JobInsertionContext(route, job, medium, null, 0d);
         // (1.*absFix + 0.*relFix) * 1. * 0.5 = (1.*100. + 0.*50.) * 1. * 0.5 = 5.
-        assertEquals(50., absFixedCosts.getCosts(context) + relFixedCosts.getCosts(context), 0.01);
+        Assertions.assertEquals(50., absFixedCosts.getCosts(context) + relFixedCosts.getCosts(context), 0.01);
     }
 
     @Test
@@ -146,7 +148,7 @@ class JobInsertionConsideringFixCostsCalculatorTest {
         relFixedCosts.setWeightOfFixCost(.5);
         JobInsertionContext context = new JobInsertionContext(route, job, medium, null, 0d);
         // (0.*absFix + 1.*relFix) * 0. * .5 = 0.
-        assertEquals(0., absFixedCosts.getCosts(context) + relFixedCosts.getCosts(context), 0.01);
+        Assertions.assertEquals(0., absFixedCosts.getCosts(context) + relFixedCosts.getCosts(context), 0.01);
     }
 
     @Test
@@ -158,7 +160,7 @@ class JobInsertionConsideringFixCostsCalculatorTest {
         relFixedCosts.setWeightOfFixCost(.5);
         JobInsertionContext context = new JobInsertionContext(route, job, medium, null, 0d);
         // (0.5*absFix + 0.5*relFix) * 0.5 * 0.= (0.5*100+0.5*50)*0.5*0.5 = 18.75
-        assertEquals(18.75, absFixedCosts.getCosts(context) + relFixedCosts.getCosts(context), 0.01);
+        Assertions.assertEquals(18.75, absFixedCosts.getCosts(context) + relFixedCosts.getCosts(context), 0.01);
     }
 
     @Test
@@ -170,7 +172,7 @@ class JobInsertionConsideringFixCostsCalculatorTest {
         relFixedCosts.setWeightOfFixCost(0.5);
         JobInsertionContext context = new JobInsertionContext(route, job, medium, null, 0d);
         // (0.75*absFix + 0.25*relFix) * 0.75 * 0.5 = (0.75*100.+0.25*50.)*0.75*0.5 = 32.8125
-        assertEquals(32.8125, absFixedCosts.getCosts(context) + relFixedCosts.getCosts(context), 0.01);
+        Assertions.assertEquals(32.8125, absFixedCosts.getCosts(context) + relFixedCosts.getCosts(context), 0.01);
     }
 
     @Test
@@ -183,7 +185,7 @@ class JobInsertionConsideringFixCostsCalculatorTest {
         when(route.getVehicle()).thenReturn(small);
         JobInsertionContext context = new JobInsertionContext(route, job, medium, null, 0d);
         // (1.*absFix + 0.*relFix) * completeness * weight  = (1.*(100.-50.) + 0.*(50.-0.)) * 1. * 1. = 50.
-        assertEquals(50., absFixedCosts.getCosts(context) + relFixedCosts.getCosts(context), 0.01);
+        Assertions.assertEquals(50., absFixedCosts.getCosts(context) + relFixedCosts.getCosts(context), 0.01);
     }
 
     @Test
@@ -196,7 +198,7 @@ class JobInsertionConsideringFixCostsCalculatorTest {
         when(route.getVehicle()).thenReturn(small);
         JobInsertionContext context = new JobInsertionContext(route, job, medium, null, 0d);
         // (0.*absFix + 1.*relFix) * completeness * weight = 0.
-        assertEquals(0., absFixedCosts.getCosts(context) + relFixedCosts.getCosts(context), 0.01);
+        Assertions.assertEquals(0., absFixedCosts.getCosts(context) + relFixedCosts.getCosts(context), 0.01);
     }
 
     @Test
@@ -209,7 +211,7 @@ class JobInsertionConsideringFixCostsCalculatorTest {
         when(route.getVehicle()).thenReturn(small);
         JobInsertionContext context = new JobInsertionContext(route, job, medium, null, 0d);
         // (0.5*absFix + 0.5*relFix) * 0.5 * 1. = (0.5*(100-50)+0.5*(50-0))*0.5*1. = 25.
-        assertEquals(25., absFixedCosts.getCosts(context) + relFixedCosts.getCosts(context), 0.01);
+        Assertions.assertEquals(25., absFixedCosts.getCosts(context) + relFixedCosts.getCosts(context), 0.01);
     }
 
     @Test
@@ -222,7 +224,7 @@ class JobInsertionConsideringFixCostsCalculatorTest {
         when(route.getVehicle()).thenReturn(small);
         JobInsertionContext context = new JobInsertionContext(route, job, medium, null, 0d);
         // (0.75*absFix + 0.25*relFix) * 0.75 * 1.= (0.75*(100.-50.)+0.25*(50.-0.))*0.75*1. = 37.5
-        assertEquals(37.5, absFixedCosts.getCosts(context) + relFixedCosts.getCosts(context), 0.01);
+        Assertions.assertEquals(37.5, absFixedCosts.getCosts(context) + relFixedCosts.getCosts(context), 0.01);
     }
 
     @Test
@@ -235,7 +237,7 @@ class JobInsertionConsideringFixCostsCalculatorTest {
         when(route.getVehicle()).thenReturn(small);
         JobInsertionContext context = new JobInsertionContext(route, job, medium, null, 0d);
         // (1.*absFix + 0.*relFix) * 1. * 0.5 = (1.*(100.-50.) + 0.*(50.-0.)) * 1. * 0.5 = 25.
-        assertEquals(25., absFixedCosts.getCosts(context) + relFixedCosts.getCosts(context), 0.01);
+        Assertions.assertEquals(25., absFixedCosts.getCosts(context) + relFixedCosts.getCosts(context), 0.01);
     }
 
     @Test
@@ -248,7 +250,7 @@ class JobInsertionConsideringFixCostsCalculatorTest {
         when(route.getVehicle()).thenReturn(small);
         JobInsertionContext context = new JobInsertionContext(route, job, medium, null, 0d);
         // (0.*absFix + 1.*relFix) * 0. * .5 = 0.
-        assertEquals(0., absFixedCosts.getCosts(context) + relFixedCosts.getCosts(context), 0.01);
+        Assertions.assertEquals(0., absFixedCosts.getCosts(context) + relFixedCosts.getCosts(context), 0.01);
     }
 
     @Test
@@ -261,7 +263,7 @@ class JobInsertionConsideringFixCostsCalculatorTest {
         when(route.getVehicle()).thenReturn(small);
         JobInsertionContext context = new JobInsertionContext(route, job, medium, null, 0d);
         // (0.5*absFix + 0.5*relFix) * 0.5 * 0.= (0.5*(100-50)+0.5*(50-0))*0.5*0.5 = 12.5
-        assertEquals(12.5, absFixedCosts.getCosts(context) + relFixedCosts.getCosts(context), 0.01);
+        Assertions.assertEquals(12.5, absFixedCosts.getCosts(context) + relFixedCosts.getCosts(context), 0.01);
     }
 
     @Test
@@ -274,7 +276,7 @@ class JobInsertionConsideringFixCostsCalculatorTest {
         when(route.getVehicle()).thenReturn(small);
         JobInsertionContext context = new JobInsertionContext(route, job, medium, null, 0d);
         // (0.75*absFix + 0.25*relFix) * 0.75 * 0.5 = (0.75*(100.-50.)+0.25*(50.-0.))*0.75*0.5 = 18.75
-        assertEquals(18.75, absFixedCosts.getCosts(context) + relFixedCosts.getCosts(context), 0.01);
+        Assertions.assertEquals(18.75, absFixedCosts.getCosts(context) + relFixedCosts.getCosts(context), 0.01);
     }
 
     @Test
@@ -288,7 +290,7 @@ class JobInsertionConsideringFixCostsCalculatorTest {
         when(stateGetter.getRouteState(route, InternalStates.MAXLOAD, Capacity.class)).thenReturn(Capacity.Builder.newInstance().addDimension(0, 25).build());
         JobInsertionContext context = new JobInsertionContext(route, job, medium, null, 0d);
         // (0.5*absFix + 0.5*relFix) * 0.5 * 0.= (0.5*(100-50)+0.5*(75-25))*0.5*0.5 = 12.5
-        assertEquals(12.5, absFixedCosts.getCosts(context) + relFixedCosts.getCosts(context), 0.01);
+        Assertions.assertEquals(12.5, absFixedCosts.getCosts(context) + relFixedCosts.getCosts(context), 0.01);
     }
 
     @Test
@@ -301,7 +303,7 @@ class JobInsertionConsideringFixCostsCalculatorTest {
         when(route.getVehicle()).thenReturn(small);
         JobInsertionContext context = new JobInsertionContext(route, job, medium, null, 0d);
         // (0.75*absFix + 0.25*relFix) * 0.75 * 0.5 = (0.75*(100.-50.)+0.25*(75.-25.))*0.75*0.5 = 18.75
-        assertEquals(18.75, absFixedCosts.getCosts(context) + relFixedCosts.getCosts(context), 0.01);
+        Assertions.assertEquals(18.75, absFixedCosts.getCosts(context) + relFixedCosts.getCosts(context), 0.01);
     }
 
     @Test
@@ -322,12 +324,13 @@ class JobInsertionConsideringFixCostsCalculatorTest {
         // (0.5*absFix + 0.5*relFix) * 0.5 * 0.= (0.5*(100-50)+0.5*(75-25))*0.5*0.5 = 12.5
         /*
          * (0.5*(100-50)+0.5*(
-		 * relFixNew - relFixOld = (75/100+100/400)/2.*100 - ((25/50+100/100)/2.*50.) =
-		 * )*0.5*0.5
-		 * = (0.5*(100-50)+0.5*((75/100+100/400)/2.*100 - ((25/50+100/100)/2.*50.)))*0.5*0.5
-		 * = (0.5*(100-50)+0.5*12.5)*0.5*0.5 = 7.8125
-		 */
-        assertEquals(7.8125, absFixedCosts.getCosts(context) + relFixedCosts.getCosts(context), 0.01);
+         * relFixNew - relFixOld = (75/100+100/400)/2.*100 - ((25/50+100/100)/2.*50.) =
+         * )*0.5*0.5
+         * = (0.5*(100-50)+0.5*((75/100+100/400)/2.*100 -
+         * ((25/50+100/100)/2.*50.)))*0.5*0.5
+         * = (0.5*(100-50)+0.5*12.5)*0.5*0.5 = 7.8125
+         */
+        Assertions.assertEquals(7.8125, absFixedCosts.getCosts(context) + relFixedCosts.getCosts(context), 0.01);
     }
 
     @Test
@@ -347,14 +350,15 @@ class JobInsertionConsideringFixCostsCalculatorTest {
         // (0.5*absFix + 0.5*relFix) * 0.5 * 0.= (0.5*(100-50)+0.5*(75-25))*0.5*0.5 = 12.5
         /*
          * (0.5*(100-50)+0.5*(
-		 * relFixNew - relFixOld = (75/100+100/400)/2.*100 - ((25/50+100/100)/2.*50.) =
-		 * )*0.5*0.5
-		 * = (0.5*(100-50)+0.5*((75/100+100/400)/2.*100 - ((25/50+100/100)/2.*50.)))*0.5*0.5
-		 * = (0.5*(100-50)+0.5*12.5)*0.5*0.5 = 7.8125
-		 */
+         * relFixNew - relFixOld = (75/100+100/400)/2.*100 - ((25/50+100/100)/2.*50.) =
+         * )*0.5*0.5
+         * = (0.5*(100-50)+0.5*((75/100+100/400)/2.*100 -
+         * ((25/50+100/100)/2.*50.)))*0.5*0.5
+         * = (0.5*(100-50)+0.5*12.5)*0.5*0.5 = 7.8125
+         */
         JobInsertionContext context = new JobInsertionContext(route, job, medium, null, 0d);
         double insertionCost = absFixedCosts.getCosts(context) + relFixedCosts.getCosts(context);
-        assertEquals(-50d, insertionCost, 0.01);
+        Assertions.assertEquals(-50d, insertionCost, 0.01);
     }
 
     @Test
@@ -367,7 +371,7 @@ class JobInsertionConsideringFixCostsCalculatorTest {
         when(route.getVehicle()).thenReturn(small);
         JobInsertionContext context = new JobInsertionContext(route, job, medium, null, 0d);
         double insertionCost = absFixedCosts.getCosts(context) + relFixedCosts.getCosts(context);
-        assertEquals(50d, insertionCost, 0.01);
+        Assertions.assertEquals(50d, insertionCost, 0.01);
     }
 
     @Test
@@ -380,7 +384,7 @@ class JobInsertionConsideringFixCostsCalculatorTest {
         when(route.getVehicle()).thenReturn(small);
         JobInsertionContext context = new JobInsertionContext(route, job, large, null, 0d);
         double insertionCost = absFixedCosts.getCosts(context) + relFixedCosts.getCosts(context);
-        assertEquals(150d, insertionCost, 0.01);
+        Assertions.assertEquals(150d, insertionCost, 0.01);
     }
 
     @Test
@@ -393,7 +397,7 @@ class JobInsertionConsideringFixCostsCalculatorTest {
         when(route.getVehicle()).thenReturn(large);
         JobInsertionContext context = new JobInsertionContext(route, job, medium, null, 0d);
         double insertionCost = absFixedCosts.getCosts(context) + relFixedCosts.getCosts(context);
-        assertEquals(-100d, insertionCost, 0.01);
+        Assertions.assertEquals(-100d, insertionCost, 0.01);
     }
 
     @Test
@@ -406,7 +410,7 @@ class JobInsertionConsideringFixCostsCalculatorTest {
         when(route.getVehicle()).thenReturn(medium);
         JobInsertionContext context = new JobInsertionContext(route, job, large, null, 0d);
         double insertionCost = absFixedCosts.getCosts(context) + relFixedCosts.getCosts(context);
-        assertEquals(100d, insertionCost, 0.01);
+        Assertions.assertEquals(100d, insertionCost, 0.01);
     }
 
     @Test
@@ -432,7 +436,7 @@ class JobInsertionConsideringFixCostsCalculatorTest {
          */
         JobInsertionContext context = new JobInsertionContext(route, job, medium, null, 0d);
         double insertionCost = absFixedCosts.getCosts(context) + relFixedCosts.getCosts(context);
-        assertEquals(2.875, insertionCost, 0.01);
+        Assertions.assertEquals(2.875, insertionCost, 0.01);
     }
 
     @Test
@@ -451,6 +455,6 @@ class JobInsertionConsideringFixCostsCalculatorTest {
         when(stateGetter.getRouteState(route, InternalStates.MAXLOAD, Capacity.class)).thenReturn(Capacity.Builder.newInstance().addDimension(0, 25).addDimension(1, 100).build());
         JobInsertionContext context = new JobInsertionContext(route, job, medium, null, 0d);
         // (0.75*absFix + 0.25*relFix) * 0.75 * 0.5 = (0.75*(100.-50.)+0.25*12.5)*0.75*0.5 = 15.234375
-        assertEquals(15.234375, absFixedCosts.getCosts(context) + relFixedCosts.getCosts(context), 0.01);
+        Assertions.assertEquals(15.234375, absFixedCosts.getCosts(context) + relFixedCosts.getCosts(context), 0.01);
     }
 }

--- a/jsprit-core/src/test/java/com/graphhopper/jsprit/core/algorithm/recreate/RegretInsertionTest.java
+++ b/jsprit-core/src/test/java/com/graphhopper/jsprit/core/algorithm/recreate/RegretInsertionTest.java
@@ -40,13 +40,13 @@ import com.graphhopper.jsprit.core.problem.solution.route.activity.TourActivity;
 import com.graphhopper.jsprit.core.problem.vehicle.*;
 import com.graphhopper.jsprit.core.util.Coordinate;
 import com.graphhopper.jsprit.core.util.Solutions;
+
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
 import java.util.ArrayList;
 import java.util.Collection;
-
-import static org.junit.jupiter.api.Assertions.*;
 
 @DisplayName("Regret Insertion Test")
 class RegretInsertionTest {
@@ -63,7 +63,7 @@ class RegretInsertionTest {
         RegretInsertionFast regretInsertion = new RegretInsertionFast(calculator, vrp, fm);
         Collection<VehicleRoute> routes = new ArrayList<VehicleRoute>();
         regretInsertion.insertJobs(routes, vrp.getJobs().values());
-        assertEquals(1, routes.size());
+        Assertions.assertEquals(1, routes.size());
     }
 
     @Test
@@ -78,7 +78,7 @@ class RegretInsertionTest {
         RegretInsertionFast regretInsertion = new RegretInsertionFast(calculator, vrp, fm);
         Collection<VehicleRoute> routes = new ArrayList<VehicleRoute>();
         regretInsertion.insertJobs(routes, vrp.getJobs().values());
-        assertEquals(2, routes.iterator().next().getActivities().size());
+        Assertions.assertEquals(2, routes.iterator().next().getActivities().size());
     }
 
     @Test
@@ -95,7 +95,7 @@ class RegretInsertionTest {
         CkeckJobSequence position = new CkeckJobSequence(2, s1);
         regretInsertion.addListener(position);
         regretInsertion.insertJobs(routes, vrp.getJobs().values());
-        assertTrue(position.isCorrect());
+        Assertions.assertTrue(position.isCorrect());
     }
 
     @Test
@@ -110,7 +110,7 @@ class RegretInsertionTest {
         ConstraintManager constraintManager = new ConstraintManager(vrp, stateManager);
         VehicleRoutingAlgorithm vra = Jsprit.Builder.newInstance(vrp).addCoreStateAndConstraintStuff(true).setProperty(Jsprit.Parameter.FAST_REGRET, "true").setStateAndConstraintManager(stateManager, constraintManager).buildAlgorithm();
         VehicleRoutingProblemSolution solution = Solutions.bestOf(vra.searchSolutions());
-        assertEquals(2, solution.getRoutes().size());
+        Assertions.assertEquals(2, solution.getRoutes().size());
     }
 
     @DisplayName("Job In Route Updater")
@@ -219,12 +219,12 @@ class RegretInsertionTest {
         for (VehicleRoute route : solution.getRoutes()) {
             if (route.getTourActivities().servesJob(s1)) {
                 if (!route.getTourActivities().servesJob(s2)) {
-                    assertFalse(true);
+                    Assertions.assertFalse(true);
                 } else
-                    assertTrue(true);
+                    Assertions.assertTrue(true);
             }
         }
-        // Assert.assertEquals(1, solution.getRoutes().size());
+        // Assertions.assertEquals(1, solution.getRoutes().size());
     }
 
     @Test
@@ -251,9 +251,9 @@ class RegretInsertionTest {
         for (VehicleRoute route : solution.getRoutes()) {
             if (route.getTourActivities().servesJob(s1)) {
                 if (!route.getTourActivities().servesJob(s2)) {
-                    assertFalse(true);
+                    Assertions.assertFalse(true);
                 } else
-                    assertTrue(true);
+                    Assertions.assertTrue(true);
             }
         }
     }
@@ -272,7 +272,7 @@ class RegretInsertionTest {
         CkeckJobSequence position = new CkeckJobSequence(2, s2);
         regretInsertion.addListener(position);
         regretInsertion.insertJobs(routes, vrp.getJobs().values());
-        assertTrue(position.isCorrect());
+        Assertions.assertTrue(position.isCorrect());
     }
 
     private JobInsertionCostsCalculator getShipmentCalculator(final VehicleRoutingProblem vrp) {

--- a/jsprit-core/src/test/java/com/graphhopper/jsprit/core/algorithm/recreate/ServiceInsertionAndLoadConstraintsTest.java
+++ b/jsprit-core/src/test/java/com/graphhopper/jsprit/core/algorithm/recreate/ServiceInsertionAndLoadConstraintsTest.java
@@ -43,6 +43,8 @@ import com.graphhopper.jsprit.core.problem.vehicle.VehicleImpl;
 import com.graphhopper.jsprit.core.problem.vehicle.VehicleType;
 import com.graphhopper.jsprit.core.problem.vehicle.VehicleTypeImpl;
 import com.graphhopper.jsprit.core.util.CostFactory;
+
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -141,6 +143,6 @@ class ServiceInsertionAndLoadConstraintsTest {
         switcher.put(Delivery.class, serviceInsertionCalc);
         switcher.put(Shipment.class, insertionCalculator);
         InsertionData iData = switcher.getInsertionData(route, pickup, vehicle, 0, DriverImpl.noDriver(), Double.MAX_VALUE);
-        assertEquals(1, iData.getDeliveryInsertionIndex());
+        Assertions.assertEquals(1, iData.getDeliveryInsertionIndex());
     }
 }

--- a/jsprit-core/src/test/java/com/graphhopper/jsprit/core/algorithm/recreate/ShipmentInsertionCalculatorFlexTest.java
+++ b/jsprit-core/src/test/java/com/graphhopper/jsprit/core/algorithm/recreate/ShipmentInsertionCalculatorFlexTest.java
@@ -46,6 +46,8 @@ import com.graphhopper.jsprit.core.problem.vehicle.VehicleImpl;
 import com.graphhopper.jsprit.core.problem.vehicle.VehicleType;
 import com.graphhopper.jsprit.core.problem.vehicle.VehicleTypeImpl;
 import com.graphhopper.jsprit.core.util.CostFactory;
+
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.DisplayName;
@@ -125,7 +127,7 @@ class ShipmentInsertionCalculatorFlexTest {
         insertionCalculator = new ShipmentInsertionCalculatorFlex(routingCosts, activityCosts, activityInsertionCostsCalculator, constraintManager);
         insertionCalculator.setJobActivityFactory(activityFactory);
         InsertionData iData = insertionCalculator.getInsertionData(route, shipment, vehicle, 0.0, null, Double.MAX_VALUE);
-        assertEquals(40.0, iData.getInsertionCost(), 0.05);
+        Assertions.assertEquals(40.0, iData.getInsertionCost(), 0.05);
     }
 
     @Test
@@ -144,9 +146,9 @@ class ShipmentInsertionCalculatorFlexTest {
         insertionCalculator = new ShipmentInsertionCalculatorFlex(routingCosts, activityCosts, activityInsertionCostsCalculator, constraintManager);
         insertionCalculator.setJobActivityFactory(activityFactory);
         InsertionData iData = insertionCalculator.getInsertionData(route, shipment2, vehicle, 0.0, null, Double.MAX_VALUE);
-        assertEquals(0.0, iData.getInsertionCost(), 0.05);
-        assertEquals(1, iData.getPickupInsertionIndex());
-        assertEquals(2, iData.getDeliveryInsertionIndex());
+        Assertions.assertEquals(0.0, iData.getInsertionCost(), 0.05);
+        Assertions.assertEquals(1, iData.getPickupInsertionIndex());
+        Assertions.assertEquals(2, iData.getDeliveryInsertionIndex());
     }
 
     private List<AbstractActivity> getTourActivities(Shipment shipment) {
@@ -182,7 +184,7 @@ class ShipmentInsertionCalculatorFlexTest {
         insertionCalculator = new ShipmentInsertionCalculatorFlex(routingCosts, activityCosts, activityInsertionCostsCalculator, constraintManager);
         insertionCalculator.setJobActivityFactory(activityFactory);
         InsertionData iData = insertionCalculator.getInsertionData(route, shipment2, vehicle, 0.0, null, Double.MAX_VALUE);
-        assertTrue(iData instanceof InsertionData.NoInsertionFound);
+        Assertions.assertTrue(iData instanceof InsertionData.NoInsertionFound);
     }
 
     @Test
@@ -205,9 +207,9 @@ class ShipmentInsertionCalculatorFlexTest {
         insertionCalculator = new ShipmentInsertionCalculatorFlex(routingCosts, activityCosts, activityInsertionCostsCalculator, constraintManager);
         insertionCalculator.setJobActivityFactory(activityFactory);
         InsertionData iData = insertionCalculator.getInsertionData(route, shipment3, vehicle, 0.0, null, Double.MAX_VALUE);
-        assertEquals(0.0, iData.getInsertionCost(), 0.05);
-        assertEquals(0, iData.getPickupInsertionIndex());
-        assertEquals(1, iData.getDeliveryInsertionIndex());
+        Assertions.assertEquals(0.0, iData.getInsertionCost(), 0.05);
+        Assertions.assertEquals(0, iData.getPickupInsertionIndex());
+        Assertions.assertEquals(1, iData.getDeliveryInsertionIndex());
     }
 
     @Test
@@ -230,9 +232,9 @@ class ShipmentInsertionCalculatorFlexTest {
         insertionCalculator = new ShipmentInsertionCalculatorFlex(routingCosts, activityCosts, activityInsertionCostsCalculator, constraintManager);
         insertionCalculator.setJobActivityFactory(activityFactory);
         InsertionData iData = insertionCalculator.getInsertionData(route, shipment3, vehicle, 0.0, null, Double.MAX_VALUE);
-        assertEquals(2.0, iData.getInsertionCost(), 0.05);
-        assertEquals(0, iData.getPickupInsertionIndex());
-        assertEquals(1, iData.getDeliveryInsertionIndex());
+        Assertions.assertEquals(2.0, iData.getInsertionCost(), 0.05);
+        Assertions.assertEquals(0, iData.getPickupInsertionIndex());
+        Assertions.assertEquals(1, iData.getDeliveryInsertionIndex());
     }
 
     @Test
@@ -257,7 +259,7 @@ class ShipmentInsertionCalculatorFlexTest {
         ShipmentInsertionCalculatorFlex insertionCalculator = new ShipmentInsertionCalculatorFlex(routingCosts, activityCosts, activityInsertionCostsCalculator, constraintManager);
         insertionCalculator.setJobActivityFactory(vrp.getJobActivityFactory());
         InsertionData iData = insertionCalculator.getInsertionData(route, shipment3, vehicle, 0.0, DriverImpl.noDriver(), Double.MAX_VALUE);
-        assertTrue(iData instanceof InsertionData.NoInsertionFound);
+        Assertions.assertTrue(iData instanceof InsertionData.NoInsertionFound);
     }
 
     @Disabled
@@ -285,7 +287,7 @@ class ShipmentInsertionCalculatorFlexTest {
         insertionCalculator.setEvalIndexDelivery(3);
         insertionCalculator.setJobActivityFactory(vrp.getJobActivityFactory());
         InsertionData iData = insertionCalculator.getInsertionData(route, shipment3, vehicle, 0.0, DriverImpl.noDriver(), Double.MAX_VALUE);
-        assertTrue(iData instanceof InsertionData.NoInsertionFound);
+        Assertions.assertTrue(iData instanceof InsertionData.NoInsertionFound);
     }
 
     @Test
@@ -320,6 +322,6 @@ class ShipmentInsertionCalculatorFlexTest {
         switcher.put(Shipment.class, insertionCalculator);
         InsertionData iData = switcher.getInsertionData(route, service, vehicle, 0, DriverImpl.noDriver(), Double.MAX_VALUE);
         // routeActVisitor.visit(route);
-        assertEquals(3, iData.getDeliveryInsertionIndex());
+        Assertions.assertEquals(3, iData.getDeliveryInsertionIndex());
     }
 }

--- a/jsprit-core/src/test/java/com/graphhopper/jsprit/core/algorithm/recreate/ShipmentInsertionCalculatorTest.java
+++ b/jsprit-core/src/test/java/com/graphhopper/jsprit/core/algorithm/recreate/ShipmentInsertionCalculatorTest.java
@@ -46,6 +46,8 @@ import com.graphhopper.jsprit.core.problem.vehicle.VehicleImpl;
 import com.graphhopper.jsprit.core.problem.vehicle.VehicleType;
 import com.graphhopper.jsprit.core.problem.vehicle.VehicleTypeImpl;
 import com.graphhopper.jsprit.core.util.CostFactory;
+
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -123,7 +125,7 @@ class ShipmentInsertionCalculatorTest {
         when(activityFactory.createActivities(shipment)).thenReturn(activities);
         insertionCalculator = new ShipmentInsertionCalculator(routingCosts, activityCosts, activityInsertionCostsCalculator, constraintManager, activityFactory);
         InsertionData iData = insertionCalculator.getInsertionData(route, shipment, vehicle, 0.0, null, Double.MAX_VALUE);
-        assertEquals(40.0, iData.getInsertionCost(), 0.05);
+        Assertions.assertEquals(40.0, iData.getInsertionCost(), 0.05);
     }
 
     @Test
@@ -141,9 +143,9 @@ class ShipmentInsertionCalculatorTest {
         when(activityFactory.createActivities(shipment2)).thenReturn(activities);
         insertionCalculator = new ShipmentInsertionCalculator(routingCosts, activityCosts, activityInsertionCostsCalculator, constraintManager, activityFactory);
         InsertionData iData = insertionCalculator.getInsertionData(route, shipment2, vehicle, 0.0, null, Double.MAX_VALUE);
-        assertEquals(0.0, iData.getInsertionCost(), 0.05);
-        assertEquals(1, iData.getPickupInsertionIndex());
-        assertEquals(2, iData.getDeliveryInsertionIndex());
+        Assertions.assertEquals(0.0, iData.getInsertionCost(), 0.05);
+        Assertions.assertEquals(1, iData.getPickupInsertionIndex());
+        Assertions.assertEquals(2, iData.getDeliveryInsertionIndex());
     }
 
     private List<AbstractActivity> getTourActivities(Shipment shipment) {
@@ -178,7 +180,7 @@ class ShipmentInsertionCalculatorTest {
         when(activityFactory.createActivities(shipment2)).thenReturn(activities);
         insertionCalculator = new ShipmentInsertionCalculator(routingCosts, activityCosts, activityInsertionCostsCalculator, constraintManager, activityFactory);
         InsertionData iData = insertionCalculator.getInsertionData(route, shipment2, vehicle, 0.0, null, Double.MAX_VALUE);
-        assertTrue(iData instanceof InsertionData.NoInsertionFound);
+        Assertions.assertTrue(iData instanceof InsertionData.NoInsertionFound);
     }
 
     @Test
@@ -200,9 +202,9 @@ class ShipmentInsertionCalculatorTest {
         when(activityFactory.createActivities(shipment3)).thenReturn(activities);
         insertionCalculator = new ShipmentInsertionCalculator(routingCosts, activityCosts, activityInsertionCostsCalculator, constraintManager, activityFactory);
         InsertionData iData = insertionCalculator.getInsertionData(route, shipment3, vehicle, 0.0, null, Double.MAX_VALUE);
-        assertEquals(0.0, iData.getInsertionCost(), 0.05);
-        assertEquals(0, iData.getPickupInsertionIndex());
-        assertEquals(1, iData.getDeliveryInsertionIndex());
+        Assertions.assertEquals(0.0, iData.getInsertionCost(), 0.05);
+        Assertions.assertEquals(0, iData.getPickupInsertionIndex());
+        Assertions.assertEquals(1, iData.getDeliveryInsertionIndex());
     }
 
     @Test
@@ -224,9 +226,9 @@ class ShipmentInsertionCalculatorTest {
         when(activityFactory.createActivities(shipment3)).thenReturn(activities);
         insertionCalculator = new ShipmentInsertionCalculator(routingCosts, activityCosts, activityInsertionCostsCalculator, constraintManager, activityFactory);
         InsertionData iData = insertionCalculator.getInsertionData(route, shipment3, vehicle, 0.0, null, Double.MAX_VALUE);
-        assertEquals(2.0, iData.getInsertionCost(), 0.05);
-        assertEquals(0, iData.getPickupInsertionIndex());
-        assertEquals(1, iData.getDeliveryInsertionIndex());
+        Assertions.assertEquals(2.0, iData.getInsertionCost(), 0.05);
+        Assertions.assertEquals(0, iData.getPickupInsertionIndex());
+        Assertions.assertEquals(1, iData.getDeliveryInsertionIndex());
     }
 
     @Test
@@ -250,7 +252,7 @@ class ShipmentInsertionCalculatorTest {
         constraintManager.addConstraint(new ShipmentPickupsFirstConstraint(), ConstraintManager.Priority.CRITICAL);
         ShipmentInsertionCalculator insertionCalculator = new ShipmentInsertionCalculator(routingCosts, activityCosts, activityInsertionCostsCalculator, constraintManager, vrp.getJobActivityFactory());
         InsertionData iData = insertionCalculator.getInsertionData(route, shipment3, vehicle, 0.0, DriverImpl.noDriver(), Double.MAX_VALUE);
-        assertTrue(iData instanceof InsertionData.NoInsertionFound);
+        Assertions.assertTrue(iData instanceof InsertionData.NoInsertionFound);
     }
 
     @Test
@@ -284,6 +286,6 @@ class ShipmentInsertionCalculatorTest {
         switcher.put(Shipment.class, insertionCalculator);
         InsertionData iData = switcher.getInsertionData(route, service, vehicle, 0, DriverImpl.noDriver(), Double.MAX_VALUE);
         // routeActVisitor.visit(route);
-        assertEquals(3, iData.getDeliveryInsertionIndex());
+        Assertions.assertEquals(3, iData.getDeliveryInsertionIndex());
     }
 }

--- a/jsprit-core/src/test/java/com/graphhopper/jsprit/core/algorithm/recreate/TestAuxilliaryCostCalculator.java
+++ b/jsprit-core/src/test/java/com/graphhopper/jsprit/core/algorithm/recreate/TestAuxilliaryCostCalculator.java
@@ -23,12 +23,13 @@ import com.graphhopper.jsprit.core.problem.cost.VehicleRoutingTransportCosts;
 import com.graphhopper.jsprit.core.problem.solution.route.activity.End;
 import com.graphhopper.jsprit.core.problem.solution.route.activity.TourActivity;
 import com.graphhopper.jsprit.core.problem.vehicle.Vehicle;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.util.Arrays;
 
-import static org.junit.Assert.assertEquals;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -40,7 +41,7 @@ public class TestAuxilliaryCostCalculator {
 
     private Vehicle vehicle;
 
-    @Before
+    @BeforeEach
     public void doBefore() {
         vehicle = mock(Vehicle.class);
 
@@ -72,7 +73,7 @@ public class TestAuxilliaryCostCalculator {
 
         AuxilliaryCostCalculator aCalc = new AuxilliaryCostCalculator(routingCosts, actCosts);
         double costs = aCalc.costOfPath(Arrays.asList(prevAct, newAct, nextAct), 0.0, null, vehicle);
-        assertEquals(6.0, costs, 0.01);
+		Assertions.assertEquals(6.0, costs, 0.01);
     }
 
     @Test
@@ -87,7 +88,7 @@ public class TestAuxilliaryCostCalculator {
 
         AuxilliaryCostCalculator aCalc = new AuxilliaryCostCalculator(routingCosts, actCosts);
         double costs = aCalc.costOfPath(Arrays.asList(prevAct, newAct, nextAct), 0.0, null, vehicle);
-        assertEquals(6.0, costs, 0.01);
+		Assertions.assertEquals(6.0, costs, 0.01);
     }
 
     @Test
@@ -103,7 +104,7 @@ public class TestAuxilliaryCostCalculator {
 
         AuxilliaryCostCalculator aCalc = new AuxilliaryCostCalculator(routingCosts, actCosts);
         double costs = aCalc.costOfPath(Arrays.asList(prevAct, newAct, nextAct), 0.0, null, vehicle);
-        assertEquals(6.0, costs, 0.01);
+		Assertions.assertEquals(6.0, costs, 0.01);
     }
 
     @Test
@@ -118,7 +119,7 @@ public class TestAuxilliaryCostCalculator {
 
         AuxilliaryCostCalculator aCalc = new AuxilliaryCostCalculator(routingCosts, actCosts);
         double costs = aCalc.costOfPath(Arrays.asList(prevAct, newAct, nextAct), 0.0, null, vehicle);
-        assertEquals(3.0, costs, 0.01);
+		Assertions.assertEquals(3.0, costs, 0.01);
     }
 
 }

--- a/jsprit-core/src/test/java/com/graphhopper/jsprit/core/algorithm/recreate/TestCalculatesServiceInsertion.java
+++ b/jsprit-core/src/test/java/com/graphhopper/jsprit/core/algorithm/recreate/TestCalculatesServiceInsertion.java
@@ -41,12 +41,13 @@ import com.graphhopper.jsprit.core.util.Coordinate;
 import com.graphhopper.jsprit.core.util.EuclideanDistanceCalculator;
 import com.graphhopper.jsprit.core.util.Locations;
 import com.graphhopper.jsprit.core.util.ManhattanDistanceCalculator;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.util.*;
 
-import static org.junit.Assert.assertEquals;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+
 import static org.mockito.Mockito.mock;
 
 
@@ -72,7 +73,7 @@ public class TestCalculatesServiceInsertion {
 
     private VehicleRoutingProblem vrp;
 
-    @Before
+    @BeforeEach
     public void setup() {
 
         VehicleType t1 = VehicleTypeImpl.Builder.newInstance("t1").addCapacityDimension(0, 1000).setCostPerDistance(1.0).build();
@@ -151,8 +152,8 @@ public class TestCalculatesServiceInsertion {
         states.informInsertionStarts(Arrays.asList(route), null);
 
         InsertionData iData = serviceInsertion.getInsertionData(route, first, vehicle, vehicle.getEarliestDeparture(), null, Double.MAX_VALUE);
-        assertEquals(20.0, iData.getInsertionCost(), 0.2);
-        assertEquals(0, iData.getDeliveryInsertionIndex());
+		Assertions.assertEquals(20.0, iData.getInsertionCost(), 0.2);
+		Assertions.assertEquals(0, iData.getDeliveryInsertionIndex());
     }
 
     @Test
@@ -161,8 +162,8 @@ public class TestCalculatesServiceInsertion {
         states.informInsertionStarts(Arrays.asList(route), null);
 
         InsertionData iData = serviceInsertion.getInsertionData(route, third, vehicle, vehicle.getEarliestDeparture(), null, Double.MAX_VALUE);
-        assertEquals(20.0, iData.getInsertionCost(), 0.2);
-        assertEquals(0, iData.getDeliveryInsertionIndex());
+		Assertions.assertEquals(20.0, iData.getInsertionCost(), 0.2);
+		Assertions.assertEquals(0, iData.getDeliveryInsertionIndex());
     }
 
     @Test
@@ -171,8 +172,8 @@ public class TestCalculatesServiceInsertion {
         states.informInsertionStarts(Arrays.asList(route), null);
 
         InsertionData iData = serviceInsertion.getInsertionData(route, second, vehicle, vehicle.getEarliestDeparture(), null, Double.MAX_VALUE);
-        assertEquals(0.0, iData.getInsertionCost(), 0.2);
-        assertEquals(1, iData.getDeliveryInsertionIndex());
+		Assertions.assertEquals(0.0, iData.getInsertionCost(), 0.2);
+		Assertions.assertEquals(1, iData.getDeliveryInsertionIndex());
     }
 
     @Test
@@ -181,8 +182,8 @@ public class TestCalculatesServiceInsertion {
         states.informInsertionStarts(Arrays.asList(route), null);
 
         InsertionData iData = serviceInsertion.getInsertionData(route, second, newVehicle, newVehicle.getEarliestDeparture(), null, Double.MAX_VALUE);
-        assertEquals(40.0, iData.getInsertionCost(), 0.2);
-        assertEquals(1, iData.getDeliveryInsertionIndex());
+		Assertions.assertEquals(40.0, iData.getInsertionCost(), 0.2);
+		Assertions.assertEquals(1, iData.getDeliveryInsertionIndex());
     }
 
     @Test
@@ -191,8 +192,8 @@ public class TestCalculatesServiceInsertion {
         states.informInsertionStarts(Arrays.asList(route), null);
 
         InsertionData iData = serviceInsertion.getInsertionData(route, third, vehicle, vehicle.getEarliestDeparture(), null, Double.MAX_VALUE);
-        assertEquals(0.0, iData.getInsertionCost(), 0.2);
-        assertEquals(2, iData.getDeliveryInsertionIndex());
+		Assertions.assertEquals(0.0, iData.getInsertionCost(), 0.2);
+		Assertions.assertEquals(2, iData.getDeliveryInsertionIndex());
     }
 
     @Test
@@ -203,8 +204,8 @@ public class TestCalculatesServiceInsertion {
         states.informInsertionStarts(Arrays.asList(route), null);
 
         InsertionData iData = serviceInsertion.getInsertionData(route, third, newVehicle, newVehicle.getEarliestDeparture(), null, Double.MAX_VALUE);
-        assertEquals(50.0, iData.getInsertionCost(), 0.2);
-        assertEquals(2, iData.getDeliveryInsertionIndex());
+		Assertions.assertEquals(50.0, iData.getInsertionCost(), 0.2);
+		Assertions.assertEquals(2, iData.getDeliveryInsertionIndex());
     }
 
     @Test
@@ -213,7 +214,7 @@ public class TestCalculatesServiceInsertion {
         AdditionalAccessEgressCalculator accessEgressCalc = new AdditionalAccessEgressCalculator(costs);
         Job job = Service.Builder.newInstance("1").addSizeDimension(0, 0).setLocation(Location.newInstance("1")).setTimeWindow(TimeWindow.newInstance(0.0, 100.0)).build();
         JobInsertionContext iContex = new JobInsertionContext(route, job, newVehicle, mock(Driver.class), 0.0);
-        assertEquals(0.0, accessEgressCalc.getCosts(iContex), 0.01);
+		Assertions.assertEquals(0.0, accessEgressCalc.getCosts(iContex), 0.01);
     }
 
     @Test
@@ -224,7 +225,7 @@ public class TestCalculatesServiceInsertion {
 
         AdditionalAccessEgressCalculator accessEgressCalc = new AdditionalAccessEgressCalculator(costs);
         JobInsertionContext iContex = new JobInsertionContext(route, first, newVehicle, mock(Driver.class), 0.0);
-        assertEquals(0.0, accessEgressCalc.getCosts(iContex), 0.01);
+		Assertions.assertEquals(0.0, accessEgressCalc.getCosts(iContex), 0.01);
     }
 
     @Test
@@ -262,6 +263,6 @@ public class TestCalculatesServiceInsertion {
         AdditionalAccessEgressCalculator accessEgressCalc = new AdditionalAccessEgressCalculator(routingCosts);
         Job job = Service.Builder.newInstance("service2").addSizeDimension(0, 0).setLocation(Location.newInstance("service")).build();
         JobInsertionContext iContex = new JobInsertionContext(route, job, newVehicle, mock(Driver.class), 0.0);
-        assertEquals(8.0, accessEgressCalc.getCosts(iContex), 0.01);
+		Assertions.assertEquals(8.0, accessEgressCalc.getCosts(iContex), 0.01);
     }
 }

--- a/jsprit-core/src/test/java/com/graphhopper/jsprit/core/algorithm/recreate/TestCalculatesServiceInsertionOnRouteLevel.java
+++ b/jsprit-core/src/test/java/com/graphhopper/jsprit/core/algorithm/recreate/TestCalculatesServiceInsertionOnRouteLevel.java
@@ -36,15 +36,16 @@ import com.graphhopper.jsprit.core.problem.vehicle.VehicleImpl;
 import com.graphhopper.jsprit.core.problem.vehicle.VehicleType;
 import com.graphhopper.jsprit.core.problem.vehicle.VehicleTypeImpl;
 import com.graphhopper.jsprit.core.util.CostFactory;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.List;
 
-import static org.junit.Assert.assertEquals;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+
 import static org.mockito.Mockito.mock;
 
 
@@ -70,7 +71,7 @@ public class TestCalculatesServiceInsertionOnRouteLevel {
 
     private VehicleRoutingProblem vrp;
 
-    @Before
+    @BeforeEach
     public void setup() {
 
 
@@ -145,8 +146,8 @@ public class TestCalculatesServiceInsertionOnRouteLevel {
         states.informInsertionStarts(Arrays.asList(route), null);
 
         InsertionData iData = serviceInsertion.getInsertionData(route, first, vehicle, vehicle.getEarliestDeparture(), null, Double.MAX_VALUE);
-        assertEquals(20.0, iData.getInsertionCost(), 0.2);
-        assertEquals(0, iData.getDeliveryInsertionIndex());
+		Assertions.assertEquals(20.0, iData.getInsertionCost(), 0.2);
+		Assertions.assertEquals(0, iData.getDeliveryInsertionIndex());
     }
 
     @Test
@@ -155,8 +156,8 @@ public class TestCalculatesServiceInsertionOnRouteLevel {
         states.informInsertionStarts(Arrays.asList(route), null);
 
         InsertionData iData = serviceInsertion.getInsertionData(route, third, vehicle, vehicle.getEarliestDeparture(), null, Double.MAX_VALUE);
-        assertEquals(0.0, iData.getInsertionCost(), 0.2);
-        assertEquals(1, iData.getDeliveryInsertionIndex());
+		Assertions.assertEquals(0.0, iData.getInsertionCost(), 0.2);
+		Assertions.assertEquals(1, iData.getDeliveryInsertionIndex());
     }
 
     @Test
@@ -165,8 +166,8 @@ public class TestCalculatesServiceInsertionOnRouteLevel {
         states.informInsertionStarts(Arrays.asList(route), null);
 
         InsertionData iData = serviceInsertion.getInsertionData(route, third, newVehicle, vehicle.getEarliestDeparture(), null, Double.MAX_VALUE);
-        assertEquals(40.0, iData.getInsertionCost(), 0.2);
-        assertEquals(1, iData.getDeliveryInsertionIndex());
+		Assertions.assertEquals(40.0, iData.getInsertionCost(), 0.2);
+		Assertions.assertEquals(1, iData.getDeliveryInsertionIndex());
     }
 
     @Test
@@ -175,8 +176,8 @@ public class TestCalculatesServiceInsertionOnRouteLevel {
         states.informInsertionStarts(Arrays.asList(route), null);
 
         InsertionData iData = serviceInsertion.getInsertionData(route, second, vehicle, vehicle.getEarliestDeparture(), null, Double.MAX_VALUE);
-        assertEquals(0.0, iData.getInsertionCost(), 0.2);
-        assertEquals(2, iData.getDeliveryInsertionIndex());
+		Assertions.assertEquals(0.0, iData.getInsertionCost(), 0.2);
+		Assertions.assertEquals(2, iData.getDeliveryInsertionIndex());
     }
 
     @Test
@@ -185,8 +186,8 @@ public class TestCalculatesServiceInsertionOnRouteLevel {
         states.informInsertionStarts(Arrays.asList(route), null);
 
         InsertionData iData = serviceInsertion.getInsertionData(route, second, newVehicle, vehicle.getEarliestDeparture(), null, Double.MAX_VALUE);
-        assertEquals(40.0, iData.getInsertionCost(), 0.2);
-        assertEquals(2, iData.getDeliveryInsertionIndex());
+		Assertions.assertEquals(40.0, iData.getInsertionCost(), 0.2);
+		Assertions.assertEquals(2, iData.getDeliveryInsertionIndex());
     }
 
 

--- a/jsprit-core/src/test/java/com/graphhopper/jsprit/core/algorithm/recreate/TestComparator.java
+++ b/jsprit-core/src/test/java/com/graphhopper/jsprit/core/algorithm/recreate/TestComparator.java
@@ -21,7 +21,7 @@ package com.graphhopper.jsprit.core.algorithm.recreate;
 import com.graphhopper.jsprit.core.problem.Location;
 import com.graphhopper.jsprit.core.problem.job.Job;
 import com.graphhopper.jsprit.core.problem.job.Service;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.util.ArrayList;
 import java.util.Collections;

--- a/jsprit-core/src/test/java/com/graphhopper/jsprit/core/algorithm/recreate/TestInserter.java
+++ b/jsprit-core/src/test/java/com/graphhopper/jsprit/core/algorithm/recreate/TestInserter.java
@@ -35,12 +35,12 @@ import com.graphhopper.jsprit.core.problem.solution.route.activity.TimeWindow;
 import com.graphhopper.jsprit.core.problem.vehicle.Vehicle;
 import com.graphhopper.jsprit.core.problem.vehicle.VehicleImpl;
 import com.graphhopper.jsprit.core.problem.vehicle.VehicleType;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.util.ArrayList;
 import java.util.List;
 
-import static org.junit.Assert.assertEquals;
+import org.junit.jupiter.api.Assertions;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -86,9 +86,10 @@ public class TestInserter {
         Inserter inserter = new Inserter(mock(InsertionListeners.class), vehicleRoutingProblem);
         inserter.insertJob(serviceToInsert, iData, route);
 
-        assertEquals(2, route.getTourActivities().getActivities().size());
-        assertEquals(route.getTourActivities().getActivities().get(1).getLocation().getId(), serviceToInsert.getLocation().getId());
-        assertEquals(route.getEnd().getLocation().getId(), vehicle.getEndLocation().getId());
+		Assertions.assertEquals(2, route.getTourActivities().getActivities().size());
+		Assertions.assertEquals(route.getTourActivities().getActivities().get(1).getLocation().getId(),
+				serviceToInsert.getLocation().getId());
+		Assertions.assertEquals(route.getEnd().getLocation().getId(), vehicle.getEndLocation().getId());
     }
 
     private Location loc(String vehLoc) {
@@ -120,9 +121,10 @@ public class TestInserter {
         Inserter inserter = new Inserter(mock(InsertionListeners.class), vehicleRoutingProblem);
         inserter.insertJob(serviceToInsert, iData, route);
 
-        assertEquals(2, route.getTourActivities().getActivities().size());
-        assertEquals(route.getTourActivities().getActivities().get(1).getLocation().getId(), serviceToInsert.getLocation().getId());
-        assertEquals(route.getEnd().getLocation().getId(), serviceToInsert.getLocation().getId());
+		Assertions.assertEquals(2, route.getTourActivities().getActivities().size());
+		Assertions.assertEquals(route.getTourActivities().getActivities().get(1).getLocation().getId(),
+				serviceToInsert.getLocation().getId());
+		Assertions.assertEquals(route.getEnd().getLocation().getId(), serviceToInsert.getLocation().getId());
     }
 
     private List<AbstractActivity> getTourActivities(Service serviceToInsert) {
@@ -160,10 +162,12 @@ public class TestInserter {
         Inserter inserter = new Inserter(mock(InsertionListeners.class), vehicleRoutingProblem);
         inserter.insertJob(shipmentToInsert, iData, route);
 
-        assertEquals(4, route.getTourActivities().getActivities().size());
-        assertEquals(route.getTourActivities().getActivities().get(2).getLocation().getId(), shipmentToInsert.getPickupLocation().getId());
-        assertEquals(route.getTourActivities().getActivities().get(3).getLocation().getId(), shipmentToInsert.getDeliveryLocation().getId());
-        assertEquals(route.getEnd().getLocation().getId(), vehicle.getEndLocation().getId());
+		Assertions.assertEquals(4, route.getTourActivities().getActivities().size());
+		Assertions.assertEquals(route.getTourActivities().getActivities().get(2).getLocation().getId(),
+				shipmentToInsert.getPickupLocation().getId());
+		Assertions.assertEquals(route.getTourActivities().getActivities().get(3).getLocation().getId(),
+				shipmentToInsert.getDeliveryLocation().getId());
+		Assertions.assertEquals(route.getEnd().getLocation().getId(), vehicle.getEndLocation().getId());
     }
 
     private List<AbstractActivity> getTourActivities(Shipment shipmentToInsert) {
@@ -198,10 +202,12 @@ public class TestInserter {
         Inserter inserter = new Inserter(mock(InsertionListeners.class), vehicleRoutingProblem);
         inserter.insertJob(shipmentToInsert, iData, route);
 
-        assertEquals(4, route.getTourActivities().getActivities().size());
-        assertEquals(route.getTourActivities().getActivities().get(2).getLocation().getId(), shipmentToInsert.getPickupLocation().getId());
-        assertEquals(route.getTourActivities().getActivities().get(3).getLocation().getId(), shipmentToInsert.getDeliveryLocation().getId());
-        assertEquals(route.getEnd().getLocation().getId(), shipmentToInsert.getDeliveryLocation().getId());
+		Assertions.assertEquals(4, route.getTourActivities().getActivities().size());
+		Assertions.assertEquals(route.getTourActivities().getActivities().get(2).getLocation().getId(),
+				shipmentToInsert.getPickupLocation().getId());
+		Assertions.assertEquals(route.getTourActivities().getActivities().get(3).getLocation().getId(),
+				shipmentToInsert.getDeliveryLocation().getId());
+		Assertions.assertEquals(route.getEnd().getLocation().getId(), shipmentToInsert.getDeliveryLocation().getId());
     }
 
     @Test
@@ -229,7 +235,7 @@ public class TestInserter {
         Inserter inserter = new Inserter(mock(InsertionListeners.class), vehicleRoutingProblem);
         inserter.insertJob(shipmentToInsert, iData, route);
 
-        assertEquals(route.getEnd().getLocation().getId(), newVehicle.getEndLocation().getId());
+		Assertions.assertEquals(route.getEnd().getLocation().getId(), newVehicle.getEndLocation().getId());
     }
 
     @Test
@@ -257,7 +263,7 @@ public class TestInserter {
         Inserter inserter = new Inserter(mock(InsertionListeners.class), vehicleRoutingProblem);
         inserter.insertJob(shipmentToInsert, iData, route);
 
-        assertEquals("delLoc", route.getEnd().getLocation().getId());
+		Assertions.assertEquals("delLoc", route.getEnd().getLocation().getId());
     }
 
     @Test
@@ -289,7 +295,7 @@ public class TestInserter {
         UpdateEndLocationIfRouteIsOpen updateEnd = new UpdateEndLocationIfRouteIsOpen();
         updateEnd.visit(route);
 
-        assertEquals("oldShipmentDelLoc", route.getEnd().getLocation().getId());
+		Assertions.assertEquals("oldShipmentDelLoc", route.getEnd().getLocation().getId());
     }
 
 }

--- a/jsprit-core/src/test/java/com/graphhopper/jsprit/core/algorithm/recreate/TestLocalActivityInsertionCostsCalculator.java
+++ b/jsprit-core/src/test/java/com/graphhopper/jsprit/core/algorithm/recreate/TestLocalActivityInsertionCostsCalculator.java
@@ -39,13 +39,14 @@ import com.graphhopper.jsprit.core.problem.vehicle.Vehicle;
 import com.graphhopper.jsprit.core.problem.vehicle.VehicleImpl;
 import com.graphhopper.jsprit.core.problem.vehicle.VehicleTypeImpl;
 import com.graphhopper.jsprit.core.util.CostFactory;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.util.ArrayList;
 import java.util.Arrays;
 
-import static org.junit.Assert.assertEquals;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -63,7 +64,7 @@ public class TestLocalActivityInsertionCostsCalculator {
 
     JobInsertionContext jic;
 
-    @Before
+    @BeforeEach
     public void doBefore() {
 
         vehicle = mock(Vehicle.class);
@@ -119,7 +120,7 @@ public class TestLocalActivityInsertionCostsCalculator {
             new End(v.getEndLocation(), 0, Double.MAX_VALUE),
             vrp.getActivities(s).get(0),
             0);
-        assertEquals(20., cost, Math.ulp(20.));
+		Assertions.assertEquals(20., cost, Math.ulp(20.));
     }
 
     @Test
@@ -150,14 +151,14 @@ public class TestLocalActivityInsertionCostsCalculator {
             new End(v.getEndLocation(), 0, Double.MAX_VALUE),
             vrp.getActivities(s).get(0),
             0);
-        assertEquals(20., cost, Math.ulp(20.));
+		Assertions.assertEquals(20., cost, Math.ulp(20.));
         cost = localActivityInsertionCostsCalculator.getCosts(
             jobInsertionContext,
             vrp.getActivities(s).get(0),
             new End(v.getEndLocation(), 0, Double.MAX_VALUE),
             vrp.getActivities(s).get(1),
             0);
-        assertEquals(10, cost, Math.ulp(10.));
+		Assertions.assertEquals(10, cost, Math.ulp(10.));
     }
 
     @Test
@@ -175,7 +176,7 @@ public class TestLocalActivityInsertionCostsCalculator {
         when(vehicle.isReturnToDepot()).thenReturn(true);
 
         double costs = calc.getCosts(jic, prevAct, nextAct, newAct, 0.0);
-        assertEquals(4.0, costs, 0.01);
+		Assertions.assertEquals(4.0, costs, 0.01);
     }
 
     @Test
@@ -191,7 +192,7 @@ public class TestLocalActivityInsertionCostsCalculator {
         when(vehicle.isReturnToDepot()).thenReturn(true);
 
         double costs = calc.getCosts(jic, prevAct, nextAct, newAct, 0.0);
-        assertEquals(4.0, costs, 0.01);
+		Assertions.assertEquals(4.0, costs, 0.01);
     }
 
     @Test
@@ -209,7 +210,7 @@ public class TestLocalActivityInsertionCostsCalculator {
         when(vehicle.isReturnToDepot()).thenReturn(false);
 
         double costs = calc.getCosts(jic, prevAct, nextAct, newAct, 0.0);
-        assertEquals(4.0, costs, 0.01);
+		Assertions.assertEquals(4.0, costs, 0.01);
     }
 
     @Test
@@ -225,7 +226,7 @@ public class TestLocalActivityInsertionCostsCalculator {
         when(vehicle.isReturnToDepot()).thenReturn(false);
 
         double costs = calc.getCosts(jic, prevAct, nextAct, newAct, 0.0);
-        assertEquals(3.0, costs, 0.01);
+		Assertions.assertEquals(3.0, costs, 0.01);
     }
 
     @Test
@@ -252,12 +253,12 @@ public class TestLocalActivityInsertionCostsCalculator {
         calc.setSolutionCompletenessRatio(1.);
 
         double c = calc.getCosts(context, prevAct, nextAct, newAct, 10);
-        assertEquals(50., c, 0.01);
+		Assertions.assertEquals(50., c, 0.01);
 
 		/*
-        new: dist = 90 & wait = 0
-		old: dist = 30 & wait = 10
-		c = new - old = 90 - 40 = 50
+		 * new: dist = 90 & wait = 0
+		 * old: dist = 30 & wait = 10
+		 * c = new - old = 90 - 40 = 50
 		 */
     }
 
@@ -285,7 +286,7 @@ public class TestLocalActivityInsertionCostsCalculator {
         LocalActivityInsertionCostsCalculator calc = new LocalActivityInsertionCostsCalculator(CostFactory.createEuclideanCosts(), new WaitingTimeCosts(), new StateManager(vrp));
         calc.setSolutionCompletenessRatio(1.);
         double c = calc.getCosts(context, prevAct, nextAct, newAct, 0);
-        assertEquals(-10., c, 0.01);
+		Assertions.assertEquals(-10., c, 0.01);
     }
 
     @Test
@@ -312,7 +313,7 @@ public class TestLocalActivityInsertionCostsCalculator {
         LocalActivityInsertionCostsCalculator calc = new LocalActivityInsertionCostsCalculator(CostFactory.createEuclideanCosts(), new WaitingTimeCosts(), new StateManager(vrp));
         calc.setSolutionCompletenessRatio(1.);
         double c = calc.getCosts(context, prevAct, nextAct, newAct, 0);
-        assertEquals(-10., c, 0.01);
+		Assertions.assertEquals(-10., c, 0.01);
     }
 
     @Test
@@ -336,7 +337,7 @@ public class TestLocalActivityInsertionCostsCalculator {
         LocalActivityInsertionCostsCalculator calc = new LocalActivityInsertionCostsCalculator(CostFactory.createEuclideanCosts(), new WaitingTimeCosts(), new StateManager(vrp));
         calc.setSolutionCompletenessRatio(1.);
         double c = calc.getCosts(context, prevAct, nextAct, newAct, 0);
-        assertEquals(110., c, 0.01);
+		Assertions.assertEquals(110., c, 0.01);
     }
 
     @Test
@@ -363,7 +364,7 @@ public class TestLocalActivityInsertionCostsCalculator {
         LocalActivityInsertionCostsCalculator calc = new LocalActivityInsertionCostsCalculator(CostFactory.createEuclideanCosts(), new WaitingTimeCosts(), new StateManager(vrp));
         calc.setSolutionCompletenessRatio(1.);
         double c = calc.getCosts(context, prevAct, nextAct, newAct, 10);
-        assertEquals(-10., c, 0.01);
+		Assertions.assertEquals(-10., c, 0.01);
     }
 
     @Test
@@ -393,7 +394,7 @@ public class TestLocalActivityInsertionCostsCalculator {
         LocalActivityInsertionCostsCalculator calc = new LocalActivityInsertionCostsCalculator(CostFactory.createEuclideanCosts(), new WaitingTimeCosts(), new StateManager(vrp));
         calc.setSolutionCompletenessRatio(0.5);
         double c = calc.getCosts(context, prevAct, nextAct, newAct, 10);
-        assertEquals(35., c, 0.01);
+		Assertions.assertEquals(35., c, 0.01);
     }
 
     @Test
@@ -401,7 +402,8 @@ public class TestLocalActivityInsertionCostsCalculator {
         VehicleTypeImpl type = VehicleTypeImpl.Builder.newInstance("t").setCostPerWaitingTime(1.).build();
 
         VehicleImpl v = VehicleImpl.Builder.newInstance("v").setType(type).setStartLocation(Location.newInstance(0, 0)).build();
-//		VehicleImpl v2 = VehicleImpl.Builder.newInstance("v2").setHasVariableDepartureTime(true).setType(type).setStartLocation(Location.newInstance(0,0)).build();
+		// VehicleImpl v2 =
+		// VehicleImpl.Builder.newInstance("v2").setHasVariableDepartureTime(true).setType(type).setStartLocation(Location.newInstance(0,0)).build();
 
         Service prevS = Service.Builder.newInstance("prev").setLocation(Location.newInstance(10, 0)).build();
         Service newS = Service.Builder.newInstance("new").setServiceTime(10).setTimeWindow(TimeWindow.newInstance(100, 120)).setLocation(Location.newInstance(20, 0)).build();
@@ -429,7 +431,7 @@ public class TestLocalActivityInsertionCostsCalculator {
         LocalActivityInsertionCostsCalculator calc = new LocalActivityInsertionCostsCalculator(CostFactory.createEuclideanCosts(), new WaitingTimeCosts(), stateManager);
         calc.setSolutionCompletenessRatio(1.);
         double c = calc.getCosts(context, prevAct, nextAct, newAct, 10);
-        assertEquals(-10., c, 0.01);
+		Assertions.assertEquals(-10., c, 0.01);
         //
         //old: dist: 0, waiting: 10 + 350 = 360
         //new: dist: 0, waiting: 80 + 270 = 350
@@ -440,7 +442,8 @@ public class TestLocalActivityInsertionCostsCalculator {
         VehicleTypeImpl type = VehicleTypeImpl.Builder.newInstance("t").setCostPerWaitingTime(1.).build();
 
         VehicleImpl v = VehicleImpl.Builder.newInstance("v").setType(type).setStartLocation(Location.newInstance(0, 0)).build();
-//		VehicleImpl v2 = VehicleImpl.Builder.newInstance("v2").setHasVariableDepartureTime(true).setType(type).setStartLocation(Location.newInstance(0,0)).build();
+		// VehicleImpl v2 =
+		// VehicleImpl.Builder.newInstance("v2").setHasVariableDepartureTime(true).setType(type).setStartLocation(Location.newInstance(0,0)).build();
 
         Service prevS = Service.Builder.newInstance("prev").setLocation(Location.newInstance(10, 0)).build();
         Service newS = Service.Builder.newInstance("new").setServiceTime(10).setTimeWindow(TimeWindow.newInstance(100, 120)).setLocation(Location.newInstance(20, 0)).build();
@@ -478,12 +481,12 @@ public class TestLocalActivityInsertionCostsCalculator {
         LocalActivityInsertionCostsCalculator calc = new LocalActivityInsertionCostsCalculator(CostFactory.createEuclideanCosts(), new WaitingTimeCosts(), stateManager);
         calc.setSolutionCompletenessRatio(1.);
         double c = calc.getCosts(context, prevAct, nextAct, newAct, 10);
-        assertEquals(20., c, 0.01);
+		Assertions.assertEquals(20., c, 0.01);
         //start-delay = new - old = 120 - 40 = 80 > future waiting time savings = 30 + 20 + 10
         //ref: 10 + 50 + 20 = 80
         //new: 80 - 10 - 30 - 20 = 20
         /*
-        w(new) + w(next) - w_old(next) - min{start_delay(next),future_waiting}
+		 * w(new) + w(next) - w_old(next) - min{start_delay(next),future_waiting}
 		 */
     }
 
@@ -492,7 +495,8 @@ public class TestLocalActivityInsertionCostsCalculator {
         VehicleTypeImpl type = VehicleTypeImpl.Builder.newInstance("t").setCostPerWaitingTime(1.).build();
 
         VehicleImpl v = VehicleImpl.Builder.newInstance("v").setType(type).setStartLocation(Location.newInstance(0, 0)).build();
-//		VehicleImpl v2 = VehicleImpl.Builder.newInstance("v2").setHasVariableDepartureTime(true).setType(type).setStartLocation(Location.newInstance(0,0)).build();
+		// VehicleImpl v2 =
+		// VehicleImpl.Builder.newInstance("v2").setHasVariableDepartureTime(true).setType(type).setStartLocation(Location.newInstance(0,0)).build();
 
         Service prevS = Service.Builder.newInstance("prev").setLocation(Location.newInstance(10, 0)).build();
         Service newS = Service.Builder.newInstance("new").setServiceTime(10).setTimeWindow(TimeWindow.newInstance(100, 120)).setLocation(Location.newInstance(20, 0)).build();
@@ -529,16 +533,17 @@ public class TestLocalActivityInsertionCostsCalculator {
         LocalActivityInsertionCostsCalculator calc = new LocalActivityInsertionCostsCalculator(CostFactory.createEuclideanCosts(), new WaitingTimeCosts(), stateManager);
         calc.setSolutionCompletenessRatio(1.);
         double c = calc.getCosts(context, prevAct, nextAct, newAct, 10);
-        assertEquals(30., c, 0.01);
+		Assertions.assertEquals(30., c, 0.01);
         //ref: 10 + 30 + 10 = 50
         //new: 50 - 50 = 0
 
 		/*
-        activity start time delay at next act = start-time-old - start-time-new is always bigger than subsequent waiting time savings
+		 * activity start time delay at next act = start-time-old - start-time-new is
+		 * always bigger than subsequent waiting time savings
 		 */
         /*
-		old = 10 + 30 + 10 = 50
-		new = 80 + 0 - 10 - min{80,40} = 30
+		 * old = 10 + 30 + 10 = 50
+		 * new = 80 + 0 - 10 - min{80,40} = 30
 		 */
     }
 
@@ -547,7 +552,8 @@ public class TestLocalActivityInsertionCostsCalculator {
         VehicleTypeImpl type = VehicleTypeImpl.Builder.newInstance("t").setCostPerWaitingTime(1.).build();
 
         VehicleImpl v = VehicleImpl.Builder.newInstance("v").setType(type).setStartLocation(Location.newInstance(0, 0)).build();
-//		VehicleImpl v2 = VehicleImpl.Builder.newInstance("v2").setHasVariableDepartureTime(true).setType(type).setStartLocation(Location.newInstance(0,0)).build();
+		// VehicleImpl v2 =
+		// VehicleImpl.Builder.newInstance("v2").setHasVariableDepartureTime(true).setType(type).setStartLocation(Location.newInstance(0,0)).build();
 
         Service prevS = Service.Builder.newInstance("prev").setLocation(Location.newInstance(10, 0)).build();
         Service newS = Service.Builder.newInstance("new").setServiceTime(10).setTimeWindow(TimeWindow.newInstance(100, 120)).setLocation(Location.newInstance(20, 0)).build();
@@ -585,15 +591,16 @@ public class TestLocalActivityInsertionCostsCalculator {
         LocalActivityInsertionCostsCalculator calc = new LocalActivityInsertionCostsCalculator(CostFactory.createEuclideanCosts(), new WaitingTimeCosts(), stateManager);
         calc.setSolutionCompletenessRatio(1.);
         double c = calc.getCosts(context, prevAct, nextAct, newAct, 10);
-        assertEquals(30., c, 0.01);
+		Assertions.assertEquals(30., c, 0.01);
 		/*
-		activity start time delay at next act = start-time-old - start-time-new is always bigger than subsequent waiting time savings
+		 * activity start time delay at next act = start-time-old - start-time-new is
+		 * always bigger than subsequent waiting time savings
 		 */
 		/*
-		old = 10 + 30 + 10 = 50
-		new = 80
-		new - old = 80 - 40 = 40
-
+		 * old = 10 + 30 + 10 = 50
+		 * new = 80
+		 * new - old = 80 - 40 = 40
+		 * 
 		 */
     }
 
@@ -602,7 +609,8 @@ public class TestLocalActivityInsertionCostsCalculator {
         VehicleTypeImpl type = VehicleTypeImpl.Builder.newInstance("t").setCostPerWaitingTime(1.).build();
 
         VehicleImpl v = VehicleImpl.Builder.newInstance("v").setType(type).setStartLocation(Location.newInstance(0, 0)).build();
-//		VehicleImpl v2 = VehicleImpl.Builder.newInstance("v2").setHasVariableDepartureTime(true).setType(type).setStartLocation(Location.newInstance(0,0)).build();
+		// VehicleImpl v2 =
+		// VehicleImpl.Builder.newInstance("v2").setHasVariableDepartureTime(true).setType(type).setStartLocation(Location.newInstance(0,0)).build();
 
         Service prevS = Service.Builder.newInstance("prev").setLocation(Location.newInstance(10, 0)).build();
         Service newS = Service.Builder.newInstance("new").setServiceTime(10).setTimeWindow(TimeWindow.newInstance(50, 70)).setLocation(Location.newInstance(20, 0)).build();
@@ -642,13 +650,14 @@ public class TestLocalActivityInsertionCostsCalculator {
         LocalActivityInsertionCostsCalculator calc = new LocalActivityInsertionCostsCalculator(CostFactory.createEuclideanCosts(), new WaitingTimeCosts(), stateManager);
         calc.setSolutionCompletenessRatio(1.);
         double c = calc.getCosts(context, prevAct, nextAct, newAct, 10);
-        assertEquals(-10., c, 0.01);
+		Assertions.assertEquals(-10., c, 0.01);
 		/*
-		activity start time delay at next act = start-time-old - start-time-new is always bigger than subsequent waiting time savings
+		 * activity start time delay at next act = start-time-old - start-time-new is
+		 * always bigger than subsequent waiting time savings
 		 */
 		/*
-		old = 10 + 40 = 50
-		new = 30 + 10 = 40
+		 * old = 10 + 40 = 50
+		 * new = 30 + 10 = 40
 		 */
     }
 

--- a/jsprit-core/src/test/java/com/graphhopper/jsprit/core/algorithm/recreate/TestMixedServiceAndShipmentsProblemOnRouteLevel.java
+++ b/jsprit-core/src/test/java/com/graphhopper/jsprit/core/algorithm/recreate/TestMixedServiceAndShipmentsProblemOnRouteLevel.java
@@ -26,76 +26,82 @@ import com.graphhopper.jsprit.core.problem.job.Shipment;
 import com.graphhopper.jsprit.core.problem.vehicle.*;
 import com.graphhopper.jsprit.core.util.Coordinate;
 import com.graphhopper.jsprit.core.util.TestUtils;
-import org.junit.Test;
 
-import static org.junit.Assert.assertTrue;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 
 public class TestMixedServiceAndShipmentsProblemOnRouteLevel {
 
 
-    @Test(expected = UnsupportedOperationException.class)
+    @Test
     public void whenHavingShipmentsAndServicesInOneProblem_andInsertionShouldBeMadeOnRouteLevel_throwException() {
-        /* get a vehicle type-builder and build a type with the typeId "vehicleType" and a capacity of 2
-         */
-        VehicleTypeImpl.Builder vehicleTypeBuilder = VehicleTypeImpl.Builder.newInstance("vehicleType").addCapacityDimension(0, 2);
-        VehicleType vehicleType = vehicleTypeBuilder.build();
 
-		/*
-         * get a vehicle-builder and build a vehicle located at (10,10) with type "vehicleType"
-		 */
-        VehicleImpl.Builder vehicleBuilder = VehicleImpl.Builder.newInstance("vehicle");
-        vehicleBuilder.setStartLocation(Location.newInstance(10, 10));
-        vehicleBuilder.setType(vehicleType);
-        VehicleImpl vehicle = vehicleBuilder.build();
+        Assertions.assertThrows(UnsupportedOperationException.class, () -> {
 
-		/*
-         * build shipments at the required locations, each with a capacity-demand of 1.
-		 * 4 shipments
-		 * 1: (5,7)->(6,9)
-		 * 2: (5,13)->(6,11)
-		 * 3: (15,7)->(14,9)
-		 * 4: (15,13)->(14,11)
-		 */
+            /* get a vehicle type-builder and build a type with the typeId "vehicleType" and a capacity of 2
+            */
+            VehicleTypeImpl.Builder vehicleTypeBuilder = VehicleTypeImpl.Builder.newInstance("vehicleType").addCapacityDimension(0, 2);
+            VehicleType vehicleType = vehicleTypeBuilder.build();
 
-        Shipment shipment1 = Shipment.Builder.newInstance("1").addSizeDimension(0, 1).setPickupLocation(TestUtils.loc(Coordinate.newInstance(5, 7))).setDeliveryLocation(TestUtils.loc(Coordinate.newInstance(6, 9))).build();
-        Shipment shipment2 = Shipment.Builder.newInstance("2").addSizeDimension(0, 1).setPickupLocation(TestUtils.loc(Coordinate.newInstance(5, 13))).setDeliveryLocation(TestUtils.loc(Coordinate.newInstance(6, 11))).build();
+            /*
+            * get a vehicle-builder and build a vehicle located at (10,10) with type
+            * "vehicleType"
+            */
+            VehicleImpl.Builder vehicleBuilder = VehicleImpl.Builder.newInstance("vehicle");
+            vehicleBuilder.setStartLocation(Location.newInstance(10, 10));
+            vehicleBuilder.setType(vehicleType);
+            VehicleImpl vehicle = vehicleBuilder.build();
 
-        Shipment shipment3 = Shipment.Builder.newInstance("3").addSizeDimension(0, 1).setPickupLocation(TestUtils.loc(Coordinate.newInstance(15, 7))).setDeliveryLocation(TestUtils.loc(Coordinate.newInstance(14, 9))).build();
-        Shipment shipment4 = Shipment.Builder.newInstance("4").addSizeDimension(0, 1).setPickupLocation(TestUtils.loc(Coordinate.newInstance(15, 13))).setDeliveryLocation(TestUtils.loc(Coordinate.newInstance(14, 11))).build();
+            /*
+            * build shipments at the required locations, each with a capacity-demand of 1.
+            * 4 shipments
+            * 1: (5,7)->(6,9)
+            * 2: (5,13)->(6,11)
+            * 3: (15,7)->(14,9)
+            * 4: (15,13)->(14,11)
+            */
 
-		/*
-         * build deliveries, (implicitly picked up in the depot)
-		 * 1: (4,8)
-		 * 2: (4,12)
-		 * 3: (16,8)
-		 * 4: (16,12)
-		 */
-        Delivery delivery1 = (Delivery) Delivery.Builder.newInstance("5").addSizeDimension(0, 1).setLocation(TestUtils.loc(Coordinate.newInstance(4, 8))).build();
-        Delivery delivery2 = (Delivery) Delivery.Builder.newInstance("6").addSizeDimension(0, 1).setLocation(TestUtils.loc(Coordinate.newInstance(4, 12))).build();
-        Delivery delivery3 = (Delivery) Delivery.Builder.newInstance("7").addSizeDimension(0, 1).setLocation(TestUtils.loc(Coordinate.newInstance(16, 8))).build();
-        Delivery delivery4 = (Delivery) Delivery.Builder.newInstance("8").addSizeDimension(0, 1).setLocation(TestUtils.loc(Coordinate.newInstance(16, 12))).build();
+            Shipment shipment1 = Shipment.Builder.newInstance("1").addSizeDimension(0, 1).setPickupLocation(TestUtils.loc(Coordinate.newInstance(5, 7))).setDeliveryLocation(TestUtils.loc(Coordinate.newInstance(6, 9))).build();
+            Shipment shipment2 = Shipment.Builder.newInstance("2").addSizeDimension(0, 1).setPickupLocation(TestUtils.loc(Coordinate.newInstance(5, 13))).setDeliveryLocation(TestUtils.loc(Coordinate.newInstance(6, 11))).build();
 
-        VehicleRoutingProblem.Builder vrpBuilder = VehicleRoutingProblem.Builder.newInstance();
-        vrpBuilder.addVehicle(vehicle);
-        vrpBuilder.addJob(shipment1).addJob(shipment2).addJob(shipment3).addJob(shipment4)
-            .addJob(delivery1).addJob(delivery2).addJob(delivery3).addJob(delivery4).build();
+            Shipment shipment3 = Shipment.Builder.newInstance("3").addSizeDimension(0, 1).setPickupLocation(TestUtils.loc(Coordinate.newInstance(15, 7))).setDeliveryLocation(TestUtils.loc(Coordinate.newInstance(14, 9))).build();
+            Shipment shipment4 = Shipment.Builder.newInstance("4").addSizeDimension(0, 1).setPickupLocation(TestUtils.loc(Coordinate.newInstance(15, 13))).setDeliveryLocation(TestUtils.loc(Coordinate.newInstance(14, 11))).build();
 
-        VehicleRoutingProblem vrp = vrpBuilder.build();
+            /*
+            * build deliveries, (implicitly picked up in the depot)
+            * 1: (4,8)
+            * 2: (4,12)
+            * 3: (16,8)
+            * 4: (16,12)
+            */
+            Delivery delivery1 = (Delivery) Delivery.Builder.newInstance("5").addSizeDimension(0, 1).setLocation(TestUtils.loc(Coordinate.newInstance(4, 8))).build();
+            Delivery delivery2 = (Delivery) Delivery.Builder.newInstance("6").addSizeDimension(0, 1).setLocation(TestUtils.loc(Coordinate.newInstance(4, 12))).build();
+            Delivery delivery3 = (Delivery) Delivery.Builder.newInstance("7").addSizeDimension(0, 1).setLocation(TestUtils.loc(Coordinate.newInstance(16, 8))).build();
+            Delivery delivery4 = (Delivery) Delivery.Builder.newInstance("8").addSizeDimension(0, 1).setLocation(TestUtils.loc(Coordinate.newInstance(16, 12))).build();
 
-        final StateManager stateManager = new StateManager(vrp);
+            VehicleRoutingProblem.Builder vrpBuilder = VehicleRoutingProblem.Builder.newInstance();
+            vrpBuilder.addVehicle(vehicle);
+            vrpBuilder.addJob(shipment1).addJob(shipment2).addJob(shipment3).addJob(shipment4)
+                .addJob(delivery1).addJob(delivery2).addJob(delivery3).addJob(delivery4).build();
+
+            VehicleRoutingProblem vrp = vrpBuilder.build();
+
+            final StateManager stateManager = new StateManager(vrp);
 
 
-        ConstraintManager constraintManager = new ConstraintManager(vrp, stateManager);
-        constraintManager.addLoadConstraint();
-        constraintManager.addTimeWindowConstraint();
+            ConstraintManager constraintManager = new ConstraintManager(vrp, stateManager);
+            constraintManager.addLoadConstraint();
+            constraintManager.addTimeWindowConstraint();
 
-        VehicleFleetManager fleetManager = new InfiniteFleetManagerFactory(vrp.getVehicles()).createFleetManager();
+            VehicleFleetManager fleetManager = new InfiniteFleetManagerFactory(vrp.getVehicles()).createFleetManager();
 
-        BestInsertionBuilder bestIBuilder = new BestInsertionBuilder(vrp, fleetManager, stateManager, constraintManager);
-        bestIBuilder.setRouteLevel(2, 2);
-        @SuppressWarnings("unused")
-        InsertionStrategy bestInsertion = bestIBuilder.build();
+            BestInsertionBuilder bestIBuilder = new BestInsertionBuilder(vrp, fleetManager, stateManager, constraintManager);
+            bestIBuilder.setRouteLevel(2, 2);
+            @SuppressWarnings("unused")
+            InsertionStrategy bestInsertion = bestIBuilder.build();
+
+        });
 
     }
 
@@ -106,22 +112,23 @@ public class TestMixedServiceAndShipmentsProblemOnRouteLevel {
         VehicleTypeImpl.Builder vehicleTypeBuilder = VehicleTypeImpl.Builder.newInstance("vehicleType").addCapacityDimension(0, 2);
         VehicleType vehicleType = vehicleTypeBuilder.build();
 
-		/*
-         * get a vehicle-builder and build a vehicle located at (10,10) with type "vehicleType"
-		 */
+        /*
+         * get a vehicle-builder and build a vehicle located at (10,10) with type
+         * "vehicleType"
+         */
         VehicleImpl.Builder vehicleBuilder = VehicleImpl.Builder.newInstance("vehicle");
         vehicleBuilder.setStartLocation(Location.newInstance(10, 10));
         vehicleBuilder.setType(vehicleType);
         VehicleImpl vehicle = vehicleBuilder.build();
 
 
-		/*
+        /*
          * build deliveries, (implicitly picked up in the depot)
-		 * 1: (4,8)
-		 * 2: (4,12)
-		 * 3: (16,8)
-		 * 4: (16,12)
-		 */
+         * 1: (4,8)
+         * 2: (4,12)
+         * 3: (16,8)
+         * 4: (16,12)
+         */
         Delivery delivery1 = (Delivery) Delivery.Builder.newInstance("5").addSizeDimension(0, 1).setLocation(Location.newInstance(4, 8)).build();
         Delivery delivery2 = (Delivery) Delivery.Builder.newInstance("6").addSizeDimension(0, 1).setLocation(Location.newInstance(4, 12)).build();
         Delivery delivery3 = (Delivery) Delivery.Builder.newInstance("7").addSizeDimension(0, 1).setLocation(Location.newInstance(16, 8)).build();
@@ -129,7 +136,7 @@ public class TestMixedServiceAndShipmentsProblemOnRouteLevel {
 
         VehicleRoutingProblem.Builder vrpBuilder = VehicleRoutingProblem.Builder.newInstance();
         vrpBuilder.addVehicle(vehicle)
-//		vrpBuilder.addJob(shipment1).addJob(shipment2).addJob(shipment3).addJob(shipment4)
+                // vrpBuilder.addJob(shipment1).addJob(shipment2).addJob(shipment3).addJob(shipment4)
             .addJob(delivery1).addJob(delivery2).addJob(delivery3).addJob(delivery4).build();
 
         VehicleRoutingProblem vrp = vrpBuilder.build();
@@ -147,7 +154,7 @@ public class TestMixedServiceAndShipmentsProblemOnRouteLevel {
         @SuppressWarnings("unused")
         InsertionStrategy bestInsertion = bestIBuilder.build();
 
-        assertTrue(true);
+        Assertions.assertTrue(true);
 
     }
 

--- a/jsprit-core/src/test/java/com/graphhopper/jsprit/core/algorithm/recreate/TestRouteLevelActivityInsertionCostEstimator.java
+++ b/jsprit-core/src/test/java/com/graphhopper/jsprit/core/algorithm/recreate/TestRouteLevelActivityInsertionCostEstimator.java
@@ -39,14 +39,14 @@ import com.graphhopper.jsprit.core.problem.vehicle.VehicleImpl;
 import com.graphhopper.jsprit.core.problem.vehicle.VehicleType;
 import com.graphhopper.jsprit.core.problem.vehicle.VehicleTypeImpl;
 import com.graphhopper.jsprit.core.util.CostFactory;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 
-import static org.junit.Assert.assertEquals;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
 
 /**
  * unit tests to test route level insertion
@@ -61,7 +61,7 @@ public class TestRouteLevelActivityInsertionCostEstimator {
 
     private StateManager stateManager;
 
-    @Before
+    @BeforeEach
     public void doBefore() {
         routingCosts = CostFactory.createEuclideanCosts();
 
@@ -118,7 +118,7 @@ public class TestRouteLevelActivityInsertionCostEstimator {
         RouteLevelActivityInsertionCostsEstimator estimator = new RouteLevelActivityInsertionCostsEstimator(routingCosts, activityCosts, stateManager);
         estimator.setForwardLooking(0);
         double iCosts = estimator.getCosts(context, route.getStart(), route.getActivities().get(0), pickupService, 0.);
-        assertEquals(0., iCosts, 0.01);
+		Assertions.assertEquals(0., iCosts, 0.01);
     }
 
     @Test
@@ -129,7 +129,7 @@ public class TestRouteLevelActivityInsertionCostEstimator {
         RouteLevelActivityInsertionCostsEstimator estimator = new RouteLevelActivityInsertionCostsEstimator(routingCosts, activityCosts, stateManager);
         estimator.setForwardLooking(0);
         double iCosts = estimator.getCosts(context, route.getStart(), route.getActivities().get(0), pickupService, 0.);
-        assertEquals(0., iCosts, 0.01);
+		Assertions.assertEquals(0., iCosts, 0.01);
     }
 
     @Test
@@ -145,7 +145,7 @@ public class TestRouteLevelActivityInsertionCostEstimator {
         double iCosts = estimator.getCosts(context, route.getStart(), route.getActivities().get(0), pickupService, 0.);
         double expectedTransportCosts = 0.;
         double expectedActivityCosts = 10.;
-        assertEquals(expectedActivityCosts + expectedTransportCosts, iCosts, 0.01);
+		Assertions.assertEquals(expectedActivityCosts + expectedTransportCosts, iCosts, 0.01);
     }
 
     @Test
@@ -158,7 +158,7 @@ public class TestRouteLevelActivityInsertionCostEstimator {
         double iCosts = estimator.getCosts(context, route.getStart(), route.getActivities().get(0), pickupService, 0.);
         double expectedTransportCosts = 0.;
         double expectedActivityCosts = 30.;
-        assertEquals(expectedActivityCosts + expectedTransportCosts, iCosts, 0.01);
+		Assertions.assertEquals(expectedActivityCosts + expectedTransportCosts, iCosts, 0.01);
     }
 
     @Test
@@ -172,7 +172,7 @@ public class TestRouteLevelActivityInsertionCostEstimator {
             estimator.getCosts(context, route.getActivities().get(0), route.getActivities().get(1), pickupService, 10.);
         double expectedTransportCosts = 10.;
         double expectedActivityCosts = 10.;
-        assertEquals(expectedTransportCosts + expectedActivityCosts, iCosts, 0.01);
+		Assertions.assertEquals(expectedTransportCosts + expectedActivityCosts, iCosts, 0.01);
     }
 
     @Test
@@ -186,7 +186,7 @@ public class TestRouteLevelActivityInsertionCostEstimator {
             estimator.getCosts(context, route.getActivities().get(0), route.getActivities().get(1), pickupService, 10.);
         double expectedTransportCosts = 10.;
         double expectedActivityCosts = 10. + 10.;
-        assertEquals(expectedTransportCosts + expectedActivityCosts, iCosts, 0.01);
+		Assertions.assertEquals(expectedTransportCosts + expectedActivityCosts, iCosts, 0.01);
     }
 
     @Test
@@ -202,7 +202,7 @@ public class TestRouteLevelActivityInsertionCostEstimator {
             estimator.getCosts(context, route.getActivities().get(0), route.getActivities().get(1), pickupService, 10.);
         double expectedTransportCosts = 10.;
         double expectedActivityCosts = 10. + 10. + 10.;
-        assertEquals(expectedTransportCosts + expectedActivityCosts, iCosts, 0.01);
+		Assertions.assertEquals(expectedTransportCosts + expectedActivityCosts, iCosts, 0.01);
     }
 
 }

--- a/jsprit-core/src/test/java/com/graphhopper/jsprit/core/algorithm/recreate/TestRouteLevelServiceInsertionCostEstimator.java
+++ b/jsprit-core/src/test/java/com/graphhopper/jsprit/core/algorithm/recreate/TestRouteLevelServiceInsertionCostEstimator.java
@@ -38,14 +38,15 @@ import com.graphhopper.jsprit.core.problem.vehicle.VehicleImpl;
 import com.graphhopper.jsprit.core.problem.vehicle.VehicleType;
 import com.graphhopper.jsprit.core.problem.vehicle.VehicleTypeImpl;
 import com.graphhopper.jsprit.core.util.CostFactory;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 
-import static org.junit.Assert.assertEquals;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -68,7 +69,7 @@ public class TestRouteLevelServiceInsertionCostEstimator {
 
     private JobActivityFactory activityFactory;
 
-    @Before
+    @BeforeEach
     public void doBefore() {
         VehicleRoutingProblem.Builder vrpBuilder = VehicleRoutingProblem.Builder.newInstance();
 
@@ -144,7 +145,7 @@ public class TestRouteLevelServiceInsertionCostEstimator {
             }
         });
         InsertionData iData = routeInserter.getInsertionData(route, s4, route.getVehicle(), route.getDepartureTime(), route.getDriver(), Double.MAX_VALUE);
-        assertEquals(0., iData.getInsertionCost(), 0.01);
+		Assertions.assertEquals(0., iData.getInsertionCost(), 0.01);
     }
 
     @Test
@@ -166,7 +167,7 @@ public class TestRouteLevelServiceInsertionCostEstimator {
             }
         });
         InsertionData iData = routeInserter.getInsertionData(route, s4, route.getVehicle(), route.getDepartureTime(), route.getDriver(), Double.MAX_VALUE);
-        assertEquals(0, iData.getDeliveryInsertionIndex(), 0.01);
+		Assertions.assertEquals(0, iData.getDeliveryInsertionIndex(), 0.01);
     }
 
     @Test
@@ -191,8 +192,8 @@ public class TestRouteLevelServiceInsertionCostEstimator {
             }
         });
         InsertionData iData = routeInserter.getInsertionData(route, s4, route.getVehicle(), route.getDepartureTime(), route.getDriver(), Double.MAX_VALUE);
-        assertEquals(0, iData.getDeliveryInsertionIndex(), 0.01);
-        assertEquals(30., iData.getInsertionCost(), 0.01);
+		Assertions.assertEquals(0, iData.getDeliveryInsertionIndex(), 0.01);
+		Assertions.assertEquals(30., iData.getInsertionCost(), 0.01);
     }
 
 
@@ -220,8 +221,8 @@ public class TestRouteLevelServiceInsertionCostEstimator {
             }
         });
         InsertionData iData = routeInserter.getInsertionData(emptyroute, s4, route.getVehicle(), route.getDepartureTime(), route.getDriver(), Double.MAX_VALUE);
-        assertEquals(0, iData.getDeliveryInsertionIndex(), 0.01);
-        assertEquals(10., iData.getInsertionCost(), 0.01);
+		Assertions.assertEquals(0, iData.getDeliveryInsertionIndex(), 0.01);
+		Assertions.assertEquals(10., iData.getInsertionCost(), 0.01);
     }
 
     @Test
@@ -248,8 +249,8 @@ public class TestRouteLevelServiceInsertionCostEstimator {
             }
         });
         InsertionData iData = routeInserter.getInsertionData(emptyroute, s4, route.getVehicle(), route.getDepartureTime(), route.getDriver(), Double.MAX_VALUE);
-        assertEquals(0, iData.getDeliveryInsertionIndex(), 0.01);
-        assertEquals(10. + 2., iData.getInsertionCost(), 0.01);
+		Assertions.assertEquals(0, iData.getDeliveryInsertionIndex(), 0.01);
+		Assertions.assertEquals(10. + 2., iData.getInsertionCost(), 0.01);
     }
 
 }

--- a/jsprit-core/src/test/java/com/graphhopper/jsprit/core/algorithm/ruin/DBSCANClustererTest.java
+++ b/jsprit-core/src/test/java/com/graphhopper/jsprit/core/algorithm/ruin/DBSCANClustererTest.java
@@ -23,6 +23,8 @@ import com.graphhopper.jsprit.core.problem.job.Service;
 import com.graphhopper.jsprit.core.problem.solution.route.VehicleRoute;
 import com.graphhopper.jsprit.core.problem.vehicle.VehicleImpl;
 import com.graphhopper.jsprit.core.util.EuclideanCosts;
+
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
@@ -47,7 +49,7 @@ class DBSCANClustererTest {
         DBSCANClusterer c = new DBSCANClusterer(new EuclideanCosts());
         c.setEpsDistance(3);
         List<Job> cluster = c.getRandomCluster(r);
-        assertEquals(2, cluster.size());
+        Assertions.assertEquals(2, cluster.size());
     }
 
     @Test
@@ -61,7 +63,7 @@ class DBSCANClustererTest {
         DBSCANClusterer c = new DBSCANClusterer(new EuclideanCosts());
         c.setEpsDistance(3);
         List<List<Job>> cluster = c.getClusters(r);
-        assertEquals(1, cluster.size());
+        Assertions.assertEquals(1, cluster.size());
     }
 
     @Test
@@ -79,6 +81,6 @@ class DBSCANClustererTest {
         c.setMinPts(1);
         c.setEpsDistance(2);
         List<List<Job>> cluster = c.getClusters(r);
-        assertEquals(3, cluster.size());
+        Assertions.assertEquals(3, cluster.size());
     }
 }

--- a/jsprit-core/src/test/java/com/graphhopper/jsprit/core/algorithm/ruin/JobNeighborhoodsImplTest.java
+++ b/jsprit-core/src/test/java/com/graphhopper/jsprit/core/algorithm/ruin/JobNeighborhoodsImplTest.java
@@ -23,6 +23,8 @@ import com.graphhopper.jsprit.core.problem.Location;
 import com.graphhopper.jsprit.core.problem.VehicleRoutingProblem;
 import com.graphhopper.jsprit.core.problem.job.Job;
 import com.graphhopper.jsprit.core.problem.job.Service;
+
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -79,7 +81,7 @@ class JobNeighborhoodsImplTest {
         while (iter.hasNext()) {
             services.add((Service) iter.next());
         }
-        assertEquals(2, services.size());
+        Assertions.assertEquals(2, services.size());
     }
 
     @Test
@@ -92,7 +94,7 @@ class JobNeighborhoodsImplTest {
         while (iter.hasNext()) {
             services.add((Service) iter.next());
         }
-        assertTrue(services.contains(s2));
+        Assertions.assertTrue(services.contains(s2));
     }
 
     @Test
@@ -105,7 +107,7 @@ class JobNeighborhoodsImplTest {
         while (iter.hasNext()) {
             services.add((Service) iter.next());
         }
-        assertTrue(services.contains(s5));
+        Assertions.assertTrue(services.contains(s5));
     }
 
     @Test
@@ -118,7 +120,7 @@ class JobNeighborhoodsImplTest {
         while (iter.hasNext()) {
             services.add((Service) iter.next());
         }
-        assertEquals(4, services.size());
+        Assertions.assertEquals(4, services.size());
     }
 
     @Test
@@ -131,7 +133,7 @@ class JobNeighborhoodsImplTest {
         while (iter.hasNext()) {
             services.add((Service) iter.next());
         }
-        assertEquals(6, services.size());
+        Assertions.assertEquals(6, services.size());
     }
 
     @Test
@@ -139,6 +141,6 @@ class JobNeighborhoodsImplTest {
     void whenRequestingNeighborhoodOfTargetJob_itShouldReturntheMaxDistance() {
         JobNeighborhoodsImpl jn = new JobNeighborhoodsImpl(vrp, jobDistance);
         jn.initialise();
-        assertEquals(6, jn.getMaxDistance(), 0.01);
+        Assertions.assertEquals(6, jn.getMaxDistance(), 0.01);
     }
 }

--- a/jsprit-core/src/test/java/com/graphhopper/jsprit/core/algorithm/ruin/JobNeighborhoodsOptimizedTest.java
+++ b/jsprit-core/src/test/java/com/graphhopper/jsprit/core/algorithm/ruin/JobNeighborhoodsOptimizedTest.java
@@ -24,6 +24,8 @@ import com.graphhopper.jsprit.core.problem.VehicleRoutingProblem;
 import com.graphhopper.jsprit.core.problem.job.Break;
 import com.graphhopper.jsprit.core.problem.job.Job;
 import com.graphhopper.jsprit.core.problem.job.Service;
+
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -83,7 +85,7 @@ class JobNeighborhoodsOptimizedTest {
         while (iter.hasNext()) {
             services.add((Service) iter.next());
         }
-        assertEquals(2, services.size());
+        Assertions.assertEquals(2, services.size());
     }
 
     @Test
@@ -96,7 +98,7 @@ class JobNeighborhoodsOptimizedTest {
         while (iter.hasNext()) {
             services.add((Service) iter.next());
         }
-        assertTrue(services.contains(s2));
+        Assertions.assertTrue(services.contains(s2));
     }
 
     @Test
@@ -109,7 +111,7 @@ class JobNeighborhoodsOptimizedTest {
         while (iter.hasNext()) {
             services.add((Service) iter.next());
         }
-        assertTrue(services.contains(s5));
+        Assertions.assertTrue(services.contains(s5));
     }
 
     @Test
@@ -122,7 +124,7 @@ class JobNeighborhoodsOptimizedTest {
         while (iter.hasNext()) {
             services.add((Service) iter.next());
         }
-        assertEquals(4, services.size());
+        Assertions.assertEquals(4, services.size());
     }
 
     @Test
@@ -135,10 +137,10 @@ class JobNeighborhoodsOptimizedTest {
         while (iter.hasNext()) {
             services.add((Service) iter.next());
         }
-        assertEquals(s6, services.get(0));
-        assertEquals(s5, services.get(1));
-        assertEquals(target, services.get(2));
-        assertEquals(s2, services.get(3));
+        Assertions.assertEquals(s6, services.get(0));
+        Assertions.assertEquals(s5, services.get(1));
+        Assertions.assertEquals(target, services.get(2));
+        Assertions.assertEquals(s2, services.get(3));
     }
 
     @Test
@@ -151,7 +153,7 @@ class JobNeighborhoodsOptimizedTest {
         while (iter.hasNext()) {
             services.add((Service) iter.next());
         }
-        assertEquals(2, services.size());
+        Assertions.assertEquals(2, services.size());
     }
 
     @Test
@@ -164,6 +166,6 @@ class JobNeighborhoodsOptimizedTest {
         while (iter.hasNext()) {
             services.add((Service) iter.next());
         }
-        assertEquals(0, services.size());
+        Assertions.assertEquals(0, services.size());
     }
 }

--- a/jsprit-core/src/test/java/com/graphhopper/jsprit/core/algorithm/ruin/JobNeighborhoodsWithCapRestrictionImplTest.java
+++ b/jsprit-core/src/test/java/com/graphhopper/jsprit/core/algorithm/ruin/JobNeighborhoodsWithCapRestrictionImplTest.java
@@ -23,6 +23,8 @@ import com.graphhopper.jsprit.core.problem.Location;
 import com.graphhopper.jsprit.core.problem.VehicleRoutingProblem;
 import com.graphhopper.jsprit.core.problem.job.Job;
 import com.graphhopper.jsprit.core.problem.job.Service;
+
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -79,7 +81,7 @@ class JobNeighborhoodsWithCapRestrictionImplTest {
         while (iter.hasNext()) {
             services.add((Service) iter.next());
         }
-        assertEquals(2, services.size());
+        Assertions.assertEquals(2, services.size());
     }
 
     @Test
@@ -92,7 +94,7 @@ class JobNeighborhoodsWithCapRestrictionImplTest {
         while (iter.hasNext()) {
             services.add((Service) iter.next());
         }
-        assertTrue(services.contains(s2));
+        Assertions.assertTrue(services.contains(s2));
     }
 
     @Test
@@ -105,7 +107,7 @@ class JobNeighborhoodsWithCapRestrictionImplTest {
         while (iter.hasNext()) {
             services.add((Service) iter.next());
         }
-        assertTrue(services.contains(s5));
+        Assertions.assertTrue(services.contains(s5));
     }
 
     @Test
@@ -118,7 +120,7 @@ class JobNeighborhoodsWithCapRestrictionImplTest {
         while (iter.hasNext()) {
             services.add((Service) iter.next());
         }
-        assertEquals(4, services.size());
+        Assertions.assertEquals(4, services.size());
     }
 
     @Test
@@ -131,6 +133,6 @@ class JobNeighborhoodsWithCapRestrictionImplTest {
         while (iter.hasNext()) {
             services.add((Service) iter.next());
         }
-        assertEquals(2, services.size());
+        Assertions.assertEquals(2, services.size());
     }
 }

--- a/jsprit-core/src/test/java/com/graphhopper/jsprit/core/algorithm/ruin/RuinBreakTest.java
+++ b/jsprit-core/src/test/java/com/graphhopper/jsprit/core/algorithm/ruin/RuinBreakTest.java
@@ -25,6 +25,8 @@ import com.graphhopper.jsprit.core.problem.solution.route.VehicleRoute;
 import com.graphhopper.jsprit.core.problem.solution.route.activity.BreakActivity;
 import com.graphhopper.jsprit.core.problem.solution.route.activity.TourActivity;
 import com.graphhopper.jsprit.core.problem.vehicle.VehicleImpl;
+
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
@@ -49,11 +51,11 @@ class RuinBreakTest {
         VehicleRoutingProblem vrp = VehicleRoutingProblem.Builder.newInstance().setFleetSize(VehicleRoutingProblem.FleetSize.FINITE).addVehicle(v).build();
         VehicleRoute route = VehicleRoute.Builder.newInstance(v).setJobActivityFactory(vrp.getJobActivityFactory()).addService(aBreak).build();
         TourActivity tourActivity = route.getActivities().get(0);
-        assertTrue(tourActivity instanceof BreakActivity);
+        Assertions.assertTrue(tourActivity instanceof BreakActivity);
         RuinBreaks ruinBreaks = new RuinBreaks();
         List<Job> unassigned = new ArrayList<Job>();
         ruinBreaks.ruinEnds(Arrays.asList(route), unassigned);
-        assertEquals(1, unassigned.size());
-        assertEquals(aBreak, unassigned.get(0));
+        Assertions.assertEquals(1, unassigned.size());
+        Assertions.assertEquals(aBreak, unassigned.get(0));
     }
 }

--- a/jsprit-core/src/test/java/com/graphhopper/jsprit/core/algorithm/ruin/RuinClustersTest.java
+++ b/jsprit-core/src/test/java/com/graphhopper/jsprit/core/algorithm/ruin/RuinClustersTest.java
@@ -25,6 +25,8 @@ import com.graphhopper.jsprit.core.problem.job.Service;
 import com.graphhopper.jsprit.core.problem.solution.route.VehicleRoute;
 import com.graphhopper.jsprit.core.problem.vehicle.VehicleImpl;
 import com.graphhopper.jsprit.core.util.RandomNumberGeneration;
+
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
@@ -61,6 +63,6 @@ class RuinClustersTest {
         Random r = RandomNumberGeneration.newInstance();
         rc.setRandom(r);
         Collection<Job> ruined = rc.ruinRoutes(Arrays.asList(vr1, vr2));
-        assertEquals(5, ruined.size());
+        Assertions.assertEquals(5, ruined.size());
     }
 }

--- a/jsprit-core/src/test/java/com/graphhopper/jsprit/core/algorithm/ruin/RuinRadialTest.java
+++ b/jsprit-core/src/test/java/com/graphhopper/jsprit/core/algorithm/ruin/RuinRadialTest.java
@@ -24,6 +24,8 @@ import com.graphhopper.jsprit.core.problem.job.Service;
 import com.graphhopper.jsprit.core.problem.solution.route.VehicleRoute;
 import com.graphhopper.jsprit.core.problem.vehicle.VehicleImpl;
 import com.graphhopper.jsprit.core.util.Coordinate;
+
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
@@ -67,8 +69,8 @@ class RuinRadialTest {
         try {
             ruinRadial.ruinRoutes(Arrays.asList(route));
         } catch (Exception e) {
-            assertFalse(true, "error when ruining routes with radial ruin");
+            Assertions.assertFalse(true, "error when ruining routes with radial ruin");
         }
-        assertTrue(true);
+        Assertions.assertTrue(true);
     }
 }

--- a/jsprit-core/src/test/java/com/graphhopper/jsprit/core/algorithm/ruin/RuinWorstTest.java
+++ b/jsprit-core/src/test/java/com/graphhopper/jsprit/core/algorithm/ruin/RuinWorstTest.java
@@ -25,6 +25,8 @@ import com.graphhopper.jsprit.core.problem.job.Shipment;
 import com.graphhopper.jsprit.core.problem.solution.route.VehicleRoute;
 import com.graphhopper.jsprit.core.problem.vehicle.VehicleImpl;
 import com.graphhopper.jsprit.core.util.Coordinate;
+
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
@@ -51,7 +53,7 @@ class RuinWorstTest {
         RuinWorst worst = new RuinWorst(vrp, 1);
         VehicleRoute route = VehicleRoute.Builder.newInstance(v).addService(s1).addService(s2).addService(s3).setJobActivityFactory(vrp.getJobActivityFactory()).build();
         Collection<Job> unassigned = worst.ruinRoutes(Arrays.asList(route));
-        assertEquals(1, unassigned.size());
+        Assertions.assertEquals(1, unassigned.size());
     }
 
     @Test
@@ -65,7 +67,7 @@ class RuinWorstTest {
         RuinWorst worst = new RuinWorst(vrp, 1);
         VehicleRoute route = VehicleRoute.Builder.newInstance(v).addService(s1).addService(s2).addService(s3).setJobActivityFactory(vrp.getJobActivityFactory()).build();
         Collection<Job> unassigned = worst.ruinRoutes(Arrays.asList(route));
-        assertEquals(s3, unassigned.iterator().next());
+        Assertions.assertEquals(s3, unassigned.iterator().next());
     }
 
     @Test
@@ -86,9 +88,9 @@ class RuinWorstTest {
         });
         VehicleRoute route = VehicleRoute.Builder.newInstance(v).addService(s1).addService(s2).addService(s3).setJobActivityFactory(vrp.getJobActivityFactory()).build();
         Collection<Job> unassigned = worst.ruinRoutes(Arrays.asList(route));
-        assertTrue(unassigned.size() == 2);
-        assertTrue(unassigned.contains(s2));
-        assertTrue(unassigned.contains(s3));
+        Assertions.assertTrue(unassigned.size() == 2);
+        Assertions.assertTrue(unassigned.contains(s2));
+        Assertions.assertTrue(unassigned.contains(s3));
     }
 
     @Test
@@ -110,8 +112,8 @@ class RuinWorstTest {
         });
         VehicleRoute route = VehicleRoute.Builder.newInstance(v).addPickup(shipment).addService(s1).addService(s2).addService(s3).addDelivery(shipment).setJobActivityFactory(vrp.getJobActivityFactory()).build();
         Collection<Job> unassigned = worst.ruinRoutes(Arrays.asList(route));
-        assertTrue(unassigned.size() == 1);
-        assertTrue(unassigned.contains(shipment));
+        Assertions.assertTrue(unassigned.size() == 1);
+        Assertions.assertTrue(unassigned.contains(shipment));
     }
 
     @Test
@@ -135,8 +137,8 @@ class RuinWorstTest {
         VehicleRoute route1 = VehicleRoute.Builder.newInstance(v).addService(s1).addService(s2).addService(s3).setJobActivityFactory(vrp.getJobActivityFactory()).build();
         VehicleRoute route2 = VehicleRoute.Builder.newInstance(v2).addPickup(shipment).addDelivery(shipment).build();
         Collection<Job> unassigned = worst.ruinRoutes(Arrays.asList(route1, route2));
-        assertTrue(unassigned.size() == 1);
-        assertTrue(unassigned.contains(shipment));
+        Assertions.assertTrue(unassigned.size() == 1);
+        Assertions.assertTrue(unassigned.contains(shipment));
     }
 
     @Test
@@ -160,8 +162,8 @@ class RuinWorstTest {
         VehicleRoute route1 = VehicleRoute.Builder.newInstance(v).addService(s1).addService(s2).addService(s3).setJobActivityFactory(vrp.getJobActivityFactory()).build();
         VehicleRoute route2 = VehicleRoute.Builder.newInstance(v2).addPickup(shipment).addDelivery(shipment).build();
         Collection<Job> unassigned = worst.ruinRoutes(Arrays.asList(route1, route2));
-        assertTrue(unassigned.size() == 2);
-        assertTrue(unassigned.contains(shipment));
-        assertTrue(unassigned.contains(s3));
+        Assertions.assertTrue(unassigned.size() == 2);
+        Assertions.assertTrue(unassigned.contains(shipment));
+        Assertions.assertTrue(unassigned.contains(s3));
     }
 }

--- a/jsprit-core/src/test/java/com/graphhopper/jsprit/core/algorithm/ruin/distance/AverageJobDistanceTest.java
+++ b/jsprit-core/src/test/java/com/graphhopper/jsprit/core/algorithm/ruin/distance/AverageJobDistanceTest.java
@@ -30,6 +30,8 @@ import org.junit.jupiter.api.Test;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import org.junit.jupiter.api.Assertions;
+
 @DisplayName("Average Job Distance Test")
 class AverageJobDistanceTest {
 
@@ -60,7 +62,7 @@ class AverageJobDistanceTest {
                 Shipment other1 = Shipment.Builder.newInstance("s1").addSizeDimension(0, 1).setPickupLocation(Location.Builder.newInstance().setId("0,0").build()).setDeliveryLocation(Location.newInstance(i + "," + j)).build();
                 Shipment other2 = Shipment.Builder.newInstance("s2").addSizeDimension(0, 1).setPickupLocation(Location.Builder.newInstance().setId("0,0").build()).setDeliveryLocation(Location.newInstance("10,10")).build();
                 double dist2 = new AvgServiceAndShipmentDistance(routingCosts).getDistance(other1, other2);
-                assertTrue(dist <= dist2 + dist2 * 0.001);
+                Assertions.assertTrue(dist <= dist2 + dist2 * 0.001);
             }
         }
     }
@@ -71,6 +73,6 @@ class AverageJobDistanceTest {
         Service s1 = Service.Builder.newInstance("s1").addSizeDimension(0, 1).setLocation(Location.newInstance("10,0")).build();
         Service s2 = Service.Builder.newInstance("s2").addSizeDimension(0, 1).setLocation(Location.newInstance("10,0")).build();
         double dist = new AvgServiceAndShipmentDistance(routingCosts).getDistance(s1, s2);
-        assertEquals(0.0, dist, 0.01);
+        Assertions.assertEquals(0.0, dist, 0.01);
     }
 }

--- a/jsprit-core/src/test/java/com/graphhopper/jsprit/core/algorithm/selector/SelectBestTest.java
+++ b/jsprit-core/src/test/java/com/graphhopper/jsprit/core/algorithm/selector/SelectBestTest.java
@@ -18,15 +18,14 @@
 package com.graphhopper.jsprit.core.algorithm.selector;
 
 import com.graphhopper.jsprit.core.problem.solution.VehicleRoutingProblemSolution;
+
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
 import java.util.Arrays;
 import java.util.Collections;
 
-import static org.hamcrest.CoreMatchers.is;
-import static org.junit.Assert.assertThat;
-import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -40,7 +39,7 @@ class SelectBestTest {
         VehicleRoutingProblemSolution sol2 = mock(VehicleRoutingProblemSolution.class);
         when(sol1.getCost()).thenReturn(1.0);
         when(sol2.getCost()).thenReturn(2.0);
-        assertThat(new SelectBest().selectSolution(Arrays.asList(sol1, sol2)), is(sol1));
+        Assertions.assertSame(new SelectBest().selectSolution(Arrays.asList(sol1, sol2)), sol1);
     }
 
     @Test
@@ -48,12 +47,12 @@ class SelectBestTest {
     void whenHavingOnly1Solutions_selectThisOne() {
         VehicleRoutingProblemSolution sol1 = mock(VehicleRoutingProblemSolution.class);
         when(sol1.getCost()).thenReturn(1.0);
-        assertThat(new SelectBest().selectSolution(Arrays.asList(sol1)), is(sol1));
+        Assertions.assertSame(new SelectBest().selectSolution(Arrays.asList(sol1)), sol1);
     }
 
     @Test
     @DisplayName("When Having No Solutions _ return Null")
     void whenHavingNoSolutions_returnNull() {
-        assertNull(new SelectBest().selectSolution(Collections.<VehicleRoutingProblemSolution>emptyList()));
+        Assertions.assertNull(new SelectBest().selectSolution(Collections.<VehicleRoutingProblemSolution>emptyList()));
     }
 }

--- a/jsprit-core/src/test/java/com/graphhopper/jsprit/core/algorithm/selector/SelectRandomlyTest.java
+++ b/jsprit-core/src/test/java/com/graphhopper/jsprit/core/algorithm/selector/SelectRandomlyTest.java
@@ -18,6 +18,8 @@
 package com.graphhopper.jsprit.core.algorithm.selector;
 
 import com.graphhopper.jsprit.core.problem.solution.VehicleRoutingProblemSolution;
+
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
@@ -25,9 +27,6 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.Random;
 
-import static org.hamcrest.CoreMatchers.is;
-import static org.junit.Assert.assertThat;
-import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -45,7 +44,7 @@ class SelectRandomlyTest {
         when(random.nextInt(2)).thenReturn(1);
         SelectRandomly selectRandomly = new SelectRandomly();
         selectRandomly.setRandom(random);
-        assertThat(selectRandomly.selectSolution(Arrays.asList(sol1, sol2)), is(sol2));
+        Assertions.assertSame(selectRandomly.selectSolution(Arrays.asList(sol1, sol2)), sol2);
     }
 
     @Test
@@ -59,7 +58,7 @@ class SelectRandomlyTest {
         when(random.nextInt(2)).thenReturn(0);
         SelectRandomly selectRandomly = new SelectRandomly();
         selectRandomly.setRandom(random);
-        assertThat(selectRandomly.selectSolution(Arrays.asList(sol1, sol2)), is(sol1));
+        Assertions.assertSame(selectRandomly.selectSolution(Arrays.asList(sol1, sol2)), sol1);
     }
 
     @Test
@@ -69,6 +68,6 @@ class SelectRandomlyTest {
         when(random.nextInt(2)).thenReturn(0);
         SelectRandomly selectRandomly = new SelectRandomly();
         selectRandomly.setRandom(random);
-        assertNull(selectRandomly.selectSolution(Collections.<VehicleRoutingProblemSolution>emptyList()));
+        Assertions.assertNull(selectRandomly.selectSolution(Collections.<VehicleRoutingProblemSolution>emptyList()));
     }
 }

--- a/jsprit-core/src/test/java/com/graphhopper/jsprit/core/algorithm/state/HardPickupAndDeliveryShipmentActivityConstraintTest.java
+++ b/jsprit-core/src/test/java/com/graphhopper/jsprit/core/algorithm/state/HardPickupAndDeliveryShipmentActivityConstraintTest.java
@@ -35,7 +35,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
+import org.junit.jupiter.api.Assertions;
 
 @DisplayName("Hard Pickup And Delivery Shipment Activity Constraint Test")
 class HardPickupAndDeliveryShipmentActivityConstraintTest {
@@ -76,7 +76,8 @@ class HardPickupAndDeliveryShipmentActivityConstraintTest {
         PickupService pickupService = (PickupService) vrp.getActivities(s1).get(0);
         PickupService anotherService = (PickupService) vrp.getActivities(s2).get(0);
         PickupShipment pickupShipment = (PickupShipment) vrp.getActivities(shipment).get(0);
-        assertEquals(ConstraintsStatus.FULFILLED, constraint.fulfilled(iFacts, pickupService, pickupShipment, anotherService, 0.0));
+        Assertions.assertEquals(ConstraintsStatus.FULFILLED,
+                constraint.fulfilled(iFacts, pickupService, pickupShipment, anotherService, 0.0));
     }
 
     @Test
@@ -87,7 +88,8 @@ class HardPickupAndDeliveryShipmentActivityConstraintTest {
         PickupShipment pickupShipment = (PickupShipment) vrp.getActivities(shipment).get(0);
         stateManager.putInternalTypedActivityState(pickupService, InternalStates.LOAD, Capacity.Builder.newInstance().addDimension(0, 2).build());
         // when(stateManager.getActivityState(pickupService, StateFactory.LOAD)).thenReturn(StateFactory.createState(2.0));
-        assertEquals(ConstraintsStatus.NOT_FULFILLED, constraint.fulfilled(iFacts, pickupService, pickupShipment, anotherService, 0.0));
+        Assertions.assertEquals(ConstraintsStatus.NOT_FULFILLED,
+                constraint.fulfilled(iFacts, pickupService, pickupShipment, anotherService, 0.0));
     }
 
     @Test
@@ -98,6 +100,7 @@ class HardPickupAndDeliveryShipmentActivityConstraintTest {
         DeliverShipment deliverShipment = (DeliverShipment) vrp.getActivities(shipment).get(1);
         stateManager.putInternalTypedActivityState(pickupService, InternalStates.LOAD, Capacity.Builder.newInstance().addDimension(0, 1).build());
         // stateManager.putInternalActivityState(pickupService, StateFactory.LOAD, StateFactory.createState(1));
-        assertEquals(ConstraintsStatus.FULFILLED, constraint.fulfilled(iFacts, pickupService, deliverShipment, anotherService, 0.0));
+        Assertions.assertEquals(ConstraintsStatus.FULFILLED,
+                constraint.fulfilled(iFacts, pickupService, deliverShipment, anotherService, 0.0));
     }
 }

--- a/jsprit-core/src/test/java/com/graphhopper/jsprit/core/algorithm/state/LoadStateTest.java
+++ b/jsprit-core/src/test/java/com/graphhopper/jsprit/core/algorithm/state/LoadStateTest.java
@@ -22,6 +22,8 @@ import com.graphhopper.jsprit.core.problem.job.*;
 import com.graphhopper.jsprit.core.problem.solution.route.VehicleRoute;
 import com.graphhopper.jsprit.core.problem.vehicle.Vehicle;
 import com.graphhopper.jsprit.core.problem.vehicle.VehicleType;
+
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -107,7 +109,7 @@ class LoadStateTest {
     void loadAtEndShouldBe15() {
         stateManager.informInsertionStarts(Arrays.asList(serviceRoute), Collections.<Job>emptyList());
         Capacity routeState = stateManager.getRouteState(serviceRoute, InternalStates.LOAD_AT_END, Capacity.class);
-        assertEquals(15, routeState.get(0));
+        Assertions.assertEquals(15, routeState.get(0));
     }
 
     @Test
@@ -115,7 +117,7 @@ class LoadStateTest {
     void loadAtBeginningShouldBe0() {
         stateManager.informInsertionStarts(Arrays.asList(serviceRoute), Collections.<Job>emptyList());
         Capacity routeState = stateManager.getRouteState(serviceRoute, InternalStates.LOAD_AT_BEGINNING, Capacity.class);
-        assertEquals(0, routeState.get(0));
+        Assertions.assertEquals(0, routeState.get(0));
     }
 
     @Test
@@ -123,7 +125,7 @@ class LoadStateTest {
     void loadAtAct1ShouldBe10() {
         stateManager.informInsertionStarts(Arrays.asList(serviceRoute), Collections.<Job>emptyList());
         Capacity atAct1 = stateManager.getActivityState(serviceRoute.getActivities().get(0), InternalStates.LOAD, Capacity.class);
-        assertEquals(10, atAct1.get(0));
+        Assertions.assertEquals(10, atAct1.get(0));
     }
 
     @Test
@@ -131,7 +133,7 @@ class LoadStateTest {
     void loadAtAct2ShouldBe15() {
         stateManager.informInsertionStarts(Arrays.asList(serviceRoute), Collections.<Job>emptyList());
         Capacity atAct2 = stateManager.getActivityState(serviceRoute.getActivities().get(1), InternalStates.LOAD, Capacity.class);
-        assertEquals(15, atAct2.get(0));
+        Assertions.assertEquals(15, atAct2.get(0));
     }
 
     @Test
@@ -139,7 +141,7 @@ class LoadStateTest {
     void futureMaxLoatAtAct1ShouldBe15() {
         stateManager.informInsertionStarts(Arrays.asList(serviceRoute), Collections.<Job>emptyList());
         Capacity atAct1 = stateManager.getActivityState(serviceRoute.getActivities().get(0), InternalStates.FUTURE_MAXLOAD, Capacity.class);
-        assertEquals(15, atAct1.get(0));
+        Assertions.assertEquals(15, atAct1.get(0));
     }
 
     @Test
@@ -147,7 +149,7 @@ class LoadStateTest {
     void futureMaxLoatAtAct2ShouldBe15() {
         stateManager.informInsertionStarts(Arrays.asList(serviceRoute), Collections.<Job>emptyList());
         Capacity atAct2 = stateManager.getActivityState(serviceRoute.getActivities().get(1), InternalStates.FUTURE_MAXLOAD, Capacity.class);
-        assertEquals(15, atAct2.get(0));
+        Assertions.assertEquals(15, atAct2.get(0));
     }
 
     @Test
@@ -155,7 +157,7 @@ class LoadStateTest {
     void pastMaxLoatAtAct1ShouldBe0() {
         stateManager.informInsertionStarts(Arrays.asList(serviceRoute), Collections.<Job>emptyList());
         Capacity atAct1 = stateManager.getActivityState(serviceRoute.getActivities().get(0), InternalStates.PAST_MAXLOAD, Capacity.class);
-        assertEquals(10, atAct1.get(0));
+        Assertions.assertEquals(10, atAct1.get(0));
     }
 
     @Test
@@ -163,7 +165,7 @@ class LoadStateTest {
     void pastMaxLoatAtAct2ShouldBe10() {
         stateManager.informInsertionStarts(Arrays.asList(serviceRoute), Collections.<Job>emptyList());
         Capacity atAct2 = stateManager.getActivityState(serviceRoute.getActivities().get(1), InternalStates.PAST_MAXLOAD, Capacity.class);
-        assertEquals(15, atAct2.get(0));
+        Assertions.assertEquals(15, atAct2.get(0));
     }
 
     /*
@@ -175,7 +177,7 @@ class LoadStateTest {
     void when_pdroute_loadAtEndShouldBe10() {
         stateManager.informInsertionStarts(Arrays.asList(pickup_delivery_route), Collections.<Job>emptyList());
         Capacity routeState = stateManager.getRouteState(pickup_delivery_route, InternalStates.LOAD_AT_END, Capacity.class);
-        assertEquals(10, routeState.get(0));
+        Assertions.assertEquals(10, routeState.get(0));
     }
 
     @Test
@@ -183,7 +185,7 @@ class LoadStateTest {
     void when_pdroute_loadAtBeginningShouldBe5() {
         stateManager.informInsertionStarts(Arrays.asList(pickup_delivery_route), Collections.<Job>emptyList());
         Capacity routeState = stateManager.getRouteState(pickup_delivery_route, InternalStates.LOAD_AT_BEGINNING, Capacity.class);
-        assertEquals(5, routeState.get(0));
+        Assertions.assertEquals(5, routeState.get(0));
     }
 
     @Test
@@ -191,7 +193,7 @@ class LoadStateTest {
     void when_pdroute_loadAtAct1ShouldBe15() {
         stateManager.informInsertionStarts(Arrays.asList(pickup_delivery_route), Collections.<Job>emptyList());
         Capacity atAct1 = stateManager.getActivityState(pickup_delivery_route.getActivities().get(0), InternalStates.LOAD, Capacity.class);
-        assertEquals(15, atAct1.get(0));
+        Assertions.assertEquals(15, atAct1.get(0));
     }
 
     @Test
@@ -199,7 +201,7 @@ class LoadStateTest {
     void when_pdroute_loadAtAct2ShouldBe10() {
         stateManager.informInsertionStarts(Arrays.asList(pickup_delivery_route), Collections.<Job>emptyList());
         Capacity atAct2 = stateManager.getActivityState(pickup_delivery_route.getActivities().get(1), InternalStates.LOAD, Capacity.class);
-        assertEquals(10, atAct2.get(0));
+        Assertions.assertEquals(10, atAct2.get(0));
     }
 
     @Test
@@ -207,7 +209,7 @@ class LoadStateTest {
     void when_pdroute_futureMaxLoatAtAct1ShouldBe15() {
         stateManager.informInsertionStarts(Arrays.asList(pickup_delivery_route), Collections.<Job>emptyList());
         Capacity atAct1 = stateManager.getActivityState(pickup_delivery_route.getActivities().get(0), InternalStates.FUTURE_MAXLOAD, Capacity.class);
-        assertEquals(15, atAct1.get(0));
+        Assertions.assertEquals(15, atAct1.get(0));
     }
 
     @Test
@@ -215,7 +217,7 @@ class LoadStateTest {
     void when_pdroute_futureMaxLoatAtAct2ShouldBe10() {
         stateManager.informInsertionStarts(Arrays.asList(pickup_delivery_route), Collections.<Job>emptyList());
         Capacity atAct2 = stateManager.getActivityState(pickup_delivery_route.getActivities().get(1), InternalStates.FUTURE_MAXLOAD, Capacity.class);
-        assertEquals(10, atAct2.get(0));
+        Assertions.assertEquals(10, atAct2.get(0));
     }
 
     @Test
@@ -223,7 +225,7 @@ class LoadStateTest {
     void when_pdroute_pastMaxLoatAtAct1ShouldBe15() {
         stateManager.informInsertionStarts(Arrays.asList(pickup_delivery_route), Collections.<Job>emptyList());
         Capacity atAct1 = stateManager.getActivityState(pickup_delivery_route.getActivities().get(0), InternalStates.PAST_MAXLOAD, Capacity.class);
-        assertEquals(15, atAct1.get(0));
+        Assertions.assertEquals(15, atAct1.get(0));
     }
 
     @Test
@@ -231,7 +233,7 @@ class LoadStateTest {
     void when_pdroute_pastMaxLoatAtAct2ShouldBe10() {
         stateManager.informInsertionStarts(Arrays.asList(pickup_delivery_route), Collections.<Job>emptyList());
         Capacity atAct2 = stateManager.getActivityState(pickup_delivery_route.getActivities().get(1), InternalStates.PAST_MAXLOAD, Capacity.class);
-        assertEquals(15, atAct2.get(0));
+        Assertions.assertEquals(15, atAct2.get(0));
     }
 
     /*
@@ -246,7 +248,7 @@ class LoadStateTest {
     void when_shipmentroute_loadAtEndShouldBe0() {
         stateManager.informInsertionStarts(Arrays.asList(shipment_route), Collections.<Job>emptyList());
         Capacity routeState = stateManager.getRouteState(shipment_route, InternalStates.LOAD_AT_END, Capacity.class);
-        assertEquals(0, routeState.get(0));
+        Assertions.assertEquals(0, routeState.get(0));
     }
 
     @Test
@@ -254,7 +256,7 @@ class LoadStateTest {
     void when_shipmentroute_loadAtBeginningShouldBe0() {
         stateManager.informInsertionStarts(Arrays.asList(shipment_route), Collections.<Job>emptyList());
         Capacity routeState = stateManager.getRouteState(shipment_route, InternalStates.LOAD_AT_BEGINNING, Capacity.class);
-        assertEquals(0, routeState.get(0));
+        Assertions.assertEquals(0, routeState.get(0));
     }
 
     @Test
@@ -262,7 +264,7 @@ class LoadStateTest {
     void when_shipmentroute_loadAtAct1ShouldBe10() {
         stateManager.informInsertionStarts(Arrays.asList(shipment_route), Collections.<Job>emptyList());
         Capacity atAct1 = stateManager.getActivityState(shipment_route.getActivities().get(0), InternalStates.LOAD, Capacity.class);
-        assertEquals(10, atAct1.get(0));
+        Assertions.assertEquals(10, atAct1.get(0));
     }
 
     @Test
@@ -270,7 +272,7 @@ class LoadStateTest {
     void when_shipmentroute_loadAtAct2ShouldBe15() {
         stateManager.informInsertionStarts(Arrays.asList(shipment_route), Collections.<Job>emptyList());
         Capacity atAct2 = stateManager.getActivityState(shipment_route.getActivities().get(1), InternalStates.LOAD, Capacity.class);
-        assertEquals(15, atAct2.get(0));
+        Assertions.assertEquals(15, atAct2.get(0));
     }
 
     @Test
@@ -278,7 +280,7 @@ class LoadStateTest {
     void when_shipmentroute_loadAtAct3ShouldBe10() {
         stateManager.informInsertionStarts(Arrays.asList(shipment_route), Collections.<Job>emptyList());
         Capacity atAct = stateManager.getActivityState(shipment_route.getActivities().get(2), InternalStates.LOAD, Capacity.class);
-        assertEquals(10, atAct.get(0));
+        Assertions.assertEquals(10, atAct.get(0));
     }
 
     @Test
@@ -286,7 +288,7 @@ class LoadStateTest {
     void when_shipmentroute_loadAtAct4ShouldBe0() {
         stateManager.informInsertionStarts(Arrays.asList(shipment_route), Collections.<Job>emptyList());
         Capacity atAct = stateManager.getActivityState(shipment_route.getActivities().get(3), InternalStates.LOAD, Capacity.class);
-        assertEquals(0, atAct.get(0));
+        Assertions.assertEquals(0, atAct.get(0));
     }
 
     @Test
@@ -294,7 +296,7 @@ class LoadStateTest {
     void when_shipmentroute_futureMaxLoatAtAct1ShouldBe15() {
         stateManager.informInsertionStarts(Arrays.asList(shipment_route), Collections.<Job>emptyList());
         Capacity atAct1 = stateManager.getActivityState(shipment_route.getActivities().get(0), InternalStates.FUTURE_MAXLOAD, Capacity.class);
-        assertEquals(15, atAct1.get(0));
+        Assertions.assertEquals(15, atAct1.get(0));
     }
 
     @Test
@@ -302,7 +304,7 @@ class LoadStateTest {
     void when_shipmentroute_futureMaxLoatAtAct2ShouldBe15() {
         stateManager.informInsertionStarts(Arrays.asList(shipment_route), Collections.<Job>emptyList());
         Capacity atAct2 = stateManager.getActivityState(shipment_route.getActivities().get(1), InternalStates.FUTURE_MAXLOAD, Capacity.class);
-        assertEquals(15, atAct2.get(0));
+        Assertions.assertEquals(15, atAct2.get(0));
     }
 
     @Test
@@ -310,7 +312,7 @@ class LoadStateTest {
     void when_shipmentroute_futureMaxLoatAtAct3ShouldBe10() {
         stateManager.informInsertionStarts(Arrays.asList(shipment_route), Collections.<Job>emptyList());
         Capacity atAct = stateManager.getActivityState(shipment_route.getActivities().get(2), InternalStates.FUTURE_MAXLOAD, Capacity.class);
-        assertEquals(10, atAct.get(0));
+        Assertions.assertEquals(10, atAct.get(0));
     }
 
     @Test
@@ -318,7 +320,7 @@ class LoadStateTest {
     void when_shipmentroute_futureMaxLoatAtAct4ShouldBe0() {
         stateManager.informInsertionStarts(Arrays.asList(shipment_route), Collections.<Job>emptyList());
         Capacity atAct = stateManager.getActivityState(shipment_route.getActivities().get(3), InternalStates.FUTURE_MAXLOAD, Capacity.class);
-        assertEquals(0, atAct.get(0));
+        Assertions.assertEquals(0, atAct.get(0));
     }
 
     @Test
@@ -326,7 +328,7 @@ class LoadStateTest {
     void when_shipmentroute_pastMaxLoatAtAct1ShouldBe10() {
         stateManager.informInsertionStarts(Arrays.asList(shipment_route), Collections.<Job>emptyList());
         Capacity atAct1 = stateManager.getActivityState(shipment_route.getActivities().get(0), InternalStates.PAST_MAXLOAD, Capacity.class);
-        assertEquals(10, atAct1.get(0));
+        Assertions.assertEquals(10, atAct1.get(0));
     }
 
     @Test
@@ -334,7 +336,7 @@ class LoadStateTest {
     void when_shipmentroute_pastMaxLoatAtAct2ShouldBe10() {
         stateManager.informInsertionStarts(Arrays.asList(shipment_route), Collections.<Job>emptyList());
         Capacity atAct2 = stateManager.getActivityState(shipment_route.getActivities().get(1), InternalStates.PAST_MAXLOAD, Capacity.class);
-        assertEquals(15, atAct2.get(0));
+        Assertions.assertEquals(15, atAct2.get(0));
     }
 
     @Test
@@ -342,7 +344,7 @@ class LoadStateTest {
     void when_shipmentroute_pastMaxLoatAtAct3ShouldBe15() {
         stateManager.informInsertionStarts(Arrays.asList(shipment_route), Collections.<Job>emptyList());
         Capacity atAct = stateManager.getActivityState(shipment_route.getActivities().get(2), InternalStates.PAST_MAXLOAD, Capacity.class);
-        assertEquals(15, atAct.get(0));
+        Assertions.assertEquals(15, atAct.get(0));
     }
 
     @Test
@@ -350,6 +352,6 @@ class LoadStateTest {
     void when_shipmentroute_pastMaxLoatAtAct4ShouldBe15() {
         stateManager.informInsertionStarts(Arrays.asList(shipment_route), Collections.<Job>emptyList());
         Capacity atAct = stateManager.getActivityState(shipment_route.getActivities().get(3), InternalStates.PAST_MAXLOAD, Capacity.class);
-        assertEquals(15, atAct.get(0));
+        Assertions.assertEquals(15, atAct.get(0));
     }
 }

--- a/jsprit-core/src/test/java/com/graphhopper/jsprit/core/algorithm/state/StateManagerTest.java
+++ b/jsprit-core/src/test/java/com/graphhopper/jsprit/core/algorithm/state/StateManagerTest.java
@@ -27,6 +27,8 @@ import com.graphhopper.jsprit.core.problem.vehicle.Vehicle;
 import com.graphhopper.jsprit.core.problem.vehicle.VehicleImpl;
 import com.graphhopper.jsprit.core.problem.vehicle.VehicleType;
 import com.graphhopper.jsprit.core.problem.vehicle.VehicleTypeImpl;
+
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -73,7 +75,7 @@ class StateManagerTest {
         StateManager stateManager = new StateManager(vrpMock);
         StateId id = InternalStates.COSTS;
         stateManager.putTypedInternalRouteState(route, id, 10.);
-        assertEquals(10., stateManager.getRouteState(route, id, Double.class), 0.01);
+        Assertions.assertEquals(10., stateManager.getRouteState(route, id, Double.class), 0.01);
     }
 
     @Test
@@ -83,7 +85,7 @@ class StateManagerTest {
         StateManager stateManager = new StateManager(vrpMock);
         StateId id = InternalStates.COSTS;
         Double costs = stateManager.getRouteState(route, id, Double.class);
-        assertTrue(costs == null);
+        Assertions.assertTrue(costs == null);
     }
 
     @Test
@@ -96,7 +98,7 @@ class StateManagerTest {
         StateManager stateManager = new StateManager(vrpMock);
         StateId id = InternalStates.COSTS;
         stateManager.putTypedInternalRouteState(route, vehicle, id, 10.);
-        assertEquals(10., stateManager.getRouteState(route, vehicle, id, Double.class), 0.01);
+        Assertions.assertEquals(10., stateManager.getRouteState(route, vehicle, id, Double.class), 0.01);
     }
 
     @Test
@@ -109,7 +111,7 @@ class StateManagerTest {
         StateManager stateManager = new StateManager(vrpMock);
         StateId id = InternalStates.COSTS;
         Double costs = stateManager.getRouteState(route, vehicle, id, Double.class);
-        assertTrue(costs == null);
+        Assertions.assertTrue(costs == null);
     }
 
     @Test
@@ -119,7 +121,7 @@ class StateManagerTest {
         StateManager stateManager = new StateManager(vrpMock);
         StateId id = stateManager.createStateId("myState");
         stateManager.putRouteState(route, id, true);
-        assertTrue(stateManager.getRouteState(route, id, Boolean.class));
+        Assertions.assertTrue(stateManager.getRouteState(route, id, Boolean.class));
     }
 
     @Test
@@ -131,7 +133,7 @@ class StateManagerTest {
         int load = 3;
         stateManager.putRouteState(route, id, load);
         int getLoad = stateManager.getRouteState(route, id, Integer.class);
-        assertEquals(3, getLoad);
+        Assertions.assertEquals(3, getLoad);
     }
 
     @Test
@@ -143,7 +145,7 @@ class StateManagerTest {
         Capacity capacity = Capacity.Builder.newInstance().addDimension(0, 500).build();
         stateManager.putRouteState(route, id, capacity);
         Capacity getCap = stateManager.getRouteState(route, id, Capacity.class);
-        assertEquals(500, getCap.get(0));
+        Assertions.assertEquals(500, getCap.get(0));
     }
 
     @Test
@@ -154,7 +156,7 @@ class StateManagerTest {
         StateManager stateManager = new StateManager(vrpMock);
         StateId id = stateManager.createStateId("myState");
         stateManager.putActivityState(activity, id, true);
-        assertTrue(stateManager.getActivityState(activity, id, Boolean.class));
+        Assertions.assertTrue(stateManager.getActivityState(activity, id, Boolean.class));
     }
 
     @Test
@@ -167,7 +169,7 @@ class StateManagerTest {
         int load = 3;
         stateManager.putActivityState(activity, id, load);
         int getLoad = stateManager.getActivityState(activity, id, Integer.class);
-        assertEquals(3, getLoad);
+        Assertions.assertEquals(3, getLoad);
     }
 
     @Test
@@ -180,7 +182,7 @@ class StateManagerTest {
         Capacity capacity = Capacity.Builder.newInstance().addDimension(0, 500).build();
         stateManager.putActivityState(activity, id, capacity);
         Capacity getCap = stateManager.getActivityState(activity, id, Capacity.class);
-        assertEquals(500, getCap.get(0));
+        Assertions.assertEquals(500, getCap.get(0));
     }
 
     @Test
@@ -190,7 +192,7 @@ class StateManagerTest {
         StateId id = stateManager.createStateId("problemState");
         stateManager.putProblemState(id, Boolean.class, true);
         boolean problemState = stateManager.getProblemState(id, Boolean.class);
-        assertTrue(problemState);
+        Assertions.assertTrue(problemState);
     }
 
     @Test
@@ -222,7 +224,7 @@ class StateManagerTest {
     void whenCreatingNewState_itShouldHaveAnIndex() {
         StateManager stateManager = new StateManager(vrpMock);
         StateId stateId = stateManager.createStateId("foo-state");
-        assertEquals(21, stateId.getIndex());
+        Assertions.assertEquals(21, stateId.getIndex());
     }
 
     @Test
@@ -231,8 +233,8 @@ class StateManagerTest {
         StateManager stateManager = new StateManager(vrpMock);
         StateId fooState = stateManager.createStateId("foo-state");
         StateId foofooState = stateManager.createStateId("foo-foo-state");
-        assertEquals(21, fooState.getIndex());
-        assertEquals(22, foofooState.getIndex());
+        Assertions.assertEquals(21, fooState.getIndex());
+        Assertions.assertEquals(22, foofooState.getIndex());
     }
 
     @Test
@@ -241,8 +243,8 @@ class StateManagerTest {
         StateManager stateManager = new StateManager(vrpMock);
         StateId fooState = stateManager.createStateId("foo-state");
         StateId foofooState = stateManager.createStateId("foo-state");
-        assertEquals(21, fooState.getIndex());
-        assertEquals(21, foofooState.getIndex());
+        Assertions.assertEquals(21, fooState.getIndex());
+        Assertions.assertEquals(21, foofooState.getIndex());
     }
 
     @Test
@@ -257,7 +259,7 @@ class StateManagerTest {
         Capacity capacity = Capacity.Builder.newInstance().addDimension(0, 500).build();
         stateManager.putRouteState(route, vehicle, id, capacity);
         Capacity getCap = stateManager.getRouteState(route, vehicle, id, Capacity.class);
-        assertEquals(500, getCap.get(0));
+        Assertions.assertEquals(500, getCap.get(0));
     }
 
     @Test
@@ -273,7 +275,7 @@ class StateManagerTest {
         when(act.getIndex()).thenReturn(1);
         stateManager.putActivityState(act, vehicle, id, capacity);
         Capacity getCap = stateManager.getActivityState(act, vehicle, id, Capacity.class);
-        assertEquals(500, getCap.get(0));
+        Assertions.assertEquals(500, getCap.get(0));
     }
 
     @Test
@@ -287,7 +289,7 @@ class StateManagerTest {
         StateId id = stateManager.createStateId("vehicleParam");
         double distanceParam = vehicle.getType().getVehicleCostParams().perDistanceUnit;
         stateManager.putRouteState(route, vehicle, id, distanceParam);
-        assertEquals(1., stateManager.getRouteState(route, vehicle, id, Double.class), 0.01);
+        Assertions.assertEquals(1., stateManager.getRouteState(route, vehicle, id, Double.class), 0.01);
     }
 
     @Test
@@ -305,8 +307,8 @@ class StateManagerTest {
         double distanceParam = vehicle.getType().getVehicleCostParams().perDistanceUnit;
         stateManager.putRouteState(route, vehicle, id, distanceParam);
         stateManager.putRouteState(route, vehicle2, id, vehicle2.getType().getVehicleCostParams().perDistanceUnit);
-        assertEquals(1., stateManager.getRouteState(route, vehicle, id, Double.class), 0.01);
-        assertEquals(4., stateManager.getRouteState(route, vehicle2, id, Double.class), 0.01);
+        Assertions.assertEquals(1., stateManager.getRouteState(route, vehicle, id, Double.class), 0.01);
+        Assertions.assertEquals(4., stateManager.getRouteState(route, vehicle2, id, Double.class), 0.01);
     }
 
     @Test
@@ -325,8 +327,8 @@ class StateManagerTest {
         double distanceParam = vehicle.getType().getVehicleCostParams().perDistanceUnit;
         stateManager.putActivityState(act, vehicle, id, distanceParam);
         stateManager.putActivityState(act, vehicle2, id, vehicle2.getType().getVehicleCostParams().perDistanceUnit);
-        assertEquals(1., stateManager.getActivityState(act, vehicle, id, Double.class), 0.01);
-        assertEquals(4., stateManager.getActivityState(act, vehicle2, id, Double.class), 0.01);
+        Assertions.assertEquals(1., stateManager.getActivityState(act, vehicle, id, Double.class), 0.01);
+        Assertions.assertEquals(4., stateManager.getActivityState(act, vehicle2, id, Double.class), 0.01);
     }
 
     @Test

--- a/jsprit-core/src/test/java/com/graphhopper/jsprit/core/algorithm/state/UpdateMaxTimeInVehicleTest.java
+++ b/jsprit-core/src/test/java/com/graphhopper/jsprit/core/algorithm/state/UpdateMaxTimeInVehicleTest.java
@@ -105,24 +105,24 @@ class UpdateMaxTimeInVehicleTest {
     // String jobId = ((TourActivity.JobActivity)act).getJob().getId();
     // if(jobId.equals("s4")){
     // Double slackTime = stateManager.getActivityState(act,route.getVehicle(), minSlackId,Double.class);
-    // Assert.assertEquals(40, slackTime, 0.001);
+	// Assertions.assertEquals(40, slackTime, 0.001);
     // }
     // if(jobId.equals("s3")){
     // Double slackTime = stateManager.getActivityState(act,route.getVehicle(), minSlackId,Double.class);
-    // Assert.assertEquals(30, slackTime, 0.001);
+	// Assertions.assertEquals(30, slackTime, 0.001);
     // }
     // if(jobId.equals("s2")){
     // Double slackTime = stateManager.getActivityState(act,route.getVehicle(), minSlackId,Double.class);
-    // Assert.assertEquals(20, slackTime, 0.001);
+	// Assertions.assertEquals(20, slackTime, 0.001);
     // }
     // if(jobId.equals("s")){
     // Double slackTime = stateManager.getActivityState(act,route.getVehicle(), minSlackId,Double.class);
-    // Assert.assertEquals(Double.MAX_VALUE, slackTime, 0.001);
+	// Assertions.assertEquals(Double.MAX_VALUE, slackTime, 0.001);
     // }
     // }
     // Double slackTime = stateManager.getRouteState(route,route.getVehicle(), minSlackId,Double.class);
-    // Assert.assertNotNull(slackTime);
-    // Assert.assertEquals(50,slackTime,0.001);
+	// Assertions.assertNotNull(slackTime);
+	// Assertions.assertEquals(50,slackTime,0.001);
     // }
     //
     // @Test
@@ -132,24 +132,24 @@ class UpdateMaxTimeInVehicleTest {
     // String jobId = ((TourActivity.JobActivity)act).getJob().getId();
     // if(jobId.equals("s4")){
     // Double slackTime = stateManager.getActivityState(act,vehicle2, minSlackId,Double.class);
-    // Assert.assertEquals(40, slackTime, 0.001);
+	// Assertions.assertEquals(40, slackTime, 0.001);
     // }
     // if(jobId.equals("s3")){
     // Double slackTime = stateManager.getActivityState(act,vehicle2, minSlackId,Double.class);
-    // Assert.assertEquals(30, slackTime, 0.001);
+	// Assertions.assertEquals(30, slackTime, 0.001);
     // }
     // if(jobId.equals("s2")){
     // Double slackTime = stateManager.getActivityState(act,vehicle2, minSlackId,Double.class);
-    // Assert.assertEquals(20, slackTime, 0.001);
+	// Assertions.assertEquals(20, slackTime, 0.001);
     // }
     // if(jobId.equals("s")){
     // Double slackTime = stateManager.getActivityState(act,vehicle2, minSlackId,Double.class);
-    // Assert.assertEquals(Double.MAX_VALUE, slackTime, 0.001);
+	// Assertions.assertEquals(Double.MAX_VALUE, slackTime, 0.001);
     // }
     // }
     // Double slackTime = stateManager.getRouteState(route,vehicle2, minSlackId,Double.class);
-    // Assert.assertNotNull(slackTime);
-    // Assert.assertEquals(40,slackTime,0.001);
+	// Assertions.assertNotNull(slackTime);
+	// Assertions.assertEquals(40,slackTime,0.001);
     // }
     @Test
     @DisplayName("Test With Shipment")

--- a/jsprit-core/src/test/java/com/graphhopper/jsprit/core/algorithm/state/UpdatePracticalTimeWindowTest.java
+++ b/jsprit-core/src/test/java/com/graphhopper/jsprit/core/algorithm/state/UpdatePracticalTimeWindowTest.java
@@ -35,6 +35,8 @@ import com.graphhopper.jsprit.core.problem.vehicle.Vehicle;
 import com.graphhopper.jsprit.core.problem.vehicle.VehicleImpl;
 import com.graphhopper.jsprit.core.problem.vehicle.VehicleType;
 import com.graphhopper.jsprit.core.util.CostFactory;
+
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -86,21 +88,24 @@ class UpdatePracticalTimeWindowTest {
     @Test
     @DisplayName("When Vehicle Route Has Pickup And Delivery And Pickup _ latest Start Time Of Act 3 Must Be Correct")
     void whenVehicleRouteHasPickupAndDeliveryAndPickup_latestStartTimeOfAct3MustBeCorrect() {
-        assertEquals(50., route.getActivities().get(2).getTheoreticalLatestOperationStartTime(), 0.01);
-        assertEquals(50., stateManager.getActivityState(route.getActivities().get(2), InternalStates.LATEST_OPERATION_START_TIME, Double.class), 0.01);
+        Assertions.assertEquals(50., route.getActivities().get(2).getTheoreticalLatestOperationStartTime(), 0.01);
+        Assertions.assertEquals(50., stateManager.getActivityState(route.getActivities().get(2),
+                InternalStates.LATEST_OPERATION_START_TIME, Double.class), 0.01);
     }
 
     @Test
     @DisplayName("When Vehicle Route Has Pickup And Delivery And Pickup _ latest Start Time Of Act 2 Must Be Correct")
     void whenVehicleRouteHasPickupAndDeliveryAndPickup_latestStartTimeOfAct2MustBeCorrect() {
-        assertEquals(40., route.getActivities().get(1).getTheoreticalLatestOperationStartTime(), 0.01);
-        assertEquals(30., stateManager.getActivityState(route.getActivities().get(1), InternalStates.LATEST_OPERATION_START_TIME, Double.class), 0.01);
+        Assertions.assertEquals(40., route.getActivities().get(1).getTheoreticalLatestOperationStartTime(), 0.01);
+        Assertions.assertEquals(30., stateManager.getActivityState(route.getActivities().get(1),
+                InternalStates.LATEST_OPERATION_START_TIME, Double.class), 0.01);
     }
 
     @Test
     @DisplayName("When Vehicle Route Has Pickup And Delivery And Pickup _ latest Start Time Of Act 1 Must Be Correct")
     void whenVehicleRouteHasPickupAndDeliveryAndPickup_latestStartTimeOfAct1MustBeCorrect() {
-        assertEquals(30., route.getActivities().get(0).getTheoreticalLatestOperationStartTime(), 0.01);
-        assertEquals(10., stateManager.getActivityState(route.getActivities().get(0), InternalStates.LATEST_OPERATION_START_TIME, Double.class), 0.01);
+        Assertions.assertEquals(30., route.getActivities().get(0).getTheoreticalLatestOperationStartTime(), 0.01);
+        Assertions.assertEquals(10., stateManager.getActivityState(route.getActivities().get(0),
+                InternalStates.LATEST_OPERATION_START_TIME, Double.class), 0.01);
     }
 }

--- a/jsprit-core/src/test/java/com/graphhopper/jsprit/core/algorithm/state/UpdateRequiredSkillsTest.java
+++ b/jsprit-core/src/test/java/com/graphhopper/jsprit/core/algorithm/state/UpdateRequiredSkillsTest.java
@@ -25,6 +25,8 @@ import com.graphhopper.jsprit.core.problem.solution.route.VehicleRoute;
 import com.graphhopper.jsprit.core.problem.vehicle.VehicleImpl;
 import com.graphhopper.jsprit.core.problem.vehicle.VehicleType;
 import com.graphhopper.jsprit.core.problem.vehicle.VehicleTypeImpl;
+
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -62,11 +64,11 @@ class UpdateRequiredSkillsTest {
     void whenUpdatingRoute_skillsAtRouteLevelShouldContainAllSkills() {
         Skills skills = stateManager.getRouteState(route, InternalStates.SKILLS, Skills.class);
         assertNotNull(skills);
-        assertEquals(5, skills.values().size());
-        assertTrue(skills.containsSkill("skill1"));
-        assertTrue(skills.containsSkill("skill2"));
-        assertTrue(skills.containsSkill("skill3"));
-        assertTrue(skills.containsSkill("skill4"));
-        assertTrue(skills.containsSkill("skill5"));
+        Assertions.assertEquals(5, skills.values().size());
+        Assertions.assertTrue(skills.containsSkill("skill1"));
+        Assertions.assertTrue(skills.containsSkill("skill2"));
+        Assertions.assertTrue(skills.containsSkill("skill3"));
+        Assertions.assertTrue(skills.containsSkill("skill4"));
+        Assertions.assertTrue(skills.containsSkill("skill5"));
     }
 }

--- a/jsprit-core/src/test/java/com/graphhopper/jsprit/core/algorithm/state/UpdateVehicleDependentTimeWindowTest.java
+++ b/jsprit-core/src/test/java/com/graphhopper/jsprit/core/algorithm/state/UpdateVehicleDependentTimeWindowTest.java
@@ -34,13 +34,13 @@ import com.graphhopper.jsprit.core.problem.vehicle.VehicleFleetManager;
 import com.graphhopper.jsprit.core.problem.vehicle.VehicleImpl;
 import com.graphhopper.jsprit.core.util.Coordinate;
 import com.graphhopper.jsprit.core.util.CostFactory;
+
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
 import java.util.*;
-
-import static org.junit.jupiter.api.Assertions.*;
 
 /**
  * unit tests to test vehicle dependent time window updater
@@ -119,74 +119,87 @@ class UpdateVehicleDependentTimeWindowTest {
         UpdateVehicleDependentPracticalTimeWindows updater = new UpdateVehicleDependentPracticalTimeWindows(stateManager, routingCosts, activityCosts);
         stateManager.addStateUpdater(updater);
         stateManager.informInsertionStarts(Arrays.asList(route), Collections.<Job>emptyList());
-        assertTrue(stateManager.hasActivityState(route.getActivities().get(0), vehicle, InternalStates.LATEST_OPERATION_START_TIME));
-        assertFalse(stateManager.hasActivityState(route.getActivities().get(0), vehicle2, InternalStates.LATEST_OPERATION_START_TIME));
+        Assertions.assertTrue(stateManager.hasActivityState(route.getActivities().get(0), vehicle,
+                InternalStates.LATEST_OPERATION_START_TIME));
+        Assertions.assertFalse(stateManager.hasActivityState(route.getActivities().get(0), vehicle2,
+                InternalStates.LATEST_OPERATION_START_TIME));
     }
 
     @Test
     @DisplayName("State Manager Should Have Memorized Correct Latest End Of Act 3")
     void stateManagerShouldHaveMemorizedCorrectLatestEndOfAct3() {
-        assertEquals(70., stateManager.getActivityState(route.getActivities().get(2), vehicle, InternalStates.LATEST_OPERATION_START_TIME, Double.class), 0.01);
+        Assertions.assertEquals(70., stateManager.getActivityState(route.getActivities().get(2), vehicle,
+                InternalStates.LATEST_OPERATION_START_TIME, Double.class), 0.01);
     }
 
     @Test
     @DisplayName("State Manager Should Have Memorized Correct Latest End Of Act 3 _ v 2")
     void stateManagerShouldHaveMemorizedCorrectLatestEndOfAct3_v2() {
-        assertEquals(70., stateManager.getActivityState(route.getActivities().get(2), vehicle, InternalStates.LATEST_OPERATION_START_TIME, Double.class), 0.01);
+        Assertions.assertEquals(70., stateManager.getActivityState(route.getActivities().get(2), vehicle,
+                InternalStates.LATEST_OPERATION_START_TIME, Double.class), 0.01);
     }
 
     @Test
     @DisplayName("State Manager Should Have Memorized Correct Latest End Of Act 3 With Vehicle 2")
     void stateManagerShouldHaveMemorizedCorrectLatestEndOfAct3WithVehicle2() {
-        assertEquals(30., stateManager.getActivityState(route.getActivities().get(2), vehicle2, InternalStates.LATEST_OPERATION_START_TIME, Double.class), 0.01);
+        Assertions.assertEquals(30., stateManager.getActivityState(route.getActivities().get(2), vehicle2,
+                InternalStates.LATEST_OPERATION_START_TIME, Double.class), 0.01);
     }
 
     @Test
     @DisplayName("State Manager Should Have Memorized Correct Latest End Of Act 3 With Vehicle 3")
     void stateManagerShouldHaveMemorizedCorrectLatestEndOfAct3WithVehicle3() {
-        assertEquals(90., stateManager.getActivityState(route.getActivities().get(2), vehicle3, InternalStates.LATEST_OPERATION_START_TIME, Double.class), 0.01);
+        Assertions.assertEquals(90., stateManager.getActivityState(route.getActivities().get(2), vehicle3,
+                InternalStates.LATEST_OPERATION_START_TIME, Double.class), 0.01);
     }
 
     @Test
     @DisplayName("State Manager Should Have Memorized Correct Latest End Of Act 2")
     void stateManagerShouldHaveMemorizedCorrectLatestEndOfAct2() {
-        assertEquals(60., stateManager.getActivityState(route.getActivities().get(1), vehicle, InternalStates.LATEST_OPERATION_START_TIME, Double.class), 0.01);
+        Assertions.assertEquals(60., stateManager.getActivityState(route.getActivities().get(1), vehicle,
+                InternalStates.LATEST_OPERATION_START_TIME, Double.class), 0.01);
     }
 
     @Test
     @DisplayName("State Manager Should Have Memorized Correct Latest End Of Act 2 _ v 2")
     void stateManagerShouldHaveMemorizedCorrectLatestEndOfAct2_v2() {
-        assertEquals(60., stateManager.getActivityState(route.getActivities().get(1), vehicle, InternalStates.LATEST_OPERATION_START_TIME, Double.class), 0.01);
+        Assertions.assertEquals(60., stateManager.getActivityState(route.getActivities().get(1), vehicle,
+                InternalStates.LATEST_OPERATION_START_TIME, Double.class), 0.01);
     }
 
     @Test
     @DisplayName("State Manager Should Have Memorized Correct Latest End Of Act 2 With Vehicle 2")
     void stateManagerShouldHaveMemorizedCorrectLatestEndOfAct2WithVehicle2() {
-        assertEquals(20., stateManager.getActivityState(route.getActivities().get(1), vehicle2, InternalStates.LATEST_OPERATION_START_TIME, Double.class), 0.01);
+        Assertions.assertEquals(20., stateManager.getActivityState(route.getActivities().get(1), vehicle2,
+                InternalStates.LATEST_OPERATION_START_TIME, Double.class), 0.01);
     }
 
     @Test
     @DisplayName("State Manager Should Have Memorized Correct Latest End Of Act 2 With Vehicle 3")
     void stateManagerShouldHaveMemorizedCorrectLatestEndOfAct2WithVehicle3() {
-        assertEquals(80., stateManager.getActivityState(route.getActivities().get(1), vehicle3, InternalStates.LATEST_OPERATION_START_TIME, Double.class), 0.01);
+        Assertions.assertEquals(80., stateManager.getActivityState(route.getActivities().get(1), vehicle3,
+                InternalStates.LATEST_OPERATION_START_TIME, Double.class), 0.01);
     }
 
     @Test
     @DisplayName("State Manager Should Have Memorized Correct Latest End Of Act 2 With Equivalent Of Vehicle 3")
     void stateManagerShouldHaveMemorizedCorrectLatestEndOfAct2WithEquivalentOfVehicle3() {
-        assertEquals(80., stateManager.getActivityState(route.getActivities().get(1), equivalentOf3, InternalStates.LATEST_OPERATION_START_TIME, Double.class), 0.01);
+        Assertions.assertEquals(80., stateManager.getActivityState(route.getActivities().get(1), equivalentOf3,
+                InternalStates.LATEST_OPERATION_START_TIME, Double.class), 0.01);
     }
 
     @Test
     @DisplayName("State Manager Should Have Memorized Correct Latest End Of Act 1 With Vehicle 2")
     void stateManagerShouldHaveMemorizedCorrectLatestEndOfAct1WithVehicle2() {
-        assertEquals(10., stateManager.getActivityState(route.getActivities().get(0), vehicle2, InternalStates.LATEST_OPERATION_START_TIME, Double.class), 0.01);
+        Assertions.assertEquals(10., stateManager.getActivityState(route.getActivities().get(0), vehicle2,
+                InternalStates.LATEST_OPERATION_START_TIME, Double.class), 0.01);
     }
 
     @Test
     @DisplayName("State Manager Should Have Memorized Correct Latest End Of Act 1 With Vehicle 3")
     void stateManagerShouldHaveMemorizedCorrectLatestEndOfAct1WithVehicle3() {
-        assertEquals(70., stateManager.getActivityState(route.getActivities().get(0), vehicle3, InternalStates.LATEST_OPERATION_START_TIME, Double.class), 0.01);
+        Assertions.assertEquals(70., stateManager.getActivityState(route.getActivities().get(0), vehicle3,
+                InternalStates.LATEST_OPERATION_START_TIME, Double.class), 0.01);
     }
 
     @Test
@@ -212,7 +225,8 @@ class UpdateVehicleDependentTimeWindowTest {
         });
         stateManager.addStateUpdater(updater);
         stateManager.informInsertionStarts(Arrays.asList(route), Collections.<Job>emptyList());
-        assertEquals(80., stateManager.getActivityState(route.getActivities().get(1), vehicle, InternalStates.LATEST_OPERATION_START_TIME, Double.class), 0.01);
+        Assertions.assertEquals(80., stateManager.getActivityState(route.getActivities().get(1), vehicle,
+                InternalStates.LATEST_OPERATION_START_TIME, Double.class), 0.01);
     }
 
     @Test
@@ -227,6 +241,6 @@ class UpdateVehicleDependentTimeWindowTest {
         stateManager.addStateUpdater(updater);
         stateManager.reCalculateStates(route);
         Double activityState = stateManager.getActivityState(route.getActivities().get(0), route.getVehicle(), InternalStates.LATEST_OPERATION_START_TIME, Double.class);
-        assertEquals(51d, activityState, 0.01);
+        Assertions.assertEquals(51d, activityState, 0.01);
     }
 }

--- a/jsprit-core/src/test/java/com/graphhopper/jsprit/core/algorithm/termination/IterationsWithoutImprovementTest.java
+++ b/jsprit-core/src/test/java/com/graphhopper/jsprit/core/algorithm/termination/IterationsWithoutImprovementTest.java
@@ -18,6 +18,8 @@
 package com.graphhopper.jsprit.core.algorithm.termination;
 
 import com.graphhopper.jsprit.core.algorithm.SearchStrategy;
+
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
@@ -42,7 +44,7 @@ class IterationsWithoutImprovementTest {
                 break;
             }
         }
-        assertEquals(100, terminatedAfter);
+        Assertions.assertEquals(100, terminatedAfter);
     }
 
     @Test
@@ -59,7 +61,7 @@ class IterationsWithoutImprovementTest {
                 break;
             }
         }
-        assertEquals(1, terminatedAfter);
+        Assertions.assertEquals(1, terminatedAfter);
     }
 
     @Test
@@ -78,6 +80,6 @@ class IterationsWithoutImprovementTest {
                 break;
             }
         }
-        assertEquals(150, terminatedAfter);
+        Assertions.assertEquals(150, terminatedAfter);
     }
 }

--- a/jsprit-core/src/test/java/com/graphhopper/jsprit/core/algorithm/termination/TimeTerminationTest.java
+++ b/jsprit-core/src/test/java/com/graphhopper/jsprit/core/algorithm/termination/TimeTerminationTest.java
@@ -24,6 +24,8 @@ import org.junit.jupiter.api.Test;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import org.junit.jupiter.api.Assertions;
+
 /**
  * Created by schroeder on 16.12.14.
  */
@@ -43,7 +45,7 @@ class TimeTerminationTest {
             }
         });
         tt.start(0);
-        assertFalse(tt.isPrematureBreak(null));
+        Assertions.assertFalse(tt.isPrematureBreak(null));
     }
 
     @Test
@@ -59,6 +61,6 @@ class TimeTerminationTest {
             }
         });
         tt.start(0);
-        assertTrue(tt.isPrematureBreak(null));
+        Assertions.assertTrue(tt.isPrematureBreak(null));
     }
 }

--- a/jsprit-core/src/test/java/com/graphhopper/jsprit/core/analysis/SolutionAnalyserTest.java
+++ b/jsprit-core/src/test/java/com/graphhopper/jsprit/core/analysis/SolutionAnalyserTest.java
@@ -35,6 +35,8 @@ import com.graphhopper.jsprit.core.problem.vehicle.VehicleTypeImpl;
 import com.graphhopper.jsprit.core.util.Coordinate;
 import com.graphhopper.jsprit.core.util.ManhattanCosts;
 import com.graphhopper.jsprit.core.util.TestUtils;
+
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -139,7 +141,7 @@ class SolutionAnalyserTest {
         VehicleRoute route1 = solution.getRoutes().iterator().next();
         // get route 1 activities
         List<TourActivity> activities = route1.getActivities();
-        assertEquals(activities.size(), 4);
+        Assertions.assertEquals(activities.size(), 4);
         // utility class to calculate manhattan distance
         @DisplayName("Manhattan Distance")
         class ManhattanDistance {
@@ -160,12 +162,12 @@ class SolutionAnalyserTest {
             // test last distance
             if (type == TransportCostsTestType.LAST_DISTANCE) {
                 double savedDist = analyser.getLastTransportDistanceAtActivity(activity, route1);
-                assertEquals(dist, savedDist, 1E-10);
+                Assertions.assertEquals(dist, savedDist, 1E-10);
             }
             // test last time
             if (type == TransportCostsTestType.LAST_TIME) {
                 double savedTime = analyser.getLastTransportTimeAtActivity(activity, route1);
-                assertEquals(dist, savedTime, 1E-10);
+                Assertions.assertEquals(dist, savedTime, 1E-10);
             }
             // test last cost
             if (type == TransportCostsTestType.LAST_COST) {
@@ -178,13 +180,13 @@ class SolutionAnalyserTest {
                 }
                 double cost = dist * perDistanceUnit;
                 double savedCost = analyser.getLastTransportCostAtActivity(activity, route1);
-                assertEquals(cost, savedCost, 1E-10);
+                Assertions.assertEquals(cost, savedCost, 1E-10);
             }
             // test total transport time at activity
             if (type == TransportCostsTestType.TRANSPORT_TIME_AT_ACTIVITY) {
                 totalTime += dist;
                 double savedTransportTime = analyser.getTransportTimeAtActivity(activity, route1);
-                assertEquals(totalTime, savedTransportTime, 1E-10);
+                Assertions.assertEquals(totalTime, savedTransportTime, 1E-10);
             }
         }
     }
@@ -193,7 +195,7 @@ class SolutionAnalyserTest {
     @DisplayName("Construction Should Work")
     void constructionShouldWork() {
         new SolutionAnalyser(vrp, solution, vrp.getTransportCosts());
-        assertTrue(true);
+        Assertions.assertTrue(true);
     }
 
     @Test
@@ -201,7 +203,7 @@ class SolutionAnalyserTest {
     void loadAtBeginningOfRoute1ShouldWork() {
         SolutionAnalyser analyser = new SolutionAnalyser(vrp, solution, vrp.getTransportCosts());
         VehicleRoute route = solution.getRoutes().iterator().next();
-        assertEquals(0, analyser.getLoadAtBeginning(route).get(0));
+        Assertions.assertEquals(0, analyser.getLoadAtBeginning(route).get(0));
     }
 
     @Test
@@ -211,7 +213,7 @@ class SolutionAnalyserTest {
         Iterator<VehicleRoute> iterator = solution.getRoutes().iterator();
         iterator.next();
         VehicleRoute route = iterator.next();
-        assertEquals(0, analyser.getLoadAtBeginning(route).get(0));
+        Assertions.assertEquals(0, analyser.getLoadAtBeginning(route).get(0));
     }
 
     @Test
@@ -219,7 +221,7 @@ class SolutionAnalyserTest {
     void loadAtEnd_OfRoute1ShouldWork() {
         SolutionAnalyser analyser = new SolutionAnalyser(vrp, solution, vrp.getTransportCosts());
         VehicleRoute route = solution.getRoutes().iterator().next();
-        assertEquals(5, analyser.getLoadAtEnd(route).get(0));
+        Assertions.assertEquals(5, analyser.getLoadAtEnd(route).get(0));
     }
 
     @Test
@@ -229,7 +231,7 @@ class SolutionAnalyserTest {
         Iterator<VehicleRoute> iterator = solution.getRoutes().iterator();
         iterator.next();
         VehicleRoute route = iterator.next();
-        assertEquals(5, analyser.getLoadAtEnd(route).get(0));
+        Assertions.assertEquals(5, analyser.getLoadAtEnd(route).get(0));
     }
 
     @Test
@@ -237,7 +239,7 @@ class SolutionAnalyserTest {
     void loadAfterActivity_ofStartActOfRoute1ShouldWork() {
         SolutionAnalyser analyser = new SolutionAnalyser(vrp, solution, vrp.getTransportCosts());
         VehicleRoute route = solution.getRoutes().iterator().next();
-        assertEquals(0, analyser.getLoadRightAfterActivity(route.getStart(), route).get(0));
+        Assertions.assertEquals(0, analyser.getLoadRightAfterActivity(route.getStart(), route).get(0));
     }
 
     @Test
@@ -245,7 +247,7 @@ class SolutionAnalyserTest {
     void loadAfterActivity_ofAct1ofRoute1ShouldWork() {
         SolutionAnalyser analyser = new SolutionAnalyser(vrp, solution, vrp.getTransportCosts());
         VehicleRoute route = solution.getRoutes().iterator().next();
-        assertEquals(2, analyser.getLoadRightAfterActivity(route.getActivities().get(0), route).get(0));
+        Assertions.assertEquals(2, analyser.getLoadRightAfterActivity(route.getActivities().get(0), route).get(0));
     }
 
     @Test
@@ -253,7 +255,7 @@ class SolutionAnalyserTest {
     void loadAfterActivity_ofAct2ofRoute1ShouldWork() {
         SolutionAnalyser analyser = new SolutionAnalyser(vrp, solution, vrp.getTransportCosts());
         VehicleRoute route = solution.getRoutes().iterator().next();
-        assertEquals(12, analyser.getLoadRightAfterActivity(route.getActivities().get(1), route).get(0));
+        Assertions.assertEquals(12, analyser.getLoadRightAfterActivity(route.getActivities().get(1), route).get(0));
     }
 
     @Test
@@ -261,7 +263,7 @@ class SolutionAnalyserTest {
     void loadAfterActivity_ofAct3ofRoute1ShouldWork() {
         SolutionAnalyser analyser = new SolutionAnalyser(vrp, solution, vrp.getTransportCosts());
         VehicleRoute route = solution.getRoutes().iterator().next();
-        assertEquals(2, analyser.getLoadRightAfterActivity(route.getActivities().get(2), route).get(0));
+        Assertions.assertEquals(2, analyser.getLoadRightAfterActivity(route.getActivities().get(2), route).get(0));
     }
 
     @Test
@@ -269,7 +271,7 @@ class SolutionAnalyserTest {
     void loadAfterActivity_ofAct4ofRoute1ShouldWork() {
         SolutionAnalyser analyser = new SolutionAnalyser(vrp, solution, vrp.getTransportCosts());
         VehicleRoute route = solution.getRoutes().iterator().next();
-        assertEquals(5, analyser.getLoadRightAfterActivity(route.getActivities().get(3), route).get(0));
+        Assertions.assertEquals(5, analyser.getLoadRightAfterActivity(route.getActivities().get(3), route).get(0));
     }
 
     @Test
@@ -277,7 +279,7 @@ class SolutionAnalyserTest {
     void loadAfterActivity_ofEndActOfRoute1ShouldWork() {
         SolutionAnalyser analyser = new SolutionAnalyser(vrp, solution, vrp.getTransportCosts());
         VehicleRoute route = solution.getRoutes().iterator().next();
-        assertEquals(5, analyser.getLoadRightAfterActivity(route.getEnd(), route).get(0));
+        Assertions.assertEquals(5, analyser.getLoadRightAfterActivity(route.getEnd(), route).get(0));
     }
 
     @Test
@@ -285,7 +287,7 @@ class SolutionAnalyserTest {
     void loadBeforeActivity_ofStartActOfRoute1ShouldWork() {
         SolutionAnalyser analyser = new SolutionAnalyser(vrp, solution, vrp.getTransportCosts());
         VehicleRoute route = solution.getRoutes().iterator().next();
-        assertEquals(0, analyser.getLoadJustBeforeActivity(route.getStart(), route).get(0));
+        Assertions.assertEquals(0, analyser.getLoadJustBeforeActivity(route.getStart(), route).get(0));
     }
 
     @Test
@@ -293,7 +295,7 @@ class SolutionAnalyserTest {
     void loadBeforeActivity_ofAct1ofRoute1ShouldWork() {
         SolutionAnalyser analyser = new SolutionAnalyser(vrp, solution, vrp.getTransportCosts());
         VehicleRoute route = solution.getRoutes().iterator().next();
-        assertEquals(0, analyser.getLoadJustBeforeActivity(route.getActivities().get(0), route).get(0));
+        Assertions.assertEquals(0, analyser.getLoadJustBeforeActivity(route.getActivities().get(0), route).get(0));
     }
 
     @Test
@@ -301,7 +303,7 @@ class SolutionAnalyserTest {
     void loadBeforeActivity_ofAct2ofRoute1ShouldWork() {
         SolutionAnalyser analyser = new SolutionAnalyser(vrp, solution, vrp.getTransportCosts());
         VehicleRoute route = solution.getRoutes().iterator().next();
-        assertEquals(2, analyser.getLoadJustBeforeActivity(route.getActivities().get(1), route).get(0));
+        Assertions.assertEquals(2, analyser.getLoadJustBeforeActivity(route.getActivities().get(1), route).get(0));
     }
 
     @Test
@@ -309,7 +311,7 @@ class SolutionAnalyserTest {
     void loadBeforeActivity_ofAct3ofRoute1ShouldWork() {
         SolutionAnalyser analyser = new SolutionAnalyser(vrp, solution, vrp.getTransportCosts());
         VehicleRoute route = solution.getRoutes().iterator().next();
-        assertEquals(12, analyser.getLoadJustBeforeActivity(route.getActivities().get(2), route).get(0));
+        Assertions.assertEquals(12, analyser.getLoadJustBeforeActivity(route.getActivities().get(2), route).get(0));
     }
 
     @Test
@@ -317,7 +319,7 @@ class SolutionAnalyserTest {
     void loadBeforeActivity_ofAct4ofRoute1ShouldWork() {
         SolutionAnalyser analyser = new SolutionAnalyser(vrp, solution, vrp.getTransportCosts());
         VehicleRoute route = solution.getRoutes().iterator().next();
-        assertEquals(2, analyser.getLoadJustBeforeActivity(route.getActivities().get(3), route).get(0));
+        Assertions.assertEquals(2, analyser.getLoadJustBeforeActivity(route.getActivities().get(3), route).get(0));
     }
 
     @Test
@@ -325,7 +327,7 @@ class SolutionAnalyserTest {
     void loadBeforeActivity_ofEndActOfRoute1ShouldWork() {
         SolutionAnalyser analyser = new SolutionAnalyser(vrp, solution, vrp.getTransportCosts());
         VehicleRoute route = solution.getRoutes().iterator().next();
-        assertEquals(5, analyser.getLoadJustBeforeActivity(route.getEnd(), route).get(0));
+        Assertions.assertEquals(5, analyser.getLoadJustBeforeActivity(route.getEnd(), route).get(0));
     }
 
     @Test
@@ -333,7 +335,7 @@ class SolutionAnalyserTest {
     void maxLoad_OfRoute1ShouldWork() {
         SolutionAnalyser analyser = new SolutionAnalyser(vrp, solution, vrp.getTransportCosts());
         VehicleRoute route = solution.getRoutes().iterator().next();
-        assertEquals(12, analyser.getMaxLoad(route).get(0));
+        Assertions.assertEquals(12, analyser.getMaxLoad(route).get(0));
     }
 
     @Test
@@ -341,7 +343,7 @@ class SolutionAnalyserTest {
     void pickupCount_OfRoute1ShouldWork() {
         SolutionAnalyser analyser = new SolutionAnalyser(vrp, solution, vrp.getTransportCosts());
         VehicleRoute route = solution.getRoutes().iterator().next();
-        assertEquals(3, analyser.getNumberOfPickups(route), 0.01);
+        Assertions.assertEquals(3, analyser.getNumberOfPickups(route), 0.01);
     }
 
     @Test
@@ -349,7 +351,7 @@ class SolutionAnalyserTest {
     void pickupCountAtBeginning_OfRoute1ShouldWork() {
         SolutionAnalyser analyser = new SolutionAnalyser(vrp, solution, vrp.getTransportCosts());
         VehicleRoute route = solution.getRoutes().iterator().next();
-        assertEquals(0, analyser.getNumberOfPickupsAtBeginning(route), 0.01);
+        Assertions.assertEquals(0, analyser.getNumberOfPickupsAtBeginning(route), 0.01);
     }
 
     @Test
@@ -358,7 +360,7 @@ class SolutionAnalyserTest {
         buildAnotherScenarioWithOnlyOneVehicleAndWithoutAnyConstraintsBefore();
         SolutionAnalyser analyser = new SolutionAnalyser(vrp, solution, vrp.getTransportCosts());
         VehicleRoute route = solution.getRoutes().iterator().next();
-        assertEquals(4, analyser.getNumberOfPickups(route), 0.01);
+        Assertions.assertEquals(4, analyser.getNumberOfPickups(route), 0.01);
     }
 
     @Test
@@ -367,21 +369,21 @@ class SolutionAnalyserTest {
         buildAnotherScenarioWithOnlyOneVehicleAndWithoutAnyConstraintsBefore();
         SolutionAnalyser analyser = new SolutionAnalyser(vrp, solution, vrp.getTransportCosts());
         VehicleRoute route = solution.getRoutes().iterator().next();
-        assertEquals(2, analyser.getNumberOfPickupsAtBeginning(route), 0.01);
+        Assertions.assertEquals(2, analyser.getNumberOfPickupsAtBeginning(route), 0.01);
     }
 
     @Test
     @DisplayName("Pickup Count _ on Solution Should Work")
     void pickupCount_onSolutionShouldWork() {
         SolutionAnalyser analyser = new SolutionAnalyser(vrp, solution, vrp.getTransportCosts());
-        assertEquals(6, analyser.getNumberOfPickups(), 0.01);
+        Assertions.assertEquals(6, analyser.getNumberOfPickups(), 0.01);
     }
 
     @Test
     @DisplayName("Pickup Count At Beginning _ on Solution Should Work")
     void pickupCountAtBeginning_onSolutionShouldWork() {
         SolutionAnalyser analyser = new SolutionAnalyser(vrp, solution, vrp.getTransportCosts());
-        assertEquals(0, analyser.getNumberOfPickupsAtBeginning(), 0.01);
+        Assertions.assertEquals(0, analyser.getNumberOfPickupsAtBeginning(), 0.01);
     }
 
     @Test
@@ -389,7 +391,7 @@ class SolutionAnalyserTest {
     void pickupCount_onAnotherSolutionShouldWork() {
         buildAnotherScenarioWithOnlyOneVehicleAndWithoutAnyConstraintsBefore();
         SolutionAnalyser analyser = new SolutionAnalyser(vrp, solution, vrp.getTransportCosts());
-        assertEquals(4, analyser.getNumberOfPickups(), 0.01);
+        Assertions.assertEquals(4, analyser.getNumberOfPickups(), 0.01);
     }
 
     @Test
@@ -397,7 +399,7 @@ class SolutionAnalyserTest {
     void pickupCountAtBeginning_onAnotherSolutionShouldWork() {
         buildAnotherScenarioWithOnlyOneVehicleAndWithoutAnyConstraintsBefore();
         SolutionAnalyser analyser = new SolutionAnalyser(vrp, solution, vrp.getTransportCosts());
-        assertEquals(2, analyser.getNumberOfPickupsAtBeginning(), 0.01);
+        Assertions.assertEquals(2, analyser.getNumberOfPickupsAtBeginning(), 0.01);
     }
 
     @Test
@@ -405,7 +407,7 @@ class SolutionAnalyserTest {
     void pickupLoad_OfRoute1ShouldWork() {
         SolutionAnalyser analyser = new SolutionAnalyser(vrp, solution, vrp.getTransportCosts());
         VehicleRoute route = solution.getRoutes().iterator().next();
-        assertEquals(15, analyser.getLoadPickedUp(route).get(0), 0.01);
+        Assertions.assertEquals(15, analyser.getLoadPickedUp(route).get(0), 0.01);
     }
 
     @Test
@@ -413,7 +415,7 @@ class SolutionAnalyserTest {
     void pickupLoadAtBeginning_OfRoute1ShouldWork() {
         SolutionAnalyser analyser = new SolutionAnalyser(vrp, solution, vrp.getTransportCosts());
         VehicleRoute route = solution.getRoutes().iterator().next();
-        assertEquals(0, analyser.getLoadAtBeginning(route).get(0), 0.01);
+        Assertions.assertEquals(0, analyser.getLoadAtBeginning(route).get(0), 0.01);
     }
 
     @Test
@@ -422,7 +424,7 @@ class SolutionAnalyserTest {
         buildAnotherScenarioWithOnlyOneVehicleAndWithoutAnyConstraintsBefore();
         SolutionAnalyser analyser = new SolutionAnalyser(vrp, solution, vrp.getTransportCosts());
         VehicleRoute route = solution.getRoutes().iterator().next();
-        assertEquals(50, analyser.getLoadPickedUp(route).get(0), 0.01);
+        Assertions.assertEquals(50, analyser.getLoadPickedUp(route).get(0), 0.01);
     }
 
     @Test
@@ -431,21 +433,21 @@ class SolutionAnalyserTest {
         buildAnotherScenarioWithOnlyOneVehicleAndWithoutAnyConstraintsBefore();
         SolutionAnalyser analyser = new SolutionAnalyser(vrp, solution, vrp.getTransportCosts());
         VehicleRoute route = solution.getRoutes().iterator().next();
-        assertEquals(40, analyser.getLoadAtBeginning(route).get(0), 0.01);
+        Assertions.assertEquals(40, analyser.getLoadAtBeginning(route).get(0), 0.01);
     }
 
     @Test
     @DisplayName("Pickup Load _ on Solution Should Work")
     void pickupLoad_onSolutionShouldWork() {
         SolutionAnalyser analyser = new SolutionAnalyser(vrp, solution, vrp.getTransportCosts());
-        assertEquals(30, analyser.getLoadPickedUp().get(0), 0.01);
+        Assertions.assertEquals(30, analyser.getLoadPickedUp().get(0), 0.01);
     }
 
     @Test
     @DisplayName("Pickup Load At Beginning _ on Solution Should Work")
     void pickupLoadAtBeginning_onSolutionShouldWork() {
         SolutionAnalyser analyser = new SolutionAnalyser(vrp, solution, vrp.getTransportCosts());
-        assertEquals(0, analyser.getLoadAtBeginning().get(0), 0.01);
+        Assertions.assertEquals(0, analyser.getLoadAtBeginning().get(0), 0.01);
     }
 
     @Test
@@ -453,7 +455,7 @@ class SolutionAnalyserTest {
     void pickupLoad_onAnotherSolutionShouldWork() {
         buildAnotherScenarioWithOnlyOneVehicleAndWithoutAnyConstraintsBefore();
         SolutionAnalyser analyser = new SolutionAnalyser(vrp, solution, vrp.getTransportCosts());
-        assertEquals(50, analyser.getLoadPickedUp().get(0), 0.01);
+        Assertions.assertEquals(50, analyser.getLoadPickedUp().get(0), 0.01);
     }
 
     @Test
@@ -461,7 +463,7 @@ class SolutionAnalyserTest {
     void pickupLoadAtBeginning_onAnotherSolutionShouldWork() {
         buildAnotherScenarioWithOnlyOneVehicleAndWithoutAnyConstraintsBefore();
         SolutionAnalyser analyser = new SolutionAnalyser(vrp, solution, vrp.getTransportCosts());
-        assertEquals(40, analyser.getLoadAtBeginning().get(0), 0.01);
+        Assertions.assertEquals(40, analyser.getLoadAtBeginning().get(0), 0.01);
     }
 
     @Test
@@ -469,7 +471,7 @@ class SolutionAnalyserTest {
     void deliveryCount_OfRoute1ShouldWork() {
         SolutionAnalyser analyser = new SolutionAnalyser(vrp, solution, vrp.getTransportCosts());
         VehicleRoute route = solution.getRoutes().iterator().next();
-        assertEquals(1, analyser.getNumberOfDeliveries(route), 0.01);
+        Assertions.assertEquals(1, analyser.getNumberOfDeliveries(route), 0.01);
     }
 
     @Test
@@ -477,7 +479,7 @@ class SolutionAnalyserTest {
     void deliveryCountAtEnd_OfRoute1ShouldWork() {
         SolutionAnalyser analyser = new SolutionAnalyser(vrp, solution, vrp.getTransportCosts());
         VehicleRoute route = solution.getRoutes().iterator().next();
-        assertEquals(2, analyser.getNumberOfDeliveriesAtEnd(route), 0.01);
+        Assertions.assertEquals(2, analyser.getNumberOfDeliveriesAtEnd(route), 0.01);
     }
 
     @Test
@@ -486,7 +488,7 @@ class SolutionAnalyserTest {
         buildAnotherScenarioWithOnlyOneVehicleAndWithoutAnyConstraintsBefore();
         SolutionAnalyser analyser = new SolutionAnalyser(vrp, solution, vrp.getTransportCosts());
         VehicleRoute route = solution.getRoutes().iterator().next();
-        assertEquals(4, analyser.getNumberOfDeliveries(route), 0.01);
+        Assertions.assertEquals(4, analyser.getNumberOfDeliveries(route), 0.01);
     }
 
     @Test
@@ -495,21 +497,21 @@ class SolutionAnalyserTest {
         buildAnotherScenarioWithOnlyOneVehicleAndWithoutAnyConstraintsBefore();
         SolutionAnalyser analyser = new SolutionAnalyser(vrp, solution, vrp.getTransportCosts());
         VehicleRoute route = solution.getRoutes().iterator().next();
-        assertEquals(2, analyser.getNumberOfDeliveriesAtEnd(route), 0.01);
+        Assertions.assertEquals(2, analyser.getNumberOfDeliveriesAtEnd(route), 0.01);
     }
 
     @Test
     @DisplayName("Delivery Count _ on Solution Should Work")
     void deliveryCount_onSolutionShouldWork() {
         SolutionAnalyser analyser = new SolutionAnalyser(vrp, solution, vrp.getTransportCosts());
-        assertEquals(2, analyser.getNumberOfDeliveries(), 0.01);
+        Assertions.assertEquals(2, analyser.getNumberOfDeliveries(), 0.01);
     }
 
     @Test
     @DisplayName("Delivery Count At End _ on Solution Should Work")
     void deliveryCountAtEnd_onSolutionShouldWork() {
         SolutionAnalyser analyser = new SolutionAnalyser(vrp, solution, vrp.getTransportCosts());
-        assertEquals(4, analyser.getNumberOfDeliveriesAtEnd(), 0.01);
+        Assertions.assertEquals(4, analyser.getNumberOfDeliveriesAtEnd(), 0.01);
     }
 
     @Test
@@ -517,7 +519,7 @@ class SolutionAnalyserTest {
     void deliveryCount_onAnotherSolutionShouldWork() {
         buildAnotherScenarioWithOnlyOneVehicleAndWithoutAnyConstraintsBefore();
         SolutionAnalyser analyser = new SolutionAnalyser(vrp, solution, vrp.getTransportCosts());
-        assertEquals(4, analyser.getNumberOfDeliveries(), 0.01);
+        Assertions.assertEquals(4, analyser.getNumberOfDeliveries(), 0.01);
     }
 
     @Test
@@ -525,7 +527,7 @@ class SolutionAnalyserTest {
     void deliveryCountAtEnd_onAnotherSolutionShouldWork() {
         buildAnotherScenarioWithOnlyOneVehicleAndWithoutAnyConstraintsBefore();
         SolutionAnalyser analyser = new SolutionAnalyser(vrp, solution, vrp.getTransportCosts());
-        assertEquals(2, analyser.getNumberOfDeliveriesAtEnd(), 0.01);
+        Assertions.assertEquals(2, analyser.getNumberOfDeliveriesAtEnd(), 0.01);
     }
 
     @Test
@@ -533,7 +535,7 @@ class SolutionAnalyserTest {
     void deliveryLoad_OfRoute1ShouldWork() {
         SolutionAnalyser analyser = new SolutionAnalyser(vrp, solution, vrp.getTransportCosts());
         VehicleRoute route = solution.getRoutes().iterator().next();
-        assertEquals(10, analyser.getLoadDelivered(route).get(0), 0.01);
+        Assertions.assertEquals(10, analyser.getLoadDelivered(route).get(0), 0.01);
     }
 
     @Test
@@ -541,7 +543,7 @@ class SolutionAnalyserTest {
     void deliveryLoadAtEnd_OfRoute1ShouldWork() {
         SolutionAnalyser analyser = new SolutionAnalyser(vrp, solution, vrp.getTransportCosts());
         VehicleRoute route = solution.getRoutes().iterator().next();
-        assertEquals(5, analyser.getLoadAtEnd(route).get(0), 0.01);
+        Assertions.assertEquals(5, analyser.getLoadAtEnd(route).get(0), 0.01);
     }
 
     @Test
@@ -550,7 +552,7 @@ class SolutionAnalyserTest {
         buildAnotherScenarioWithOnlyOneVehicleAndWithoutAnyConstraintsBefore();
         SolutionAnalyser analyser = new SolutionAnalyser(vrp, solution, vrp.getTransportCosts());
         VehicleRoute route = solution.getRoutes().iterator().next();
-        assertEquals(70, analyser.getLoadDelivered(route).get(0), 0.01);
+        Assertions.assertEquals(70, analyser.getLoadDelivered(route).get(0), 0.01);
     }
 
     @Test
@@ -559,21 +561,21 @@ class SolutionAnalyserTest {
         buildAnotherScenarioWithOnlyOneVehicleAndWithoutAnyConstraintsBefore();
         SolutionAnalyser analyser = new SolutionAnalyser(vrp, solution, vrp.getTransportCosts());
         VehicleRoute route = solution.getRoutes().iterator().next();
-        assertEquals(20, analyser.getLoadAtEnd(route).get(0), 0.01);
+        Assertions.assertEquals(20, analyser.getLoadAtEnd(route).get(0), 0.01);
     }
 
     @Test
     @DisplayName("Delivery Load _ on Solution Should Work")
     void deliveryLoad_onSolutionShouldWork() {
         SolutionAnalyser analyser = new SolutionAnalyser(vrp, solution, vrp.getTransportCosts());
-        assertEquals(20, analyser.getLoadDelivered().get(0), 0.01);
+        Assertions.assertEquals(20, analyser.getLoadDelivered().get(0), 0.01);
     }
 
     @Test
     @DisplayName("Delivery Load At End _ on Solution Should Work")
     void deliveryLoadAtEnd_onSolutionShouldWork() {
         SolutionAnalyser analyser = new SolutionAnalyser(vrp, solution, vrp.getTransportCosts());
-        assertEquals(10, analyser.getLoadAtEnd().get(0), 0.01);
+        Assertions.assertEquals(10, analyser.getLoadAtEnd().get(0), 0.01);
     }
 
     @Test
@@ -581,7 +583,7 @@ class SolutionAnalyserTest {
     void deliveryLoad_onAnotherSolutionShouldWork() {
         buildAnotherScenarioWithOnlyOneVehicleAndWithoutAnyConstraintsBefore();
         SolutionAnalyser analyser = new SolutionAnalyser(vrp, solution, vrp.getTransportCosts());
-        assertEquals(70, analyser.getLoadDelivered().get(0), 0.01);
+        Assertions.assertEquals(70, analyser.getLoadDelivered().get(0), 0.01);
     }
 
     @Test
@@ -589,7 +591,7 @@ class SolutionAnalyserTest {
     void deliveryLoadAtEnd_onAnotherSolutionShouldWork() {
         buildAnotherScenarioWithOnlyOneVehicleAndWithoutAnyConstraintsBefore();
         SolutionAnalyser analyser = new SolutionAnalyser(vrp, solution, vrp.getTransportCosts());
-        assertEquals(20, analyser.getLoadAtEnd().get(0), 0.01);
+        Assertions.assertEquals(20, analyser.getLoadAtEnd().get(0), 0.01);
     }
 
     @Test
@@ -597,7 +599,7 @@ class SolutionAnalyserTest {
     void operationTime_OfRoute1ShouldWork() {
         SolutionAnalyser analyser = new SolutionAnalyser(vrp, solution, vrp.getTransportCosts());
         VehicleRoute route = solution.getRoutes().iterator().next();
-        assertEquals(46. + 40., analyser.getOperationTime(route), 0.01);
+        Assertions.assertEquals(46. + 40., analyser.getOperationTime(route), 0.01);
     }
 
     @Test
@@ -609,8 +611,8 @@ class SolutionAnalyserTest {
         VehicleRoutingProblem vrp = VehicleRoutingProblem.Builder.newInstance().addVehicle(vehicle).addJob(service).setRoutingCost(new ManhattanCosts()).build();
         VehicleRoute route = VehicleRoute.Builder.newInstance(vehicle).setJobActivityFactory(vrp.getJobActivityFactory()).addService(service).build();
         SolutionAnalyser analyser = new SolutionAnalyser(vrp, new VehicleRoutingProblemSolution(Collections.singletonList(route), 300), vrp.getTransportCosts());
-        assertEquals(30, analyser.getOperationTime(), 0.01);
-        assertEquals(30, analyser.getOperationTime(route), 0.01);
+        Assertions.assertEquals(30, analyser.getOperationTime(), 0.01);
+        Assertions.assertEquals(30, analyser.getOperationTime(route), 0.01);
     }
 
     @Test
@@ -618,7 +620,7 @@ class SolutionAnalyserTest {
     void waitingTime_OfRoute1ShouldWork() {
         SolutionAnalyser analyser = new SolutionAnalyser(vrp, solution, vrp.getTransportCosts());
         VehicleRoute route = solution.getRoutes().iterator().next();
-        assertEquals(4., analyser.getWaitingTime(route), 0.01);
+        Assertions.assertEquals(4., analyser.getWaitingTime(route), 0.01);
     }
 
     @Test
@@ -626,7 +628,7 @@ class SolutionAnalyserTest {
     void transportTime_OfRoute1ShouldWork() {
         SolutionAnalyser analyser = new SolutionAnalyser(vrp, solution, vrp.getTransportCosts());
         VehicleRoute route = solution.getRoutes().iterator().next();
-        assertEquals(42., analyser.getTransportTime(route), 0.01);
+        Assertions.assertEquals(42., analyser.getTransportTime(route), 0.01);
     }
 
     @Test
@@ -634,7 +636,7 @@ class SolutionAnalyserTest {
     void serviceTime_OfRoute1ShouldWork() {
         SolutionAnalyser analyser = new SolutionAnalyser(vrp, solution, vrp.getTransportCosts());
         VehicleRoute route = solution.getRoutes().iterator().next();
-        assertEquals(40., analyser.getServiceTime(route), 0.01);
+        Assertions.assertEquals(40., analyser.getServiceTime(route), 0.01);
     }
 
     @Test
@@ -642,7 +644,7 @@ class SolutionAnalyserTest {
     void distance_OfRoute1ShouldWork() {
         SolutionAnalyser analyser = new SolutionAnalyser(vrp, solution, vrp.getTransportCosts());
         VehicleRoute route = solution.getRoutes().iterator().next();
-        assertEquals(42., analyser.getDistance(route), 0.01);
+        Assertions.assertEquals(42., analyser.getDistance(route), 0.01);
     }
 
     @Test
@@ -650,7 +652,7 @@ class SolutionAnalyserTest {
     void waitingTime_atStartActOfRoute1ShouldWork() {
         SolutionAnalyser analyser = new SolutionAnalyser(vrp, solution, vrp.getTransportCosts());
         VehicleRoute route = solution.getRoutes().iterator().next();
-        assertEquals(0, analyser.getWaitingTimeAtActivity(route.getStart(), route), 0.01);
+        Assertions.assertEquals(0, analyser.getWaitingTimeAtActivity(route.getStart(), route), 0.01);
     }
 
     @Test
@@ -658,7 +660,7 @@ class SolutionAnalyserTest {
     void waitingTime_ofAct1ofRoute1ShouldWork() {
         SolutionAnalyser analyser = new SolutionAnalyser(vrp, solution, vrp.getTransportCosts());
         VehicleRoute route = solution.getRoutes().iterator().next();
-        assertEquals(4., analyser.getWaitingTimeAtActivity(route.getActivities().get(0), route), 0.01);
+        Assertions.assertEquals(4., analyser.getWaitingTimeAtActivity(route.getActivities().get(0), route), 0.01);
     }
 
     @Test
@@ -666,7 +668,7 @@ class SolutionAnalyserTest {
     void waitingTime_ofAct2ofRoute1ShouldWork() {
         SolutionAnalyser analyser = new SolutionAnalyser(vrp, solution, vrp.getTransportCosts());
         VehicleRoute route = solution.getRoutes().iterator().next();
-        assertEquals(0., analyser.getWaitingTimeAtActivity(route.getActivities().get(1), route), 0.01);
+        Assertions.assertEquals(0., analyser.getWaitingTimeAtActivity(route.getActivities().get(1), route), 0.01);
     }
 
     @Test
@@ -674,7 +676,7 @@ class SolutionAnalyserTest {
     void waitingTime_ofAct3ofRoute1ShouldWork() {
         SolutionAnalyser analyser = new SolutionAnalyser(vrp, solution, vrp.getTransportCosts());
         VehicleRoute route = solution.getRoutes().iterator().next();
-        assertEquals(0., analyser.getWaitingTimeAtActivity(route.getActivities().get(2), route), 0.01);
+        Assertions.assertEquals(0., analyser.getWaitingTimeAtActivity(route.getActivities().get(2), route), 0.01);
     }
 
     @Test
@@ -682,7 +684,7 @@ class SolutionAnalyserTest {
     void waitingTime_ofAct4ofRoute1ShouldWork() {
         SolutionAnalyser analyser = new SolutionAnalyser(vrp, solution, vrp.getTransportCosts());
         VehicleRoute route = solution.getRoutes().iterator().next();
-        assertEquals(0., analyser.getWaitingTimeAtActivity(route.getActivities().get(3), route), 0.01);
+        Assertions.assertEquals(0., analyser.getWaitingTimeAtActivity(route.getActivities().get(3), route), 0.01);
     }
 
     @Test
@@ -690,7 +692,7 @@ class SolutionAnalyserTest {
     void waitingTime_ofEndActOfRoute1ShouldWork() {
         SolutionAnalyser analyser = new SolutionAnalyser(vrp, solution, vrp.getTransportCosts());
         VehicleRoute route = solution.getRoutes().iterator().next();
-        assertEquals(0., analyser.getWaitingTimeAtActivity(route.getEnd(), route), 0.01);
+        Assertions.assertEquals(0., analyser.getWaitingTimeAtActivity(route.getEnd(), route), 0.01);
     }
 
     @Test
@@ -698,7 +700,7 @@ class SolutionAnalyserTest {
     void distance_atStartActOfRoute1ShouldWork() {
         SolutionAnalyser analyser = new SolutionAnalyser(vrp, solution, vrp.getTransportCosts());
         VehicleRoute route = solution.getRoutes().iterator().next();
-        assertEquals(0, analyser.getDistanceAtActivity(route.getStart(), route), 0.01);
+        Assertions.assertEquals(0, analyser.getDistanceAtActivity(route.getStart(), route), 0.01);
     }
 
     @Test
@@ -706,7 +708,7 @@ class SolutionAnalyserTest {
     void distance_ofAct1ofRoute1ShouldWork() {
         SolutionAnalyser analyser = new SolutionAnalyser(vrp, solution, vrp.getTransportCosts());
         VehicleRoute route = solution.getRoutes().iterator().next();
-        assertEquals(6., analyser.getDistanceAtActivity(route.getActivities().get(0), route), 0.01);
+        Assertions.assertEquals(6., analyser.getDistanceAtActivity(route.getActivities().get(0), route), 0.01);
     }
 
     @Test
@@ -714,7 +716,7 @@ class SolutionAnalyserTest {
     void distance_ofAct2ofRoute1ShouldWork() {
         SolutionAnalyser analyser = new SolutionAnalyser(vrp, solution, vrp.getTransportCosts());
         VehicleRoute route = solution.getRoutes().iterator().next();
-        assertEquals(12., analyser.getDistanceAtActivity(route.getActivities().get(1), route), 0.01);
+        Assertions.assertEquals(12., analyser.getDistanceAtActivity(route.getActivities().get(1), route), 0.01);
     }
 
     @Test
@@ -722,7 +724,7 @@ class SolutionAnalyserTest {
     void distance_ofAct3ofRoute1ShouldWork() {
         SolutionAnalyser analyser = new SolutionAnalyser(vrp, solution, vrp.getTransportCosts());
         VehicleRoute route = solution.getRoutes().iterator().next();
-        assertEquals(16., analyser.getDistanceAtActivity(route.getActivities().get(2), route), 0.01);
+        Assertions.assertEquals(16., analyser.getDistanceAtActivity(route.getActivities().get(2), route), 0.01);
     }
 
     @Test
@@ -730,7 +732,7 @@ class SolutionAnalyserTest {
     void distance_ofAct4ofRoute1ShouldWork() {
         SolutionAnalyser analyser = new SolutionAnalyser(vrp, solution, vrp.getTransportCosts());
         VehicleRoute route = solution.getRoutes().iterator().next();
-        assertEquals(27., analyser.getDistanceAtActivity(route.getActivities().get(3), route), 0.01);
+        Assertions.assertEquals(27., analyser.getDistanceAtActivity(route.getActivities().get(3), route), 0.01);
     }
 
     @Test
@@ -738,7 +740,7 @@ class SolutionAnalyserTest {
     void distance_ofEndActOfRoute1ShouldWork() {
         SolutionAnalyser analyser = new SolutionAnalyser(vrp, solution, vrp.getTransportCosts());
         VehicleRoute route = solution.getRoutes().iterator().next();
-        assertEquals(42., analyser.getDistanceAtActivity(route.getEnd(), route), 0.01);
+        Assertions.assertEquals(42., analyser.getDistanceAtActivity(route.getEnd(), route), 0.01);
     }
 
     @Test
@@ -746,7 +748,7 @@ class SolutionAnalyserTest {
     void lateArrivalTimes_atStartActOfRoute1ShouldWork() {
         SolutionAnalyser analyser = new SolutionAnalyser(vrp, solution, vrp.getTransportCosts());
         VehicleRoute route = solution.getRoutes().iterator().next();
-        assertEquals(0, analyser.getTimeWindowViolationAtActivity(route.getStart(), route), 0.01);
+        Assertions.assertEquals(0, analyser.getTimeWindowViolationAtActivity(route.getStart(), route), 0.01);
     }
 
     @Test
@@ -754,7 +756,8 @@ class SolutionAnalyserTest {
     void lateArrivalTimes_ofAct1ofRoute1ShouldWork() {
         SolutionAnalyser analyser = new SolutionAnalyser(vrp, solution, vrp.getTransportCosts());
         VehicleRoute route = solution.getRoutes().iterator().next();
-        assertEquals(0., analyser.getTimeWindowViolationAtActivity(route.getActivities().get(0), route), 0.01);
+        Assertions.assertEquals(0., analyser.getTimeWindowViolationAtActivity(route.getActivities().get(0), route),
+                0.01);
     }
 
     @Test
@@ -762,7 +765,8 @@ class SolutionAnalyserTest {
     void lateArrivalTimes_ofAct2ofRoute1ShouldWork() {
         SolutionAnalyser analyser = new SolutionAnalyser(vrp, solution, vrp.getTransportCosts());
         VehicleRoute route = solution.getRoutes().iterator().next();
-        assertEquals(0., analyser.getTimeWindowViolationAtActivity(route.getActivities().get(1), route), 0.01);
+        Assertions.assertEquals(0., analyser.getTimeWindowViolationAtActivity(route.getActivities().get(1), route),
+                0.01);
     }
 
     @Test
@@ -770,7 +774,8 @@ class SolutionAnalyserTest {
     void lateArrivalTimes_ofAct3ofRoute1ShouldWork() {
         SolutionAnalyser analyser = new SolutionAnalyser(vrp, solution, vrp.getTransportCosts());
         VehicleRoute route = solution.getRoutes().iterator().next();
-        assertEquals(0., analyser.getTimeWindowViolationAtActivity(route.getActivities().get(2), route), 0.01);
+        Assertions.assertEquals(0., analyser.getTimeWindowViolationAtActivity(route.getActivities().get(2), route),
+                0.01);
     }
 
     @Test
@@ -778,7 +783,8 @@ class SolutionAnalyserTest {
     void lateArrivalTimes_ofAct4ofRoute1ShouldWork() {
         SolutionAnalyser analyser = new SolutionAnalyser(vrp, solution, vrp.getTransportCosts());
         VehicleRoute route = solution.getRoutes().iterator().next();
-        assertEquals(0., analyser.getTimeWindowViolationAtActivity(route.getActivities().get(3), route), 0.01);
+        Assertions.assertEquals(0., analyser.getTimeWindowViolationAtActivity(route.getActivities().get(3), route),
+                0.01);
     }
 
     @Test
@@ -786,7 +792,7 @@ class SolutionAnalyserTest {
     void lateArrivalTimes_ofEndActOfRoute1ShouldWork() {
         SolutionAnalyser analyser = new SolutionAnalyser(vrp, solution, vrp.getTransportCosts());
         VehicleRoute route = solution.getRoutes().iterator().next();
-        assertEquals(0., analyser.getTimeWindowViolationAtActivity(route.getEnd(), route), 0.01);
+        Assertions.assertEquals(0., analyser.getTimeWindowViolationAtActivity(route.getEnd(), route), 0.01);
     }
 
     @Test
@@ -794,7 +800,7 @@ class SolutionAnalyserTest {
     void lateArrTimes_OfRoute1ShouldWork() {
         SolutionAnalyser analyser = new SolutionAnalyser(vrp, solution, vrp.getTransportCosts());
         VehicleRoute route = solution.getRoutes().iterator().next();
-        assertEquals(0., analyser.getTimeWindowViolation(route), 0.01);
+        Assertions.assertEquals(0., analyser.getTimeWindowViolation(route), 0.01);
     }
 
     @Test
@@ -802,7 +808,7 @@ class SolutionAnalyserTest {
     void variableTransportCosts_OfRoute1ShouldWork() {
         SolutionAnalyser analyser = new SolutionAnalyser(vrp, solution, vrp.getTransportCosts());
         VehicleRoute route = solution.getRoutes().iterator().next();
-        assertEquals(84., analyser.getVariableTransportCosts(route), 0.01);
+        Assertions.assertEquals(84., analyser.getVariableTransportCosts(route), 0.01);
     }
 
     @Test
@@ -810,7 +816,7 @@ class SolutionAnalyserTest {
     void fixedCosts_OfRoute1ShouldWork() {
         SolutionAnalyser analyser = new SolutionAnalyser(vrp, solution, vrp.getTransportCosts());
         VehicleRoute route = solution.getRoutes().iterator().next();
-        assertEquals(100., analyser.getFixedCosts(route), 0.01);
+        Assertions.assertEquals(100., analyser.getFixedCosts(route), 0.01);
     }
 
     @Test
@@ -818,7 +824,7 @@ class SolutionAnalyserTest {
     void transportCosts_atStartActOfRoute1ShouldWork() {
         SolutionAnalyser analyser = new SolutionAnalyser(vrp, solution, vrp.getTransportCosts());
         VehicleRoute route = solution.getRoutes().iterator().next();
-        assertEquals(0, analyser.getVariableTransportCostsAtActivity(route.getStart(), route), 0.01);
+        Assertions.assertEquals(0, analyser.getVariableTransportCostsAtActivity(route.getStart(), route), 0.01);
     }
 
     @Test
@@ -826,7 +832,8 @@ class SolutionAnalyserTest {
     void transportCosts_ofAct1ofRoute1ShouldWork() {
         SolutionAnalyser analyser = new SolutionAnalyser(vrp, solution, vrp.getTransportCosts());
         VehicleRoute route = solution.getRoutes().iterator().next();
-        assertEquals(6. * 2., analyser.getVariableTransportCostsAtActivity(route.getActivities().get(0), route), 0.01);
+        Assertions.assertEquals(6. * 2.,
+                analyser.getVariableTransportCostsAtActivity(route.getActivities().get(0), route), 0.01);
     }
 
     @Test
@@ -834,7 +841,8 @@ class SolutionAnalyserTest {
     void transportCosts_ofAct2ofRoute1ShouldWork() {
         SolutionAnalyser analyser = new SolutionAnalyser(vrp, solution, vrp.getTransportCosts());
         VehicleRoute route = solution.getRoutes().iterator().next();
-        assertEquals(12. * 2., analyser.getVariableTransportCostsAtActivity(route.getActivities().get(1), route), 0.01);
+        Assertions.assertEquals(12. * 2.,
+                analyser.getVariableTransportCostsAtActivity(route.getActivities().get(1), route), 0.01);
     }
 
     @Test
@@ -842,7 +850,8 @@ class SolutionAnalyserTest {
     void transportCosts_ofAct3ofRoute1ShouldWork() {
         SolutionAnalyser analyser = new SolutionAnalyser(vrp, solution, vrp.getTransportCosts());
         VehicleRoute route = solution.getRoutes().iterator().next();
-        assertEquals(16. * 2., analyser.getVariableTransportCostsAtActivity(route.getActivities().get(2), route), 0.01);
+        Assertions.assertEquals(16. * 2.,
+                analyser.getVariableTransportCostsAtActivity(route.getActivities().get(2), route), 0.01);
     }
 
     @Test
@@ -850,7 +859,8 @@ class SolutionAnalyserTest {
     void transportCosts_ofAct4ofRoute1ShouldWork() {
         SolutionAnalyser analyser = new SolutionAnalyser(vrp, solution, vrp.getTransportCosts());
         VehicleRoute route = solution.getRoutes().iterator().next();
-        assertEquals(27. * 2., analyser.getVariableTransportCostsAtActivity(route.getActivities().get(3), route), 0.01);
+        Assertions.assertEquals(27. * 2.,
+                analyser.getVariableTransportCostsAtActivity(route.getActivities().get(3), route), 0.01);
     }
 
     @Test
@@ -858,7 +868,7 @@ class SolutionAnalyserTest {
     void transportCosts_ofEndActOfRoute1ShouldWork() {
         SolutionAnalyser analyser = new SolutionAnalyser(vrp, solution, vrp.getTransportCosts());
         VehicleRoute route = solution.getRoutes().iterator().next();
-        assertEquals(42. * 2., analyser.getVariableTransportCostsAtActivity(route.getEnd(), route), 0.01);
+        Assertions.assertEquals(42. * 2., analyser.getVariableTransportCostsAtActivity(route.getEnd(), route), 0.01);
     }
 
     @Test
@@ -868,7 +878,7 @@ class SolutionAnalyserTest {
         VehicleRoute route = solution.getRoutes().iterator().next();
         Capacity atBeginning = analyser.getCapacityViolationAtBeginning(route);
         for (int i = 0; i < atBeginning.getNuOfDimensions(); i++) {
-            assertEquals(0, atBeginning.get(i));
+            Assertions.assertEquals(0, atBeginning.get(i));
         }
     }
 
@@ -879,7 +889,7 @@ class SolutionAnalyserTest {
         VehicleRoute route = solution.getRoutes().iterator().next();
         Capacity atEnd = analyser.getCapacityViolationAtEnd(route);
         for (int i = 0; i < atEnd.getNuOfDimensions(); i++) {
-            assertEquals(0, atEnd.get(i));
+            Assertions.assertEquals(0, atEnd.get(i));
         }
     }
 
@@ -890,7 +900,7 @@ class SolutionAnalyserTest {
         SolutionAnalyser analyser = new SolutionAnalyser(vrp, solution, vrp.getTransportCosts());
         VehicleRoute route = solution.getRoutes().iterator().next();
         Capacity cap = analyser.getCapacityViolation(route);
-        assertEquals(50, cap.get(0));
+        Assertions.assertEquals(50, cap.get(0));
     }
 
     @Test
@@ -900,7 +910,7 @@ class SolutionAnalyserTest {
         SolutionAnalyser analyser = new SolutionAnalyser(vrp, solution, vrp.getTransportCosts());
         VehicleRoute route = solution.getRoutes().iterator().next();
         Capacity atEnd = analyser.getCapacityViolationAtEnd(route);
-        assertEquals(5, atEnd.get(0));
+        Assertions.assertEquals(5, atEnd.get(0));
     }
 
     @Test
@@ -911,7 +921,7 @@ class SolutionAnalyserTest {
         TourActivity act = route.getStart();
         Capacity cap = analyser.getCapacityViolationAfterActivity(act, route);
         for (int i = 0; i < cap.getNuOfDimensions(); i++) {
-            assertEquals(0, cap.get(i));
+            Assertions.assertEquals(0, cap.get(i));
         }
     }
 
@@ -922,7 +932,7 @@ class SolutionAnalyserTest {
         SolutionAnalyser analyser = new SolutionAnalyser(vrp, solution, vrp.getTransportCosts());
         VehicleRoute route = solution.getRoutes().iterator().next();
         Capacity cap = analyser.getCapacityViolationAtBeginning(route);
-        assertEquals(25, cap.get(0));
+        Assertions.assertEquals(25, cap.get(0));
     }
 
     @Test
@@ -932,7 +942,7 @@ class SolutionAnalyserTest {
         SolutionAnalyser analyser = new SolutionAnalyser(vrp, solution, vrp.getTransportCosts());
         VehicleRoute route = solution.getRoutes().iterator().next();
         Capacity cap = analyser.getCapacityViolationAfterActivity(route.getStart(), route);
-        assertEquals(25, cap.get(0));
+        Assertions.assertEquals(25, cap.get(0));
     }
 
     @Test
@@ -942,7 +952,7 @@ class SolutionAnalyserTest {
         SolutionAnalyser analyser = new SolutionAnalyser(vrp, solution, vrp.getTransportCosts());
         VehicleRoute route = solution.getRoutes().iterator().next();
         Capacity cap = analyser.getCapacityViolationAfterActivity(route.getActivities().get(0), route);
-        assertEquals(35, cap.get(0));
+        Assertions.assertEquals(35, cap.get(0));
     }
 
     @Test
@@ -952,7 +962,7 @@ class SolutionAnalyserTest {
         SolutionAnalyser analyser = new SolutionAnalyser(vrp, solution, vrp.getTransportCosts());
         VehicleRoute route = solution.getRoutes().iterator().next();
         Capacity cap = analyser.getCapacityViolationAfterActivity(route.getActivities().get(1), route);
-        assertEquals(50, cap.get(0));
+        Assertions.assertEquals(50, cap.get(0));
     }
 
     @Test
@@ -962,7 +972,7 @@ class SolutionAnalyserTest {
         SolutionAnalyser analyser = new SolutionAnalyser(vrp, solution, vrp.getTransportCosts());
         VehicleRoute route = solution.getRoutes().iterator().next();
         Capacity cap = analyser.getCapacityViolationAfterActivity(route.getActivities().get(2), route);
-        assertEquals(35, cap.get(0));
+        Assertions.assertEquals(35, cap.get(0));
     }
 
     @Test
@@ -972,7 +982,7 @@ class SolutionAnalyserTest {
         SolutionAnalyser analyser = new SolutionAnalyser(vrp, solution, vrp.getTransportCosts());
         VehicleRoute route = solution.getRoutes().iterator().next();
         Capacity cap = analyser.getCapacityViolationAfterActivity(route.getActivities().get(3), route);
-        assertEquals(15, cap.get(0));
+        Assertions.assertEquals(15, cap.get(0));
     }
 
     @Test
@@ -982,7 +992,7 @@ class SolutionAnalyserTest {
         SolutionAnalyser analyser = new SolutionAnalyser(vrp, solution, vrp.getTransportCosts());
         VehicleRoute route = solution.getRoutes().iterator().next();
         Capacity cap = analyser.getCapacityViolationAfterActivity(route.getActivities().get(4), route);
-        assertEquals(0, cap.get(0));
+        Assertions.assertEquals(0, cap.get(0));
     }
 
     @Test
@@ -992,7 +1002,7 @@ class SolutionAnalyserTest {
         SolutionAnalyser analyser = new SolutionAnalyser(vrp, solution, vrp.getTransportCosts());
         VehicleRoute route = solution.getRoutes().iterator().next();
         Capacity cap = analyser.getCapacityViolationAfterActivity(route.getActivities().get(5), route);
-        assertEquals(10, cap.get(0));
+        Assertions.assertEquals(10, cap.get(0));
     }
 
     @Test
@@ -1002,7 +1012,7 @@ class SolutionAnalyserTest {
         SolutionAnalyser analyser = new SolutionAnalyser(vrp, solution, vrp.getTransportCosts());
         VehicleRoute route = solution.getRoutes().iterator().next();
         Capacity cap = analyser.getCapacityViolationAfterActivity(route.getActivities().get(6), route);
-        assertEquals(0, cap.get(0));
+        Assertions.assertEquals(0, cap.get(0));
     }
 
     @Test
@@ -1012,7 +1022,7 @@ class SolutionAnalyserTest {
         SolutionAnalyser analyser = new SolutionAnalyser(vrp, solution, vrp.getTransportCosts());
         VehicleRoute route = solution.getRoutes().iterator().next();
         Capacity cap = analyser.getCapacityViolationAfterActivity(route.getActivities().get(7), route);
-        assertEquals(5, cap.get(0));
+        Assertions.assertEquals(5, cap.get(0));
     }
 
     @Test
@@ -1022,7 +1032,7 @@ class SolutionAnalyserTest {
         SolutionAnalyser analyser = new SolutionAnalyser(vrp, solution, vrp.getTransportCosts());
         VehicleRoute route = solution.getRoutes().iterator().next();
         Capacity cap = analyser.getCapacityViolationAfterActivity(route.getEnd(), route);
-        assertEquals(5, cap.get(0));
+        Assertions.assertEquals(5, cap.get(0));
     }
 
     @Test
@@ -1033,7 +1043,7 @@ class SolutionAnalyserTest {
         TourActivity act = route.getActivities().get(0);
         Capacity cap = analyser.getCapacityViolationAfterActivity(act, route);
         for (int i = 0; i < cap.getNuOfDimensions(); i++) {
-            assertEquals(0, cap.get(i));
+            Assertions.assertEquals(0, cap.get(i));
         }
     }
 
@@ -1045,7 +1055,7 @@ class SolutionAnalyserTest {
         TourActivity act = route.getActivities().get(1);
         Capacity cap = analyser.getCapacityViolationAfterActivity(act, route);
         for (int i = 0; i < cap.getNuOfDimensions(); i++) {
-            assertEquals(0, cap.get(i));
+            Assertions.assertEquals(0, cap.get(i));
         }
     }
 
@@ -1057,7 +1067,7 @@ class SolutionAnalyserTest {
         TourActivity act = route.getActivities().get(2);
         Capacity cap = analyser.getCapacityViolationAfterActivity(act, route);
         for (int i = 0; i < cap.getNuOfDimensions(); i++) {
-            assertEquals(0, cap.get(i));
+            Assertions.assertEquals(0, cap.get(i));
         }
     }
 
@@ -1069,7 +1079,7 @@ class SolutionAnalyserTest {
         TourActivity act = route.getActivities().get(3);
         Capacity cap = analyser.getCapacityViolationAfterActivity(act, route);
         for (int i = 0; i < cap.getNuOfDimensions(); i++) {
-            assertEquals(0, cap.get(i));
+            Assertions.assertEquals(0, cap.get(i));
         }
     }
 
@@ -1081,7 +1091,7 @@ class SolutionAnalyserTest {
         TourActivity act = route.getEnd();
         Capacity cap = analyser.getCapacityViolationAfterActivity(act, route);
         for (int i = 0; i < cap.getNuOfDimensions(); i++) {
-            assertEquals(0, cap.get(i));
+            Assertions.assertEquals(0, cap.get(i));
         }
     }
 
@@ -1091,7 +1101,7 @@ class SolutionAnalyserTest {
         SolutionAnalyser analyser = new SolutionAnalyser(vrp, solution, vrp.getTransportCosts());
         VehicleRoute route = solution.getRoutes().iterator().next();
         Double violation = analyser.getTimeWindowViolation(route);
-        assertEquals(0., violation, 0.01);
+        Assertions.assertEquals(0., violation, 0.01);
     }
 
     @Test
@@ -1101,7 +1111,7 @@ class SolutionAnalyserTest {
         SolutionAnalyser analyser = new SolutionAnalyser(vrp, solution, vrp.getTransportCosts());
         VehicleRoute route = solution.getRoutes().iterator().next();
         Double violation = analyser.getTimeWindowViolation(route);
-        assertEquals((2 + 26 + 57 + 77 + 90 + 114 + 144 + 20), violation, 0.01);
+        Assertions.assertEquals((2 + 26 + 57 + 77 + 90 + 114 + 144 + 20), violation, 0.01);
     }
 
     @Test
@@ -1111,7 +1121,7 @@ class SolutionAnalyserTest {
         SolutionAnalyser analyser = new SolutionAnalyser(vrp, solution, vrp.getTransportCosts());
         VehicleRoute route = solution.getRoutes().iterator().next();
         Double violation = analyser.getTimeWindowViolationAtActivity(route.getStart(), route);
-        assertEquals(0., violation, 0.01);
+        Assertions.assertEquals(0., violation, 0.01);
     }
 
     @Test
@@ -1121,7 +1131,7 @@ class SolutionAnalyserTest {
         SolutionAnalyser analyser = new SolutionAnalyser(vrp, solution, vrp.getTransportCosts());
         VehicleRoute route = solution.getRoutes().iterator().next();
         Double violation = analyser.getTimeWindowViolationAtActivity(route.getActivities().get(0), route);
-        assertEquals(0., violation, 0.01);
+        Assertions.assertEquals(0., violation, 0.01);
     }
 
     @Test
@@ -1131,7 +1141,7 @@ class SolutionAnalyserTest {
         SolutionAnalyser analyser = new SolutionAnalyser(vrp, solution, vrp.getTransportCosts());
         VehicleRoute route = solution.getRoutes().iterator().next();
         Double violation = analyser.getTimeWindowViolationAtActivity(route.getActivities().get(1), route);
-        assertEquals(2., violation, 0.01);
+        Assertions.assertEquals(2., violation, 0.01);
     }
 
     @Test
@@ -1141,7 +1151,7 @@ class SolutionAnalyserTest {
         SolutionAnalyser analyser = new SolutionAnalyser(vrp, solution, vrp.getTransportCosts());
         VehicleRoute route = solution.getRoutes().iterator().next();
         Double violation = analyser.getTimeWindowViolationAtActivity(route.getActivities().get(2), route);
-        assertEquals(26., violation, 0.01);
+        Assertions.assertEquals(26., violation, 0.01);
     }
 
     @Test
@@ -1151,7 +1161,7 @@ class SolutionAnalyserTest {
         SolutionAnalyser analyser = new SolutionAnalyser(vrp, solution, vrp.getTransportCosts());
         VehicleRoute route = solution.getRoutes().iterator().next();
         Double violation = analyser.getTimeWindowViolationAtActivity(route.getActivities().get(3), route);
-        assertEquals(57., violation, 0.01);
+        Assertions.assertEquals(57., violation, 0.01);
     }
 
     @Test
@@ -1161,7 +1171,7 @@ class SolutionAnalyserTest {
         SolutionAnalyser analyser = new SolutionAnalyser(vrp, solution, vrp.getTransportCosts());
         VehicleRoute route = solution.getRoutes().iterator().next();
         Double violation = analyser.getTimeWindowViolationAtActivity(route.getActivities().get(4), route);
-        assertEquals(77., violation, 0.01);
+        Assertions.assertEquals(77., violation, 0.01);
     }
 
     @Test
@@ -1171,7 +1181,7 @@ class SolutionAnalyserTest {
         SolutionAnalyser analyser = new SolutionAnalyser(vrp, solution, vrp.getTransportCosts());
         VehicleRoute route = solution.getRoutes().iterator().next();
         Double violation = analyser.getTimeWindowViolationAtActivity(route.getActivities().get(5), route);
-        assertEquals(90., violation, 0.01);
+        Assertions.assertEquals(90., violation, 0.01);
     }
 
     @Test
@@ -1181,7 +1191,7 @@ class SolutionAnalyserTest {
         SolutionAnalyser analyser = new SolutionAnalyser(vrp, solution, vrp.getTransportCosts());
         VehicleRoute route = solution.getRoutes().iterator().next();
         Double violation = analyser.getTimeWindowViolationAtActivity(route.getActivities().get(6), route);
-        assertEquals(114., violation, 0.01);
+        Assertions.assertEquals(114., violation, 0.01);
     }
 
     @Test
@@ -1191,7 +1201,7 @@ class SolutionAnalyserTest {
         SolutionAnalyser analyser = new SolutionAnalyser(vrp, solution, vrp.getTransportCosts());
         VehicleRoute route = solution.getRoutes().iterator().next();
         Double violation = analyser.getTimeWindowViolationAtActivity(route.getActivities().get(7), route);
-        assertEquals(144., violation, 0.01);
+        Assertions.assertEquals(144., violation, 0.01);
     }
 
     @Test
@@ -1201,7 +1211,7 @@ class SolutionAnalyserTest {
         SolutionAnalyser analyser = new SolutionAnalyser(vrp, solution, vrp.getTransportCosts());
         VehicleRoute route = solution.getRoutes().iterator().next();
         Double violation = analyser.getTimeWindowViolationAtActivity(route.getEnd(), route);
-        assertEquals(20., violation, 0.01);
+        Assertions.assertEquals(20., violation, 0.01);
     }
 
     @Test
@@ -1211,7 +1221,7 @@ class SolutionAnalyserTest {
         SolutionAnalyser analyser = new SolutionAnalyser(vrp, solution, vrp.getTransportCosts());
         VehicleRoute route = solution.getRoutes().iterator().next();
         Boolean violation = analyser.hasBackhaulConstraintViolation(route);
-        assertTrue(violation);
+        Assertions.assertTrue(violation);
     }
 
     @Test
@@ -1261,7 +1271,7 @@ class SolutionAnalyserTest {
         SolutionAnalyser analyser = new SolutionAnalyser(vrp, solution, vrp.getTransportCosts());
         VehicleRoute route = solution.getRoutes().iterator().next();
         Boolean violation = analyser.hasBackhaulConstraintViolationAtActivity(route.getActivities().get(3), route);
-        assertTrue(violation);
+        Assertions.assertTrue(violation);
     }
 
     @Test
@@ -1271,7 +1281,7 @@ class SolutionAnalyserTest {
         SolutionAnalyser analyser = new SolutionAnalyser(vrp, solution, vrp.getTransportCosts());
         VehicleRoute route = solution.getRoutes().iterator().next();
         Boolean violation = analyser.hasBackhaulConstraintViolationAtActivity(route.getActivities().get(4), route);
-        assertTrue(violation);
+        Assertions.assertTrue(violation);
     }
 
     @Test
@@ -1361,7 +1371,7 @@ class SolutionAnalyserTest {
         SolutionAnalyser analyser = new SolutionAnalyser(vrp, solution, vrp.getTransportCosts());
         VehicleRoute route = solution.getRoutes().iterator().next();
         Boolean violation = analyser.hasBackhaulConstraintViolationAtActivity(route.getActivities().get(3), route);
-        assertTrue(violation);
+        Assertions.assertTrue(violation);
     }
 
     @Test
@@ -1371,7 +1381,7 @@ class SolutionAnalyserTest {
         SolutionAnalyser analyser = new SolutionAnalyser(vrp, solution, vrp.getTransportCosts());
         VehicleRoute route = solution.getRoutes().iterator().next();
         Boolean violation = analyser.hasBackhaulConstraintViolationAtActivity(route.getActivities().get(4), route);
-        assertTrue(violation);
+        Assertions.assertTrue(violation);
     }
 
     @Test
@@ -1433,7 +1443,7 @@ class SolutionAnalyserTest {
         route.getTourActivities().removeActivity(deliverShipment);
         SolutionAnalyser analyser = new SolutionAnalyser(vrp, solution, vrp.getTransportCosts());
         Boolean violation = analyser.hasShipmentConstraintViolation(route);
-        assertTrue(violation);
+        Assertions.assertTrue(violation);
     }
 
     @Test
@@ -1445,7 +1455,7 @@ class SolutionAnalyserTest {
         route.getTourActivities().removeActivity(deliverShipment);
         SolutionAnalyser analyser = new SolutionAnalyser(vrp, solution, vrp.getTransportCosts());
         Boolean violation = analyser.hasShipmentConstraintViolationAtActivity(route.getActivities().get(1), route);
-        assertTrue(violation);
+        Assertions.assertTrue(violation);
     }
 
     @Test
@@ -1458,7 +1468,7 @@ class SolutionAnalyserTest {
         assertFalse(route.getActivities().contains(deliverShipment));
         SolutionAnalyser analyser = new SolutionAnalyser(vrp, solution, vrp.getTransportCosts());
         Boolean violation = analyser.hasShipmentConstraintViolation(route);
-        assertTrue(violation);
+        Assertions.assertTrue(violation);
     }
 
     @Test
@@ -1471,7 +1481,7 @@ class SolutionAnalyserTest {
         assertFalse(route.getActivities().contains(pickupShipment));
         SolutionAnalyser analyser = new SolutionAnalyser(vrp, solution, vrp.getTransportCosts());
         Boolean violation = analyser.hasShipmentConstraintViolationAtActivity(route.getActivities().get(1), route);
-        assertTrue(violation);
+        Assertions.assertTrue(violation);
     }
 
     @Test
@@ -1484,7 +1494,7 @@ class SolutionAnalyserTest {
         assertFalse(route.getActivities().contains(pickupShipment));
         SolutionAnalyser analyser = new SolutionAnalyser(vrp, solution, vrp.getTransportCosts());
         Boolean violation = analyser.hasShipmentConstraintViolation(route);
-        assertTrue(violation);
+        Assertions.assertTrue(violation);
     }
 
     @Test
@@ -1497,7 +1507,7 @@ class SolutionAnalyserTest {
         assertFalse(route.getActivities().contains(pickupShipment));
         SolutionAnalyser analyser = new SolutionAnalyser(vrp, solution, vrp.getTransportCosts());
         Boolean violation = analyser.hasShipmentConstraintViolation();
-        assertTrue(violation);
+        Assertions.assertTrue(violation);
     }
 
     @Test
@@ -1506,7 +1516,7 @@ class SolutionAnalyserTest {
         SolutionAnalyser analyser = new SolutionAnalyser(vrp, solution, vrp.getTransportCosts());
         VehicleRoute route = solution.getRoutes().iterator().next();
         Boolean violated = analyser.hasSkillConstraintViolation(route);
-        assertTrue(violated);
+        Assertions.assertTrue(violated);
     }
 
     @Test
@@ -1533,7 +1543,7 @@ class SolutionAnalyserTest {
         SolutionAnalyser analyser = new SolutionAnalyser(vrp, solution, vrp.getTransportCosts());
         VehicleRoute route = solution.getRoutes().iterator().next();
         Boolean violated = analyser.hasSkillConstraintViolationAtActivity(route.getActivities().get(1), route);
-        assertTrue(violated);
+        Assertions.assertTrue(violated);
     }
 
     @Test
@@ -1542,7 +1552,7 @@ class SolutionAnalyserTest {
         SolutionAnalyser analyser = new SolutionAnalyser(vrp, solution, vrp.getTransportCosts());
         VehicleRoute route = solution.getRoutes().iterator().next();
         Boolean violated = analyser.hasSkillConstraintViolationAtActivity(route.getActivities().get(2), route);
-        assertTrue(violated);
+        Assertions.assertTrue(violated);
     }
 
     @Test
@@ -1579,7 +1589,7 @@ class SolutionAnalyserTest {
     void skillViolationOnSolution_shouldWork() {
         SolutionAnalyser analyser = new SolutionAnalyser(vrp, solution, vrp.getTransportCosts());
         Boolean violated = analyser.hasSkillConstraintViolation();
-        assertTrue(violated);
+        Assertions.assertTrue(violated);
     }
 
     @Test
@@ -1596,7 +1606,7 @@ class SolutionAnalyserTest {
         buildAnotherScenarioWithOnlyOneVehicleAndWithoutAnyConstraintsBefore();
         SolutionAnalyser analyser = new SolutionAnalyser(vrp, solution, vrp.getTransportCosts());
         Boolean violated = analyser.hasBackhaulConstraintViolation();
-        assertTrue(violated);
+        Assertions.assertTrue(violated);
     }
 
     @Test
@@ -1626,7 +1636,7 @@ class SolutionAnalyserTest {
             VehicleRoutingProblem vrp = VehicleRoutingProblem.Builder.newInstance().addVehicle(vehicle).build();
             VehicleRoutingProblemSolution solution = new VehicleRoutingProblemSolution(Collections.singletonList(vehicleRoute), 0);
             new SolutionAnalyser(vrp, solution, (from, to, departureTime, vehicle1) -> 100);
-            assertTrue(true);
+            Assertions.assertTrue(true);
         } catch (Exception e) {
             fail();
         }

--- a/jsprit-core/src/test/java/com/graphhopper/jsprit/core/problem/CapacityTest.java
+++ b/jsprit-core/src/test/java/com/graphhopper/jsprit/core/problem/CapacityTest.java
@@ -17,6 +17,7 @@
  */
 package com.graphhopper.jsprit.core.problem;
 
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
@@ -33,7 +34,7 @@ class CapacityTest {
         Capacity.Builder capBuilder = Capacity.Builder.newInstance();
         capBuilder.addDimension(0, 4);
         Capacity cap = capBuilder.build();
-        assertEquals(1, cap.getNuOfDimensions());
+        Assertions.assertEquals(1, cap.getNuOfDimensions());
     }
 
     @Test
@@ -43,7 +44,7 @@ class CapacityTest {
         capBuilder.addDimension(0, 4);
         capBuilder.addDimension(1, 10);
         Capacity cap = capBuilder.build();
-        assertEquals(2, cap.getNuOfDimensions());
+        Assertions.assertEquals(2, cap.getNuOfDimensions());
     }
 
     @Test
@@ -54,7 +55,7 @@ class CapacityTest {
         Capacity.Builder capBuilder = Capacity.Builder.newInstance();
         capBuilder.addDimension(nuOfCapDimensions - 1, 4);
         Capacity cap = capBuilder.build();
-        assertEquals(nuOfCapDimensions, cap.getNuOfDimensions());
+        Assertions.assertEquals(nuOfCapDimensions, cap.getNuOfDimensions());
     }
 
     @Test
@@ -63,7 +64,7 @@ class CapacityTest {
         Capacity.Builder capBuilder = Capacity.Builder.newInstance();
         capBuilder.addDimension(0, 4);
         Capacity cap = capBuilder.build();
-        assertEquals(4, cap.get(0));
+        Assertions.assertEquals(4, cap.get(0));
     }
 
     @Test
@@ -72,7 +73,7 @@ class CapacityTest {
         Capacity.Builder capBuilder = Capacity.Builder.newInstance();
         capBuilder.addDimension(0, 4);
         Capacity cap = capBuilder.build();
-        assertEquals(0, cap.get(2));
+        Assertions.assertEquals(0, cap.get(2));
     }
 
     @Test
@@ -80,8 +81,8 @@ class CapacityTest {
     void whenSettingNoDim_DefaultIsOneDimWithDimValueOfZero() {
         Capacity.Builder capBuilder = Capacity.Builder.newInstance();
         Capacity cap = capBuilder.build();
-        assertEquals(1, cap.getNuOfDimensions());
-        assertEquals(0, cap.get(0));
+        Assertions.assertEquals(1, cap.getNuOfDimensions());
+        Assertions.assertEquals(0, cap.get(0));
     }
 
     @Test
@@ -92,7 +93,7 @@ class CapacityTest {
         capBuilder.addDimension(1, 10);
         Capacity cap = capBuilder.build();
         Capacity copiedCapacity = Capacity.copyOf(cap);
-        assertEquals(2, copiedCapacity.getNuOfDimensions());
+        Assertions.assertEquals(2, copiedCapacity.getNuOfDimensions());
     }
 
     @Test
@@ -103,15 +104,15 @@ class CapacityTest {
         capBuilder.addDimension(1, 10);
         Capacity cap = capBuilder.build();
         Capacity copiedCapacity = Capacity.copyOf(cap);
-        assertEquals(4, copiedCapacity.get(0));
-        assertEquals(10, copiedCapacity.get(1));
+        Assertions.assertEquals(4, copiedCapacity.get(0));
+        Assertions.assertEquals(10, copiedCapacity.get(1));
     }
 
     @Test
     @DisplayName("When Copying Null _ it Should Return Null")
     void whenCopyingNull_itShouldReturnNull() {
         Capacity nullCap = Capacity.copyOf(null);
-        assertTrue(nullCap == null);
+        Assertions.assertTrue(nullCap == null);
     }
 
     @Test
@@ -120,7 +121,7 @@ class CapacityTest {
         Capacity cap1 = Capacity.Builder.newInstance().addDimension(0, 1).build();
         Capacity cap2 = Capacity.Builder.newInstance().addDimension(0, 2).build();
         Capacity result = Capacity.addup(cap1, cap2);
-        assertEquals(3, result.get(0));
+        Assertions.assertEquals(3, result.get(0));
     }
 
     @Test
@@ -129,7 +130,7 @@ class CapacityTest {
         Capacity cap1 = Capacity.Builder.newInstance().addDimension(0, 1).build();
         Capacity cap2 = Capacity.Builder.newInstance().addDimension(0, 2).build();
         Capacity result = Capacity.addup(cap1, cap2);
-        assertEquals(1, result.getNuOfDimensions());
+        Assertions.assertEquals(1, result.getNuOfDimensions());
     }
 
     @Test
@@ -138,7 +139,7 @@ class CapacityTest {
         Capacity cap1 = Capacity.Builder.newInstance().addDimension(0, 1).addDimension(1, 2).addDimension(2, 3).build();
         Capacity cap2 = Capacity.Builder.newInstance().addDimension(0, 2).addDimension(1, 3).addDimension(2, 4).build();
         Capacity result = Capacity.addup(cap1, cap2);
-        assertEquals(3, result.getNuOfDimensions());
+        Assertions.assertEquals(3, result.getNuOfDimensions());
     }
 
     @Test
@@ -147,17 +148,17 @@ class CapacityTest {
         Capacity cap1 = Capacity.Builder.newInstance().addDimension(0, 1).addDimension(1, 2).addDimension(2, 3).build();
         Capacity cap2 = Capacity.Builder.newInstance().addDimension(0, 2).addDimension(1, 3).addDimension(2, 4).build();
         Capacity result = Capacity.addup(cap1, cap2);
-        assertEquals(3, result.get(0));
-        assertEquals(5, result.get(1));
-        assertEquals(7, result.get(2));
+        Assertions.assertEquals(3, result.get(0));
+        Assertions.assertEquals(5, result.get(1));
+        Assertions.assertEquals(7, result.get(2));
     }
 
     public void whenAddingUpTwoCapacitiesWithDifferentNuOfDimensions_itShouldAddThemCorrectly() {
         Capacity cap1 = Capacity.Builder.newInstance().addDimension(0, 1).addDimension(1, 2).build();
         Capacity cap2 = Capacity.Builder.newInstance().addDimension(0, 2).build();
         Capacity result = Capacity.addup(cap1, cap2);
-        assertEquals(3, result.get(0));
-        assertEquals(2, result.get(1));
+        Assertions.assertEquals(3, result.get(0));
+        Assertions.assertEquals(2, result.get(1));
     }
 
     @Test
@@ -176,7 +177,7 @@ class CapacityTest {
         Capacity cap1 = Capacity.Builder.newInstance().addDimension(0, 1).build();
         Capacity cap2 = Capacity.Builder.newInstance().addDimension(0, 2).build();
         Capacity result = Capacity.subtract(cap2, cap1);
-        assertEquals(1, result.get(0));
+        Assertions.assertEquals(1, result.get(0));
     }
 
     @Test
@@ -185,7 +186,7 @@ class CapacityTest {
         Capacity cap1 = Capacity.Builder.newInstance().addDimension(0, 1).build();
         Capacity cap2 = Capacity.Builder.newInstance().addDimension(0, 2).build();
         Capacity result = Capacity.subtract(cap2, cap1);
-        assertEquals(1, result.getNuOfDimensions());
+        Assertions.assertEquals(1, result.getNuOfDimensions());
     }
 
     @Test
@@ -194,7 +195,7 @@ class CapacityTest {
         Capacity cap1 = Capacity.Builder.newInstance().addDimension(0, 1).addDimension(1, 2).addDimension(2, 3).build();
         Capacity cap2 = Capacity.Builder.newInstance().addDimension(0, 2).addDimension(1, 3).addDimension(2, 4).build();
         Capacity result = Capacity.subtract(cap2, cap1);
-        assertEquals(3, result.getNuOfDimensions());
+        Assertions.assertEquals(3, result.getNuOfDimensions());
     }
 
     @Test
@@ -203,9 +204,9 @@ class CapacityTest {
         Capacity cap1 = Capacity.Builder.newInstance().addDimension(0, 1).addDimension(1, 2).addDimension(2, 3).build();
         Capacity cap2 = Capacity.Builder.newInstance().addDimension(0, 2).addDimension(1, 3).addDimension(2, 4).build();
         Capacity result = Capacity.subtract(cap2, cap1);
-        assertEquals(1, result.get(0));
-        assertEquals(1, result.get(1));
-        assertEquals(1, result.get(2));
+        Assertions.assertEquals(1, result.get(0));
+        Assertions.assertEquals(1, result.get(1));
+        Assertions.assertEquals(1, result.get(2));
     }
 
     @Test
@@ -214,8 +215,8 @@ class CapacityTest {
         Capacity cap1 = Capacity.Builder.newInstance().addDimension(0, 1).addDimension(1, 2).build();
         Capacity cap2 = Capacity.Builder.newInstance().addDimension(0, 2).build();
         Capacity result = Capacity.subtract(cap2, cap1);
-        assertEquals(1, result.get(0));
-        assertEquals(-2, result.get(1));
+        Assertions.assertEquals(1, result.get(0));
+        Assertions.assertEquals(-2, result.get(1));
     }
 
     @Test
@@ -234,9 +235,9 @@ class CapacityTest {
         Capacity cap1 = Capacity.Builder.newInstance().addDimension(0, 1).addDimension(1, 2).addDimension(2, 3).build();
         Capacity cap2 = Capacity.Builder.newInstance().addDimension(0, 2).addDimension(1, 3).addDimension(2, 4).build();
         Capacity result = Capacity.subtract(cap1, cap2);
-        assertEquals(-1, result.get(0));
-        assertEquals(-1, result.get(1));
-        assertEquals(-1, result.get(2));
+        Assertions.assertEquals(-1, result.get(0));
+        Assertions.assertEquals(-1, result.get(1));
+        Assertions.assertEquals(-1, result.get(2));
     }
 
     @Test
@@ -244,7 +245,7 @@ class CapacityTest {
     void whenOneCapIsLessThanAnother_itShouldReturnCorrectBoolean() {
         Capacity cap1 = Capacity.Builder.newInstance().addDimension(0, 1).addDimension(1, 2).addDimension(2, 3).build();
         Capacity cap2 = Capacity.Builder.newInstance().addDimension(0, 2).addDimension(1, 3).addDimension(2, 4).build();
-        assertTrue(cap1.isLessOrEqual(cap2));
+        Assertions.assertTrue(cap1.isLessOrEqual(cap2));
     }
 
     @Test
@@ -252,7 +253,7 @@ class CapacityTest {
     void whenOneCapIsLessThanAnother_itShouldReturnCorrectBoolean_v2() {
         Capacity cap1 = Capacity.Builder.newInstance().addDimension(0, 2).addDimension(1, 2).addDimension(2, 4).build();
         Capacity cap2 = Capacity.Builder.newInstance().addDimension(0, 2).addDimension(1, 3).addDimension(2, 4).build();
-        assertTrue(cap1.isLessOrEqual(cap2));
+        Assertions.assertTrue(cap1.isLessOrEqual(cap2));
     }
 
     @Test
@@ -260,7 +261,7 @@ class CapacityTest {
     void whenOneCapIsLessThanAnother_itShouldReturnCorrectBoolean_v3() {
         Capacity cap1 = Capacity.Builder.newInstance().addDimension(0, 2).addDimension(1, 3).addDimension(2, 4).build();
         Capacity cap2 = Capacity.Builder.newInstance().addDimension(0, 2).addDimension(1, 3).addDimension(2, 4).build();
-        assertTrue(cap1.isLessOrEqual(cap2));
+        Assertions.assertTrue(cap1.isLessOrEqual(cap2));
     }
 
     @Test
@@ -268,7 +269,7 @@ class CapacityTest {
     void whenOneCapIsBiggerThanAnother_itShouldReturnCorrectBoolean() {
         Capacity cap1 = Capacity.Builder.newInstance().addDimension(0, 2).addDimension(1, 3).addDimension(2, 4).build();
         Capacity cap2 = Capacity.Builder.newInstance().addDimension(0, 2).addDimension(1, 4).addDimension(2, 4).build();
-        assertFalse(cap2.isLessOrEqual(cap1));
+        Assertions.assertFalse(cap2.isLessOrEqual(cap1));
     }
 
     @Test
@@ -276,7 +277,7 @@ class CapacityTest {
     void whenOneCapIsBiggerThanAnother_greaterOrEqualShouldReturnTrue() {
         Capacity cap1 = Capacity.Builder.newInstance().addDimension(0, 2).addDimension(1, 3).addDimension(2, 4).build();
         Capacity cap2 = Capacity.Builder.newInstance().addDimension(0, 2).addDimension(1, 4).addDimension(2, 4).build();
-        assertTrue(cap2.isGreaterOrEqual(cap1));
+        Assertions.assertTrue(cap2.isGreaterOrEqual(cap1));
     }
 
     @Test
@@ -285,7 +286,7 @@ class CapacityTest {
         Capacity cap1 = Capacity.Builder.newInstance().addDimension(0, 2).addDimension(1, 3).addDimension(2, 4).build();
         // which is zero-cap
         Capacity cap2 = Capacity.Builder.newInstance().build();
-        assertTrue(cap1.isGreaterOrEqual(cap2));
+        Assertions.assertTrue(cap1.isGreaterOrEqual(cap2));
     }
 
     @Test
@@ -293,7 +294,7 @@ class CapacityTest {
     void whenOneCapIsEqualToAnother_greaterOrEqualShouldReturnTrue() {
         Capacity cap1 = Capacity.Builder.newInstance().addDimension(0, 2).addDimension(1, 3).addDimension(2, 4).build();
         Capacity cap2 = Capacity.Builder.newInstance().addDimension(0, 2).addDimension(1, 3).addDimension(2, 4).build();
-        assertTrue(cap2.isGreaterOrEqual(cap1));
+        Assertions.assertTrue(cap2.isGreaterOrEqual(cap1));
     }
 
     @Test
@@ -305,9 +306,9 @@ class CapacityTest {
         Capacity wheelChair = Capacity.Builder.newInstance().addDimension(wheelChairSpace, 1).build();
         Capacity passenger = Capacity.Builder.newInstance().addDimension(passengerSeats, 1).build();
         Capacity wheelChair_plus_passenger = Capacity.addup(wheelChair, passenger);
-        assertEquals(1, wheelChair_plus_passenger.get(wheelChairSpace));
-        assertEquals(1, wheelChair_plus_passenger.get(passengerSeats));
-        assertTrue(wheelChair_plus_passenger.isLessOrEqual(cap1));
+        Assertions.assertEquals(1, wheelChair_plus_passenger.get(wheelChairSpace));
+        Assertions.assertEquals(1, wheelChair_plus_passenger.get(passengerSeats));
+        Assertions.assertTrue(wheelChair_plus_passenger.isLessOrEqual(cap1));
     }
 
     @Test
@@ -320,10 +321,10 @@ class CapacityTest {
         Capacity wheelChair = Capacity.Builder.newInstance().addDimension(wheelChairSpace, 1).addDimension(weight, 80).build();
         Capacity passenger = Capacity.Builder.newInstance().addDimension(passengerSeats, 1).addDimension(weight, 30).build();
         Capacity wheelChair_plus_passenger = Capacity.addup(wheelChair, passenger);
-        assertEquals(1, wheelChair_plus_passenger.get(wheelChairSpace));
-        assertEquals(1, wheelChair_plus_passenger.get(passengerSeats));
-        assertEquals(110, wheelChair_plus_passenger.get(weight));
-        assertFalse(wheelChair_plus_passenger.isLessOrEqual(cap1));
+        Assertions.assertEquals(1, wheelChair_plus_passenger.get(wheelChairSpace));
+        Assertions.assertEquals(1, wheelChair_plus_passenger.get(passengerSeats));
+        Assertions.assertEquals(110, wheelChair_plus_passenger.get(weight));
+        Assertions.assertFalse(wheelChair_plus_passenger.isLessOrEqual(cap1));
     }
 
     @Test
@@ -331,9 +332,9 @@ class CapacityTest {
     void whenInvertingCap_itShouldBeDoneCorrectly() {
         Capacity cap = Capacity.Builder.newInstance().addDimension(0, 2).addDimension(1, 3).addDimension(2, 4).build();
         Capacity inverted = Capacity.invert(cap);
-        assertEquals(-2, inverted.get(0));
-        assertEquals(-3, inverted.get(1));
-        assertEquals(-4, inverted.get(2));
+        Assertions.assertEquals(-2, inverted.get(0));
+        Assertions.assertEquals(-3, inverted.get(1));
+        Assertions.assertEquals(-4, inverted.get(2));
     }
 
     @Test
@@ -341,8 +342,8 @@ class CapacityTest {
     void whenDeterminingTheMaximumOfTwoCapacities_itShouldReturnCapWithMaxOfEachDimension() {
         Capacity cap1 = Capacity.Builder.newInstance().addDimension(0, 3).addDimension(1, 3).build();
         Capacity cap2 = Capacity.Builder.newInstance().addDimension(0, 2).addDimension(1, 4).build();
-        assertEquals(3, Capacity.max(cap1, cap2).get(0));
-        assertEquals(4, Capacity.max(cap1, cap2).get(1));
+        Assertions.assertEquals(3, Capacity.max(cap1, cap2).get(0));
+        Assertions.assertEquals(4, Capacity.max(cap1, cap2).get(1));
     }
 
     @Test
@@ -350,8 +351,8 @@ class CapacityTest {
     void whenDeterminingTheMaximumOfTwoCapacities_itShouldReturnCapWithMaxOfEachDimension_v2() {
         Capacity cap1 = Capacity.Builder.newInstance().addDimension(0, 1).addDimension(1, 3).build();
         Capacity cap2 = Capacity.Builder.newInstance().addDimension(0, 2).addDimension(1, 4).build();
-        assertEquals(2, Capacity.max(cap1, cap2).get(0));
-        assertEquals(4, Capacity.max(cap1, cap2).get(1));
+        Assertions.assertEquals(2, Capacity.max(cap1, cap2).get(0));
+        Assertions.assertEquals(4, Capacity.max(cap1, cap2).get(1));
     }
 
     @Test
@@ -359,9 +360,9 @@ class CapacityTest {
     void whenDeterminingTheMaximumOfTwoCapacities_itShouldReturnCapWithMaxOfEachDimension_v3() {
         Capacity cap1 = Capacity.Builder.newInstance().addDimension(0, 1).addDimension(1, 3).addDimension(2, 3).build();
         Capacity cap2 = Capacity.Builder.newInstance().addDimension(0, 2).addDimension(1, 4).build();
-        assertEquals(2, Capacity.max(cap1, cap2).get(0));
-        assertEquals(4, Capacity.max(cap1, cap2).get(1));
-        assertEquals(3, Capacity.max(cap1, cap2).get(2));
+        Assertions.assertEquals(2, Capacity.max(cap1, cap2).get(0));
+        Assertions.assertEquals(4, Capacity.max(cap1, cap2).get(1));
+        Assertions.assertEquals(3, Capacity.max(cap1, cap2).get(2));
     }
 
     @Test
@@ -369,7 +370,7 @@ class CapacityTest {
     void whenDividingTwoCapacities_itShouldReturn05() {
         Capacity cap1 = Capacity.Builder.newInstance().addDimension(0, 1).addDimension(1, 2).build();
         Capacity cap2 = Capacity.Builder.newInstance().addDimension(0, 2).addDimension(1, 4).build();
-        assertEquals(0.5, Capacity.divide(cap1, cap2), 0.001);
+        Assertions.assertEquals(0.5, Capacity.divide(cap1, cap2), 0.001);
     }
 
     @Test
@@ -377,7 +378,7 @@ class CapacityTest {
     void whenDividingTwoEqualCapacities_itShouldReturn10() {
         Capacity cap1 = Capacity.Builder.newInstance().addDimension(0, 2).addDimension(1, 4).build();
         Capacity cap2 = Capacity.Builder.newInstance().addDimension(0, 2).addDimension(1, 4).build();
-        assertEquals(1.0, Capacity.divide(cap1, cap2), 0.001);
+        Assertions.assertEquals(1.0, Capacity.divide(cap1, cap2), 0.001);
     }
 
     @Test
@@ -385,7 +386,7 @@ class CapacityTest {
     void whenDividingTwoCapacities_itShouldReturn00() {
         Capacity cap1 = Capacity.Builder.newInstance().addDimension(0, 0).addDimension(1, 0).build();
         Capacity cap2 = Capacity.Builder.newInstance().addDimension(0, 2).addDimension(1, 4).build();
-        assertEquals(0.0, Capacity.divide(cap1, cap2), 0.001);
+        Assertions.assertEquals(0.0, Capacity.divide(cap1, cap2), 0.001);
     }
 
     @Test
@@ -403,7 +404,7 @@ class CapacityTest {
     void whenBothDimOfNominatorAndDenominatorAreZero_divisionShouldIgnoreThisDim() {
         Capacity cap1 = Capacity.Builder.newInstance().addDimension(0, 1).addDimension(1, 2).addDimension(3, 0).build();
         Capacity cap2 = Capacity.Builder.newInstance().addDimension(0, 2).addDimension(1, 4).addDimension(3, 0).build();
-        assertEquals(0.5, Capacity.divide(cap1, cap2), 0.001);
+        Assertions.assertEquals(0.5, Capacity.divide(cap1, cap2), 0.001);
     }
 
     @Test
@@ -411,7 +412,7 @@ class CapacityTest {
     void whenDividingZeroCaps_itShouldReturnZero() {
         Capacity cap1 = Capacity.Builder.newInstance().build();
         Capacity cap2 = Capacity.Builder.newInstance().build();
-        assertEquals(0.0, Capacity.divide(cap1, cap2), 0.001);
+        Assertions.assertEquals(0.0, Capacity.divide(cap1, cap2), 0.001);
     }
 
     @Test
@@ -419,7 +420,7 @@ class CapacityTest {
     void shouldBeEqual() {
         Capacity cap1 = Capacity.Builder.newInstance().build();
         Capacity cap2 = Capacity.Builder.newInstance().build();
-        assertTrue(cap1.equals(cap2));
+        Assertions.assertTrue(cap1.equals(cap2));
     }
 
     @Test
@@ -427,6 +428,6 @@ class CapacityTest {
     void shouldBeEqual2() {
         Capacity cap1 = Capacity.Builder.newInstance().addDimension(0, 10).addDimension(1, 100).addDimension(2, 1000).build();
         Capacity cap2 = Capacity.Builder.newInstance().addDimension(0, 10).addDimension(2, 1000).addDimension(1, 100).build();
-        assertTrue(cap1.equals(cap2));
+        Assertions.assertTrue(cap1.equals(cap2));
     }
 }

--- a/jsprit-core/src/test/java/com/graphhopper/jsprit/core/problem/LocationTest.java
+++ b/jsprit-core/src/test/java/com/graphhopper/jsprit/core/problem/LocationTest.java
@@ -18,6 +18,8 @@
 package com.graphhopper.jsprit.core.problem;
 
 import com.graphhopper.jsprit.core.util.Coordinate;
+
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
@@ -36,23 +38,23 @@ class LocationTest {
     @DisplayName("When Index Set _ build Location")
     void whenIndexSet_buildLocation() {
         Location l = Location.Builder.newInstance().setIndex(1).build();
-        assertEquals(1, l.getIndex());
-        assertTrue(true);
+        Assertions.assertEquals(1, l.getIndex());
+        Assertions.assertTrue(true);
     }
 
     @Test
     @DisplayName("When Name Set _ build Location")
     void whenNameSet_buildLocation() {
         Location l = Location.Builder.newInstance().setName("mystreet 6a").setIndex(1).build();
-        assertEquals(l.getName(), "mystreet 6a");
+        Assertions.assertEquals(l.getName(), "mystreet 6a");
     }
 
     @Test
     @DisplayName("When Index Set Wit Factory _ return Correct Location")
     void whenIndexSetWitFactory_returnCorrectLocation() {
         Location l = Location.newInstance(1);
-        assertEquals(1, l.getIndex());
-        assertTrue(true);
+        Assertions.assertEquals(1, l.getIndex());
+        Assertions.assertTrue(true);
     }
 
     @Test
@@ -75,25 +77,25 @@ class LocationTest {
     @DisplayName("When Id Set _ build")
     void whenIdSet_build() {
         Location l = Location.Builder.newInstance().setId("id").build();
-        assertEquals(l.getId(), "id");
-        assertTrue(true);
+        Assertions.assertEquals(l.getId(), "id");
+        Assertions.assertTrue(true);
     }
 
     @Test
     @DisplayName("When Id Set With Factory _ return Correct Location")
     void whenIdSetWithFactory_returnCorrectLocation() {
         Location l = Location.newInstance("id");
-        assertEquals(l.getId(), "id");
-        assertTrue(true);
+        Assertions.assertEquals(l.getId(), "id");
+        Assertions.assertTrue(true);
     }
 
     @Test
     @DisplayName("When Coordinate Set _ build")
     void whenCoordinateSet_build() {
         Location l = Location.Builder.newInstance().setCoordinate(Coordinate.newInstance(10, 20)).build();
-        assertEquals(10., l.getCoordinate().getX(), 0.001);
-        assertEquals(20., l.getCoordinate().getY(), 0.001);
-        assertTrue(true);
+        Assertions.assertEquals(10., l.getCoordinate().getX(), 0.001);
+        Assertions.assertEquals(20., l.getCoordinate().getY(), 0.001);
+        Assertions.assertTrue(true);
     }
 
     @Test
@@ -101,9 +103,9 @@ class LocationTest {
     void whenCoordinateSetWithFactory_returnCorrectLocation() {
         // Location l = Location.Builder.newInstance().setCoordinate(Coordinate.newInstance(10,20)).build();
         Location l = Location.newInstance(10, 20);
-        assertEquals(10., l.getCoordinate().getX(), 0.001);
-        assertEquals(20., l.getCoordinate().getY(), 0.001);
-        assertTrue(true);
+        Assertions.assertEquals(10., l.getCoordinate().getX(), 0.001);
+        Assertions.assertEquals(20., l.getCoordinate().getY(), 0.001);
+        Assertions.assertTrue(true);
     }
 
     @Test
@@ -112,8 +114,8 @@ class LocationTest {
         Location one = Location.Builder.newInstance().setCoordinate(Coordinate.newInstance(10, 20)).setUserData(new HashMap<String, Object>()).build();
         Location two = Location.Builder.newInstance().setIndex(1).setUserData(42).build();
         Location three = Location.Builder.newInstance().setIndex(2).build();
-        assertTrue(one.getUserData() instanceof Map);
-        assertEquals(42, two.getUserData());
+        Assertions.assertTrue(one.getUserData() instanceof Map);
+        Assertions.assertEquals(42, two.getUserData());
         assertNull(three.getUserData());
     }
 }

--- a/jsprit-core/src/test/java/com/graphhopper/jsprit/core/problem/SkillsTest.java
+++ b/jsprit-core/src/test/java/com/graphhopper/jsprit/core/problem/SkillsTest.java
@@ -17,6 +17,7 @@
  */
 package com.graphhopper.jsprit.core.problem;
 
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
@@ -35,24 +36,24 @@ class SkillsTest {
     @DisplayName("When Skills Added _ they Should Bein Skill Set")
     void whenSkillsAdded_theyShouldBeinSkillSet() {
         Skills skills = Skills.Builder.newInstance().addSkill("skill1").addSkill("skill2").build();
-        assertTrue(skills.containsSkill("skill1"));
-        assertTrue(skills.containsSkill("skill2"));
+        Assertions.assertTrue(skills.containsSkill("skill1"));
+        Assertions.assertTrue(skills.containsSkill("skill2"));
     }
 
     @Test
     @DisplayName("When Skills Added Case Insensitive _ they Should Bein Skill Set")
     void whenSkillsAddedCaseInsensitive_theyShouldBeinSkillSet() {
         Skills skills = Skills.Builder.newInstance().addSkill("skill1").addSkill("skill2").build();
-        assertTrue(skills.containsSkill("skilL1"));
-        assertTrue(skills.containsSkill("skIll2"));
+        Assertions.assertTrue(skills.containsSkill("skilL1"));
+        Assertions.assertTrue(skills.containsSkill("skIll2"));
     }
 
     @Test
     @DisplayName("When Skills Added Case Insensitive 2 _ they Should Bein Skill Set")
     void whenSkillsAddedCaseInsensitive2_theyShouldBeinSkillSet() {
         Skills skills = Skills.Builder.newInstance().addSkill("Skill1").addSkill("skill2").build();
-        assertTrue(skills.containsSkill("skilL1"));
-        assertTrue(skills.containsSkill("skIll2"));
+        Assertions.assertTrue(skills.containsSkill("skilL1"));
+        Assertions.assertTrue(skills.containsSkill("skIll2"));
     }
 
     @Test
@@ -62,8 +63,8 @@ class SkillsTest {
         skillSet.add("skill1");
         skillSet.add("skill2");
         Skills skills = Skills.Builder.newInstance().addAllSkills(skillSet).build();
-        assertTrue(skills.containsSkill("skill1"));
-        assertTrue(skills.containsSkill("skill2"));
+        Assertions.assertTrue(skills.containsSkill("skill1"));
+        Assertions.assertTrue(skills.containsSkill("skill2"));
     }
 
     @Test
@@ -73,8 +74,8 @@ class SkillsTest {
         skillSet.add("skill1");
         skillSet.add("skill2");
         Skills skills = Skills.Builder.newInstance().addAllSkills(skillSet).build();
-        assertTrue(skills.containsSkill("skilL1"));
-        assertTrue(skills.containsSkill("skill2"));
+        Assertions.assertTrue(skills.containsSkill("skilL1"));
+        Assertions.assertTrue(skills.containsSkill("skill2"));
     }
 
     @Test
@@ -84,8 +85,8 @@ class SkillsTest {
         skillSet.add("skill1");
         skillSet.add("Skill2");
         Skills skills = Skills.Builder.newInstance().addAllSkills(skillSet).build();
-        assertTrue(skills.containsSkill("skill1"));
-        assertTrue(skills.containsSkill("skill2"));
+        Assertions.assertTrue(skills.containsSkill("skill1"));
+        Assertions.assertTrue(skills.containsSkill("skill2"));
     }
 
     @Test
@@ -95,8 +96,8 @@ class SkillsTest {
         skillSet.add(" skill1");
         skillSet.add("Skill2");
         Skills skills = Skills.Builder.newInstance().addAllSkills(skillSet).build();
-        assertTrue(skills.containsSkill("skill1"));
-        assertTrue(skills.containsSkill("skill2"));
+        Assertions.assertTrue(skills.containsSkill("skill1"));
+        Assertions.assertTrue(skills.containsSkill("skill2"));
     }
 
     @Test
@@ -106,14 +107,14 @@ class SkillsTest {
         skillSet.add("skill1 ");
         skillSet.add("Skill2");
         Skills skills = Skills.Builder.newInstance().addAllSkills(skillSet).build();
-        assertTrue(skills.containsSkill("skill1"));
-        assertTrue(skills.containsSkill("skill2"));
+        Assertions.assertTrue(skills.containsSkill("skill1"));
+        Assertions.assertTrue(skills.containsSkill("skill2"));
     }
 
     @Test
     @DisplayName("When Skills Added Trailing Whitespace Should Not Matter 2")
     void whenSkillsAddedTrailingWhitespaceShouldNotMatter2() {
         Skills skills = Skills.Builder.newInstance().addSkill("skill1 ").build();
-        assertTrue(skills.containsSkill("skill1"));
+        Assertions.assertTrue(skills.containsSkill("skill1"));
     }
 }

--- a/jsprit-core/src/test/java/com/graphhopper/jsprit/core/problem/VehicleRoutingProblemTest.java
+++ b/jsprit-core/src/test/java/com/graphhopper/jsprit/core/problem/VehicleRoutingProblemTest.java
@@ -31,6 +31,8 @@ import com.graphhopper.jsprit.core.problem.vehicle.VehicleType;
 import com.graphhopper.jsprit.core.problem.vehicle.VehicleTypeImpl;
 import com.graphhopper.jsprit.core.util.Coordinate;
 import com.graphhopper.jsprit.core.util.TestUtils;
+
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
@@ -38,9 +40,6 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
 
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.junit.jupiter.api.Assertions.*;
-import static org.junit.matchers.JUnitMatchers.hasItem;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -71,7 +70,7 @@ class VehicleRoutingProblemTest {
         VehicleRoutingProblem.Builder builder = VehicleRoutingProblem.Builder.newInstance();
         builder.setFleetSize(FleetSize.INFINITE);
         VehicleRoutingProblem vrp = builder.build();
-        assertEquals(FleetSize.INFINITE, vrp.getFleetSize());
+        Assertions.assertEquals(FleetSize.INFINITE, vrp.getFleetSize());
     }
 
     @Test
@@ -80,7 +79,7 @@ class VehicleRoutingProblemTest {
         VehicleRoutingProblem.Builder builder = VehicleRoutingProblem.Builder.newInstance();
         builder.setFleetSize(FleetSize.FINITE);
         VehicleRoutingProblem vrp = builder.build();
-        assertEquals(FleetSize.FINITE, vrp.getFleetSize());
+        Assertions.assertEquals(FleetSize.FINITE, vrp.getFleetSize());
     }
 
     @Test
@@ -93,8 +92,8 @@ class VehicleRoutingProblemTest {
         VehicleImpl v4 = VehicleImpl.Builder.newInstance("v4").setStartLocation(Location.newInstance("start")).build();
         builder.addVehicle(v1).addVehicle(v2).addVehicle(v3).addVehicle(v4);
         VehicleRoutingProblem vrp = builder.build();
-        assertEquals(4, vrp.getVehicles().size());
-        assertEquals(1, vrp.getAllLocations().size());
+        Assertions.assertEquals(4, vrp.getVehicles().size());
+        Assertions.assertEquals(1, vrp.getAllLocations().size());
     }
 
     @Test
@@ -107,7 +106,7 @@ class VehicleRoutingProblemTest {
         VehicleImpl v4 = VehicleImpl.Builder.newInstance("v4").setStartLocation(Location.newInstance("start")).build();
         builder.addAllVehicles(Arrays.asList(v1, v2, v3, v4));
         VehicleRoutingProblem vrp = builder.build();
-        assertEquals(4, vrp.getVehicles().size());
+        Assertions.assertEquals(4, vrp.getVehicles().size());
     }
 
     @Test
@@ -122,7 +121,7 @@ class VehicleRoutingProblemTest {
         VehicleImpl v4 = VehicleImpl.Builder.newInstance("v4").setStartLocation(Location.newInstance("yo")).setType(type2).build();
         builder.addVehicle(v1).addVehicle(v2).addVehicle(v3).addVehicle(v4);
         VehicleRoutingProblem vrp = builder.build();
-        assertEquals(2, vrp.getTypes().size());
+        Assertions.assertEquals(2, vrp.getTypes().size());
     }
 
     @Test
@@ -134,10 +133,10 @@ class VehicleRoutingProblemTest {
         vrpBuilder.addJob(s);
         vrpBuilder.addJob(s2);
         VehicleRoutingProblem vrp = vrpBuilder.build();
-        assertEquals(2, vrp.getJobs().size());
-        assertEquals(s, vrp.getJobs().get("s"));
-        assertEquals(s2, vrp.getJobs().get("s2"));
-        assertEquals(2, vrp.getAllLocations().size());
+        Assertions.assertEquals(2, vrp.getJobs().size());
+        Assertions.assertEquals(s, vrp.getJobs().get("s"));
+        Assertions.assertEquals(s2, vrp.getJobs().get("s2"));
+        Assertions.assertEquals(2, vrp.getAllLocations().size());
     }
 
     @Test
@@ -148,11 +147,11 @@ class VehicleRoutingProblemTest {
         VehicleRoutingProblem.Builder vrpBuilder = VehicleRoutingProblem.Builder.newInstance();
         vrpBuilder.addJob(s1).addJob(s2);
         VehicleRoutingProblem vrp = vrpBuilder.build();
-        assertEquals(2, vrp.getJobs().size());
-        assertEquals(s1, vrp.getJobs().get("s1"));
-        assertEquals(s2, vrp.getJobs().get("s2"));
-        assertEquals(1, vrp.getAllLocations().size());
-        assertEquals(1, vrp.getJobsWithLocation().size());
+        Assertions.assertEquals(2, vrp.getJobs().size());
+        Assertions.assertEquals(s1, vrp.getJobs().get("s1"));
+        Assertions.assertEquals(s2, vrp.getJobs().get("s2"));
+        Assertions.assertEquals(1, vrp.getAllLocations().size());
+        Assertions.assertEquals(1, vrp.getJobsWithLocation().size());
     }
 
     @Test
@@ -163,10 +162,10 @@ class VehicleRoutingProblemTest {
         VehicleRoutingProblem.Builder vrpBuilder = VehicleRoutingProblem.Builder.newInstance();
         vrpBuilder.addJob(s1).addJob(s2);
         VehicleRoutingProblem vrp = vrpBuilder.build();
-        assertEquals(2, vrp.getJobs().size());
-        assertEquals(s1, vrp.getJobs().get("s1"));
-        assertEquals(s2, vrp.getJobs().get("s2"));
-        assertEquals(1, vrp.getAllLocations().size());
+        Assertions.assertEquals(2, vrp.getJobs().size());
+        Assertions.assertEquals(s1, vrp.getJobs().get("s1"));
+        Assertions.assertEquals(s2, vrp.getJobs().get("s2"));
+        Assertions.assertEquals(1, vrp.getAllLocations().size());
     }
 
     @Test
@@ -181,9 +180,9 @@ class VehicleRoutingProblemTest {
         VehicleRoutingProblem.Builder vrpBuilder = VehicleRoutingProblem.Builder.newInstance();
         vrpBuilder.addJob(s1).addJob(s2);
         VehicleRoutingProblem vrp = vrpBuilder.build();
-        assertEquals(2, vrp.getJobs().size());
-        assertEquals(s1, vrp.getJobs().get("s1"));
-        assertEquals(s2, vrp.getJobs().get("s2"));
+        Assertions.assertEquals(2, vrp.getJobs().size());
+        Assertions.assertEquals(s1, vrp.getJobs().get("s1"));
+        Assertions.assertEquals(s2, vrp.getJobs().get("s2"));
     }
 
     @Test
@@ -198,9 +197,9 @@ class VehicleRoutingProblemTest {
         VehicleRoutingProblem.Builder vrpBuilder = VehicleRoutingProblem.Builder.newInstance();
         vrpBuilder.addAllJobs(Arrays.asList(s1, s2));
         VehicleRoutingProblem vrp = vrpBuilder.build();
-        assertEquals(2, vrp.getJobs().size());
-        assertEquals(s1, vrp.getJobs().get("s1"));
-        assertEquals(s2, vrp.getJobs().get("s2"));
+        Assertions.assertEquals(2, vrp.getJobs().size());
+        Assertions.assertEquals(s1, vrp.getJobs().get("s1"));
+        Assertions.assertEquals(s2, vrp.getJobs().get("s2"));
     }
 
     @Test
@@ -217,9 +216,9 @@ class VehicleRoutingProblemTest {
         VehicleRoutingProblem.Builder vrpBuilder = VehicleRoutingProblem.Builder.newInstance();
         vrpBuilder.addJob(s1).addJob(s2);
         VehicleRoutingProblem vrp = vrpBuilder.build();
-        assertEquals(2, vrp.getJobs().size());
-        assertEquals(s1, vrp.getJobs().get("s1"));
-        assertEquals(s2, vrp.getJobs().get("s2"));
+        Assertions.assertEquals(2, vrp.getJobs().size());
+        Assertions.assertEquals(s1, vrp.getJobs().get("s1"));
+        Assertions.assertEquals(s2, vrp.getJobs().get("s2"));
     }
 
     @Test
@@ -236,9 +235,9 @@ class VehicleRoutingProblemTest {
         VehicleRoutingProblem.Builder vrpBuilder = VehicleRoutingProblem.Builder.newInstance();
         vrpBuilder.addAllJobs(Arrays.asList(s1, s2));
         VehicleRoutingProblem vrp = vrpBuilder.build();
-        assertEquals(2, vrp.getJobs().size());
-        assertEquals(s1, vrp.getJobs().get("s1"));
-        assertEquals(s2, vrp.getJobs().get("s2"));
+        Assertions.assertEquals(2, vrp.getJobs().size());
+        Assertions.assertEquals(s1, vrp.getJobs().get("s1"));
+        Assertions.assertEquals(s2, vrp.getJobs().get("s2"));
     }
 
     @Test
@@ -256,9 +255,9 @@ class VehicleRoutingProblemTest {
         VehicleRoutingProblem.Builder vrpBuilder = VehicleRoutingProblem.Builder.newInstance();
         vrpBuilder.addAllJobs(services);
         VehicleRoutingProblem vrp = vrpBuilder.build();
-        assertEquals(2, vrp.getJobs().size());
-        assertEquals(s1, vrp.getJobs().get("s1"));
-        assertEquals(s2, vrp.getJobs().get("s2"));
+        Assertions.assertEquals(2, vrp.getJobs().size());
+        Assertions.assertEquals(s1, vrp.getJobs().get("s1"));
+        Assertions.assertEquals(s2, vrp.getJobs().get("s2"));
     }
 
     @Test
@@ -278,7 +277,7 @@ class VehicleRoutingProblemTest {
             }
         });
         VehicleRoutingProblem problem = builder.build();
-        assertEquals(4.0, problem.getActivityCosts().getActivityCost(null, 0.0, null, null), 0.01);
+        Assertions.assertEquals(4.0, problem.getActivityCosts().getActivityCost(null, 0.0, null, null), 0.01);
     }
 
     @Test
@@ -303,7 +302,8 @@ class VehicleRoutingProblemTest {
             }
         });
         VehicleRoutingProblem problem = builder.build();
-        assertEquals(4.0, problem.getTransportCosts().getTransportCost(loc(""), loc(""), 0.0, null, null), 0.01);
+        Assertions.assertEquals(4.0, problem.getTransportCosts().getTransportCost(loc(""), loc(""), 0.0, null, null),
+                0.01);
     }
 
     private Location loc(String i) {
@@ -313,7 +313,7 @@ class VehicleRoutingProblemTest {
     @Test
     @DisplayName("When Adding Vehicles With Same Id _ it Should Throw Exception")
     void whenAddingVehiclesWithSameId_itShouldThrowException() {
-        assertThrows(IllegalArgumentException.class, () -> {
+        Assertions.assertThrows(IllegalArgumentException.class, () -> {
             VehicleRoutingProblem.Builder builder = VehicleRoutingProblem.Builder.newInstance();
             VehicleType type = VehicleTypeImpl.Builder.newInstance("type").build();
             VehicleImpl vehicle1 = VehicleImpl.Builder.newInstance("v").setStartLocation(Location.newInstance("loc")).setType(type).build();
@@ -326,7 +326,7 @@ class VehicleRoutingProblemTest {
     @Test
     @DisplayName("When Adding Vehicle Types With Same Id But Different Costs _ it Should Throw Exception")
     void whenAddingVehicleTypesWithSameIdButDifferentCosts_itShouldThrowException() {
-        assertThrows(IllegalArgumentException.class, () -> {
+        Assertions.assertThrows(IllegalArgumentException.class, () -> {
             VehicleRoutingProblem.Builder builder = VehicleRoutingProblem.Builder.newInstance();
             VehicleType type1 = VehicleTypeImpl.Builder.newInstance("type").build();
             VehicleType type2 = VehicleTypeImpl.Builder.newInstance("type").setCostPerServiceTime(2d).build();
@@ -340,7 +340,7 @@ class VehicleRoutingProblemTest {
     @Test
     @DisplayName("When Building Problem With Same Break Id _ it Should Throw Exception")
     void whenBuildingProblemWithSameBreakId_itShouldThrowException() {
-        assertThrows(IllegalArgumentException.class, () -> {
+        Assertions.assertThrows(IllegalArgumentException.class, () -> {
             VehicleRoutingProblem.Builder builder = VehicleRoutingProblem.Builder.newInstance();
             VehicleType type = VehicleTypeImpl.Builder.newInstance("type").build();
             VehicleImpl vehicle1 = VehicleImpl.Builder.newInstance("v1").setStartLocation(Location.newInstance("loc")).setType(type).setBreak(Break.Builder.newInstance("break").build()).build();
@@ -359,8 +359,8 @@ class VehicleRoutingProblemTest {
         VehicleType type = VehicleTypeImpl.Builder.newInstance("type").build();
         VehicleImpl vehicle = VehicleImpl.Builder.newInstance("v").setStartLocation(Location.newInstance("loc")).setType(type).build();
         builder.addVehicle(vehicle);
-        assertEquals(1, builder.getAddedVehicleTypes().size());
-        assertEquals(type, builder.getAddedVehicleTypes().iterator().next());
+        Assertions.assertEquals(1, builder.getAddedVehicleTypes().size());
+        Assertions.assertEquals(type, builder.getAddedVehicleTypes().iterator().next());
     }
 
     @Test
@@ -372,8 +372,8 @@ class VehicleRoutingProblemTest {
         VehicleImpl vehicle2 = VehicleImpl.Builder.newInstance("v2").setStartLocation(Location.newInstance("loc")).setType(type).build();
         builder.addVehicle(vehicle);
         builder.addVehicle(vehicle2);
-        assertEquals(1, builder.getAddedVehicleTypes().size());
-        assertEquals(type, builder.getAddedVehicleTypes().iterator().next());
+        Assertions.assertEquals(1, builder.getAddedVehicleTypes().size());
+        Assertions.assertEquals(type, builder.getAddedVehicleTypes().iterator().next());
     }
 
     @Test
@@ -386,7 +386,7 @@ class VehicleRoutingProblemTest {
         VehicleImpl vehicle2 = VehicleImpl.Builder.newInstance("v2").setStartLocation(Location.newInstance("loc")).setType(type2).build();
         builder.addVehicle(vehicle);
         builder.addVehicle(vehicle2);
-        assertEquals(2, builder.getAddedVehicleTypes().size());
+        Assertions.assertEquals(2, builder.getAddedVehicleTypes().size());
     }
 
     @Test
@@ -395,7 +395,7 @@ class VehicleRoutingProblemTest {
         VehicleImpl vehicle = VehicleImpl.Builder.newInstance("v").setStartLocation(Location.newInstance("start")).setEndLocation(Location.newInstance("end")).build();
         VehicleRoutingProblem.Builder vrpBuilder = VehicleRoutingProblem.Builder.newInstance();
         vrpBuilder.addVehicle(vehicle);
-        assertTrue(vrpBuilder.getLocationMap().containsKey("start"));
+        Assertions.assertTrue(vrpBuilder.getLocationMap().containsKey("start"));
     }
 
     @Test
@@ -404,7 +404,7 @@ class VehicleRoutingProblemTest {
         VehicleImpl vehicle = VehicleImpl.Builder.newInstance("v").setStartLocation(Location.newInstance("start")).setEndLocation(Location.newInstance("end")).build();
         VehicleRoutingProblem.Builder vrpBuilder = VehicleRoutingProblem.Builder.newInstance();
         vrpBuilder.addVehicle(vehicle);
-        assertTrue(vrpBuilder.getLocationMap().containsKey("end"));
+        Assertions.assertTrue(vrpBuilder.getLocationMap().containsKey("end"));
     }
 
     @Test
@@ -415,7 +415,7 @@ class VehicleRoutingProblemTest {
         VehicleRoutingProblem.Builder vrpBuilder = VehicleRoutingProblem.Builder.newInstance();
         vrpBuilder.addInitialVehicleRoute(route);
         VehicleRoutingProblem vrp = vrpBuilder.build();
-        assertTrue(!vrp.getInitialVehicleRoutes().isEmpty());
+        Assertions.assertTrue(!vrp.getInitialVehicleRoutes().isEmpty());
     }
 
     @Test
@@ -428,8 +428,8 @@ class VehicleRoutingProblemTest {
         VehicleRoutingProblem.Builder vrpBuilder = VehicleRoutingProblem.Builder.newInstance();
         vrpBuilder.addInitialVehicleRoutes(Arrays.asList(route1, route2));
         VehicleRoutingProblem vrp = vrpBuilder.build();
-        assertEquals(2, vrp.getInitialVehicleRoutes().size());
-        assertEquals(2, vrp.getAllLocations().size());
+        Assertions.assertEquals(2, vrp.getInitialVehicleRoutes().size());
+        Assertions.assertEquals(2, vrp.getAllLocations().size());
     }
 
     @Test
@@ -442,8 +442,8 @@ class VehicleRoutingProblemTest {
         VehicleRoutingProblem.Builder vrpBuilder = VehicleRoutingProblem.Builder.newInstance();
         vrpBuilder.addInitialVehicleRoute(route);
         VehicleRoutingProblem vrp = vrpBuilder.build();
-        assertThat(vrp.getAllLocations(), hasItem(start));
-        assertThat(vrp.getAllLocations(), hasItem(end));
+        Assertions.assertTrue(vrp.getAllLocations().contains(start));
+        Assertions.assertTrue(vrp.getAllLocations().contains(end));
     }
 
     @Test
@@ -456,8 +456,8 @@ class VehicleRoutingProblemTest {
         VehicleRoute initialRoute = VehicleRoute.Builder.newInstance(vehicle).addService(service).build();
         vrpBuilder.addInitialVehicleRoute(initialRoute);
         VehicleRoutingProblem vrp = vrpBuilder.build();
-        assertFalse(vrp.getJobs().containsKey("myService"));
-        assertEquals(3, vrp.getAllLocations().size());
+        Assertions.assertFalse(vrp.getJobs().containsKey("myService"));
+        Assertions.assertEquals(3, vrp.getAllLocations().size());
     }
 
     @Test
@@ -469,15 +469,15 @@ class VehicleRoutingProblemTest {
         vrpBuilder.addJob(service);
         vrpBuilder.addJob(shipment);
         VehicleRoutingProblem vrp = vrpBuilder.build();
-        assertEquals(1, service.getIndex());
-        assertEquals(2, shipment.getIndex());
-        assertEquals(3, vrp.getAllLocations().size());
+        Assertions.assertEquals(1, service.getIndex());
+        Assertions.assertEquals(2, shipment.getIndex());
+        Assertions.assertEquals(3, vrp.getAllLocations().size());
     }
 
     @Test
     @DisplayName("When Adding Two Services With The Same Id _ it Should Throw Exception")
     void whenAddingTwoServicesWithTheSameId_itShouldThrowException() {
-        assertThrows(IllegalArgumentException.class, () -> {
+        Assertions.assertThrows(IllegalArgumentException.class, () -> {
             Service service1 = Service.Builder.newInstance("myService").setLocation(Location.newInstance("loc")).build();
             Service service2 = Service.Builder.newInstance("myService").setLocation(Location.newInstance("loc")).build();
             VehicleRoutingProblem.Builder vrpBuilder = VehicleRoutingProblem.Builder.newInstance();
@@ -491,7 +491,7 @@ class VehicleRoutingProblemTest {
     @Test
     @DisplayName("When Adding Two Shipments With The Same Id _ it Should Throw Exception")
     void whenAddingTwoShipmentsWithTheSameId_itShouldThrowException() {
-        assertThrows(IllegalArgumentException.class, () -> {
+        Assertions.assertThrows(IllegalArgumentException.class, () -> {
             Shipment shipment1 = Shipment.Builder.newInstance("shipment").setPickupLocation(Location.Builder.newInstance().setId("pick").build()).setDeliveryLocation(Location.newInstance("del")).build();
             Shipment shipment2 = Shipment.Builder.newInstance("shipment").setPickupLocation(Location.Builder.newInstance().setId("pick").build()).setDeliveryLocation(Location.newInstance("del")).build();
             VehicleRoutingProblem.Builder vrpBuilder = VehicleRoutingProblem.Builder.newInstance();
@@ -511,8 +511,8 @@ class VehicleRoutingProblemTest {
         vrpBuilder.addVehicle(veh1);
         vrpBuilder.addVehicle(veh2);
         vrpBuilder.build();
-        assertEquals(1, veh1.getIndex());
-        assertEquals(2, veh2.getIndex());
+        Assertions.assertEquals(1, veh1.getIndex());
+        Assertions.assertEquals(2, veh2.getIndex());
     }
 
     @Test
@@ -524,8 +524,8 @@ class VehicleRoutingProblemTest {
         vrpBuilder.addVehicle(veh1);
         vrpBuilder.addVehicle(veh2);
         vrpBuilder.build();
-        assertEquals(1, veh1.getVehicleTypeIdentifier().getIndex());
-        assertEquals(1, veh2.getVehicleTypeIdentifier().getIndex());
+        Assertions.assertEquals(1, veh1.getVehicleTypeIdentifier().getIndex());
+        Assertions.assertEquals(1, veh2.getVehicleTypeIdentifier().getIndex());
     }
 
     @Test
@@ -537,7 +537,7 @@ class VehicleRoutingProblemTest {
         vrpBuilder.addVehicle(veh1);
         vrpBuilder.addVehicle(veh2);
         vrpBuilder.build();
-        assertEquals(1, veh1.getVehicleTypeIdentifier().getIndex());
-        assertEquals(2, veh2.getVehicleTypeIdentifier().getIndex());
+        Assertions.assertEquals(1, veh1.getVehicleTypeIdentifier().getIndex());
+        Assertions.assertEquals(2, veh2.getVehicleTypeIdentifier().getIndex());
     }
 }

--- a/jsprit-core/src/test/java/com/graphhopper/jsprit/core/problem/constraint/LoadConstraintTest.java
+++ b/jsprit-core/src/test/java/com/graphhopper/jsprit/core/problem/constraint/LoadConstraintTest.java
@@ -25,6 +25,8 @@ import com.graphhopper.jsprit.core.problem.solution.route.VehicleRoute;
 import com.graphhopper.jsprit.core.problem.solution.route.activity.*;
 import com.graphhopper.jsprit.core.problem.vehicle.Vehicle;
 import com.graphhopper.jsprit.core.problem.vehicle.VehicleType;
+
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -32,7 +34,6 @@ import org.junit.jupiter.api.Test;
 import java.util.Collections;
 import java.util.List;
 
-import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -115,7 +116,7 @@ class LoadConstraintTest {
         when(s.getSize()).thenReturn(Capacity.Builder.newInstance().addDimension(0, 5).build());
         ServiceLoadRouteLevelConstraint loadconstraint = new ServiceLoadRouteLevelConstraint(stateManager);
         JobInsertionContext context = new JobInsertionContext(serviceRoute, s, serviceRoute.getVehicle(), null, 0.);
-        assertTrue(loadconstraint.fulfilled(context));
+        Assertions.assertTrue(loadconstraint.fulfilled(context));
     }
 
     private static Service createMock(Capacity size) {
@@ -166,7 +167,7 @@ class LoadConstraintTest {
         when(newAct.getSize()).thenReturn(size);
         when(newAct.getJob()).thenReturn(s);
         HardActivityConstraint.ConstraintsStatus status = loadConstraint.fulfilled(context, serviceRoute.getStart(), newAct, serviceRoute.getActivities().get(0), 0.);
-        assertEquals(HardActivityConstraint.ConstraintsStatus.FULFILLED, status);
+        Assertions.assertEquals(HardActivityConstraint.ConstraintsStatus.FULFILLED, status);
     }
 
     @Test
@@ -181,7 +182,7 @@ class LoadConstraintTest {
         when(newAct.getSize()).thenReturn(size);
         when(newAct.getJob()).thenReturn(s);
         HardActivityConstraint.ConstraintsStatus status = loadConstraint.fulfilled(context, serviceRoute.getActivities().get(0), newAct, serviceRoute.getActivities().get(1), 0.);
-        assertEquals(HardActivityConstraint.ConstraintsStatus.FULFILLED, status);
+        Assertions.assertEquals(HardActivityConstraint.ConstraintsStatus.FULFILLED, status);
     }
 
     @Test
@@ -196,7 +197,7 @@ class LoadConstraintTest {
         when(newAct.getSize()).thenReturn(size);
         when(newAct.getJob()).thenReturn(s);
         HardActivityConstraint.ConstraintsStatus status = loadConstraint.fulfilled(context, serviceRoute.getActivities().get(1), newAct, serviceRoute.getEnd(), 0.);
-        assertEquals(HardActivityConstraint.ConstraintsStatus.FULFILLED, status);
+        Assertions.assertEquals(HardActivityConstraint.ConstraintsStatus.FULFILLED, status);
     }
 
     /*
@@ -214,7 +215,7 @@ class LoadConstraintTest {
         when(newAct.getSize()).thenReturn(size);
         when(newAct.getJob()).thenReturn(s);
         HardActivityConstraint.ConstraintsStatus status = loadConstraint.fulfilled(context, serviceRoute.getStart(), newAct, serviceRoute.getActivities().get(0), 0.);
-        assertEquals(HardActivityConstraint.ConstraintsStatus.NOT_FULFILLED, status);
+        Assertions.assertEquals(HardActivityConstraint.ConstraintsStatus.NOT_FULFILLED, status);
     }
 
     @Test
@@ -229,7 +230,7 @@ class LoadConstraintTest {
         when(newAct.getSize()).thenReturn(size);
         when(newAct.getJob()).thenReturn(s);
         HardActivityConstraint.ConstraintsStatus status = loadConstraint.fulfilled(context, serviceRoute.getActivities().get(0), newAct, serviceRoute.getActivities().get(1), 0.);
-        assertEquals(HardActivityConstraint.ConstraintsStatus.NOT_FULFILLED, status);
+        Assertions.assertEquals(HardActivityConstraint.ConstraintsStatus.NOT_FULFILLED, status);
     }
 
     @Test
@@ -244,7 +245,7 @@ class LoadConstraintTest {
         when(newAct.getSize()).thenReturn(size);
         when(newAct.getJob()).thenReturn(s);
         HardActivityConstraint.ConstraintsStatus status = loadConstraint.fulfilled(context, serviceRoute.getActivities().get(1), newAct, serviceRoute.getEnd(), 0.);
-        assertEquals(HardActivityConstraint.ConstraintsStatus.NOT_FULFILLED, status);
+        Assertions.assertEquals(HardActivityConstraint.ConstraintsStatus.NOT_FULFILLED, status);
     }
 
     @Test
@@ -254,7 +255,7 @@ class LoadConstraintTest {
         Service s = createMock(Capacity.Builder.newInstance().addDimension(0, 6).build());
         ServiceLoadRouteLevelConstraint loadconstraint = new ServiceLoadRouteLevelConstraint(stateManager);
         JobInsertionContext context = new JobInsertionContext(serviceRoute, s, serviceRoute.getVehicle(), null, 0.);
-        assertFalse(loadconstraint.fulfilled(context));
+        Assertions.assertFalse(loadconstraint.fulfilled(context));
     }
 
     /*
@@ -269,7 +270,7 @@ class LoadConstraintTest {
         Pickup s = createPickupMock(Capacity.Builder.newInstance().addDimension(0, 10).build());
         ServiceLoadRouteLevelConstraint loadconstraint = new ServiceLoadRouteLevelConstraint(stateManager);
         JobInsertionContext context = new JobInsertionContext(pickup_delivery_route, s, serviceRoute.getVehicle(), null, 0.);
-        assertTrue(loadconstraint.fulfilled(context));
+        Assertions.assertTrue(loadconstraint.fulfilled(context));
     }
 
     @Test
@@ -279,7 +280,7 @@ class LoadConstraintTest {
         Delivery s = createDeliveryMock(Capacity.Builder.newInstance().addDimension(0, 15).build());
         ServiceLoadRouteLevelConstraint loadconstraint = new ServiceLoadRouteLevelConstraint(stateManager);
         JobInsertionContext context = new JobInsertionContext(pickup_delivery_route, s, serviceRoute.getVehicle(), null, 0.);
-        assertTrue(loadconstraint.fulfilled(context));
+        Assertions.assertTrue(loadconstraint.fulfilled(context));
     }
 
     @Test
@@ -289,7 +290,7 @@ class LoadConstraintTest {
         Pickup s = createPickupMock(Capacity.Builder.newInstance().addDimension(0, 11).build());
         ServiceLoadRouteLevelConstraint loadconstraint = new ServiceLoadRouteLevelConstraint(stateManager);
         JobInsertionContext context = new JobInsertionContext(pickup_delivery_route, s, serviceRoute.getVehicle(), null, 0.);
-        assertFalse(loadconstraint.fulfilled(context));
+        Assertions.assertFalse(loadconstraint.fulfilled(context));
     }
 
     @Test
@@ -299,7 +300,7 @@ class LoadConstraintTest {
         Delivery s = createDeliveryMock(Capacity.Builder.newInstance().addDimension(0, 16).build());
         ServiceLoadRouteLevelConstraint loadconstraint = new ServiceLoadRouteLevelConstraint(stateManager);
         JobInsertionContext context = new JobInsertionContext(pickup_delivery_route, s, serviceRoute.getVehicle(), null, 0.);
-        assertFalse(loadconstraint.fulfilled(context));
+        Assertions.assertFalse(loadconstraint.fulfilled(context));
     }
 
     /*
@@ -314,7 +315,7 @@ class LoadConstraintTest {
         JobInsertionContext context = new JobInsertionContext(pickup_delivery_route, s, pickup_delivery_route.getVehicle(), null, 0.);
         PickupService newAct = new PickupService(s);
         HardActivityConstraint.ConstraintsStatus status = loadConstraint.fulfilled(context, pickup_delivery_route.getStart(), newAct, pickup_delivery_route.getActivities().get(0), 0.);
-        assertEquals(HardActivityConstraint.ConstraintsStatus.FULFILLED, status);
+        Assertions.assertEquals(HardActivityConstraint.ConstraintsStatus.FULFILLED, status);
     }
 
     @Test
@@ -326,7 +327,7 @@ class LoadConstraintTest {
         JobInsertionContext context = new JobInsertionContext(pickup_delivery_route, s, pickup_delivery_route.getVehicle(), null, 0.);
         PickupService newAct = new PickupService(s);
         HardActivityConstraint.ConstraintsStatus status = loadConstraint.fulfilled(context, pickup_delivery_route.getActivities().get(0), newAct, pickup_delivery_route.getActivities().get(1), 0.);
-        assertEquals(HardActivityConstraint.ConstraintsStatus.FULFILLED, status);
+        Assertions.assertEquals(HardActivityConstraint.ConstraintsStatus.FULFILLED, status);
     }
 
     @Test
@@ -338,7 +339,7 @@ class LoadConstraintTest {
         JobInsertionContext context = new JobInsertionContext(pickup_delivery_route, s, pickup_delivery_route.getVehicle(), null, 0.);
         PickupService newAct = new PickupService(s);
         HardActivityConstraint.ConstraintsStatus status = loadConstraint.fulfilled(context, pickup_delivery_route.getActivities().get(1), newAct, pickup_delivery_route.getEnd(), 0.);
-        assertEquals(HardActivityConstraint.ConstraintsStatus.FULFILLED, status);
+        Assertions.assertEquals(HardActivityConstraint.ConstraintsStatus.FULFILLED, status);
     }
 
     /*
@@ -353,7 +354,7 @@ class LoadConstraintTest {
         JobInsertionContext context = new JobInsertionContext(pickup_delivery_route, s, pickup_delivery_route.getVehicle(), null, 0.);
         PickupService newAct = new PickupService(s);
         HardActivityConstraint.ConstraintsStatus status = loadConstraint.fulfilled(context, pickup_delivery_route.getStart(), newAct, pickup_delivery_route.getActivities().get(0), 0.);
-        assertEquals(HardActivityConstraint.ConstraintsStatus.NOT_FULFILLED, status);
+        Assertions.assertEquals(HardActivityConstraint.ConstraintsStatus.NOT_FULFILLED, status);
     }
 
     @Test
@@ -365,7 +366,7 @@ class LoadConstraintTest {
         JobInsertionContext context = new JobInsertionContext(pickup_delivery_route, s, pickup_delivery_route.getVehicle(), null, 0.);
         PickupService newAct = new PickupService(s);
         HardActivityConstraint.ConstraintsStatus status = loadConstraint.fulfilled(context, pickup_delivery_route.getActivities().get(0), newAct, pickup_delivery_route.getActivities().get(1), 0.);
-        assertEquals(HardActivityConstraint.ConstraintsStatus.NOT_FULFILLED, status);
+        Assertions.assertEquals(HardActivityConstraint.ConstraintsStatus.NOT_FULFILLED, status);
     }
 
     @Test
@@ -377,7 +378,7 @@ class LoadConstraintTest {
         JobInsertionContext context = new JobInsertionContext(pickup_delivery_route, s, pickup_delivery_route.getVehicle(), null, 0.);
         PickupService newAct = new PickupService(s);
         HardActivityConstraint.ConstraintsStatus status = loadConstraint.fulfilled(context, pickup_delivery_route.getActivities().get(1), newAct, pickup_delivery_route.getEnd(), 0.);
-        assertEquals(HardActivityConstraint.ConstraintsStatus.NOT_FULFILLED, status);
+        Assertions.assertEquals(HardActivityConstraint.ConstraintsStatus.NOT_FULFILLED, status);
     }
 
     /*
@@ -392,7 +393,7 @@ class LoadConstraintTest {
         JobInsertionContext context = new JobInsertionContext(pickup_delivery_route, s, pickup_delivery_route.getVehicle(), null, 0.);
         DeliverService newAct = new DeliverService(s);
         HardActivityConstraint.ConstraintsStatus status = loadConstraint.fulfilled(context, pickup_delivery_route.getStart(), newAct, pickup_delivery_route.getActivities().get(0), 0.);
-        assertEquals(HardActivityConstraint.ConstraintsStatus.FULFILLED, status);
+        Assertions.assertEquals(HardActivityConstraint.ConstraintsStatus.FULFILLED, status);
     }
 
     @Test
@@ -404,7 +405,7 @@ class LoadConstraintTest {
         JobInsertionContext context = new JobInsertionContext(pickup_delivery_route, s, pickup_delivery_route.getVehicle(), null, 0.);
         DeliverService newAct = new DeliverService(s);
         HardActivityConstraint.ConstraintsStatus status = loadConstraint.fulfilled(context, pickup_delivery_route.getStart(), newAct, pickup_delivery_route.getActivities().get(0), 0.);
-        assertEquals(HardActivityConstraint.ConstraintsStatus.NOT_FULFILLED_BREAK, status);
+        Assertions.assertEquals(HardActivityConstraint.ConstraintsStatus.NOT_FULFILLED_BREAK, status);
     }
 
     @Test
@@ -416,7 +417,7 @@ class LoadConstraintTest {
         JobInsertionContext context = new JobInsertionContext(pickup_delivery_route, s, pickup_delivery_route.getVehicle(), null, 0.);
         DeliverService newAct = new DeliverService(s);
         HardActivityConstraint.ConstraintsStatus status = loadConstraint.fulfilled(context, pickup_delivery_route.getActivities().get(0), newAct, pickup_delivery_route.getActivities().get(1), 0.);
-        assertEquals(HardActivityConstraint.ConstraintsStatus.FULFILLED, status);
+        Assertions.assertEquals(HardActivityConstraint.ConstraintsStatus.FULFILLED, status);
     }
 
     @Test
@@ -428,7 +429,7 @@ class LoadConstraintTest {
         JobInsertionContext context = new JobInsertionContext(pickup_delivery_route, s, pickup_delivery_route.getVehicle(), null, 0.);
         DeliverService newAct = new DeliverService(s);
         HardActivityConstraint.ConstraintsStatus status = loadConstraint.fulfilled(context, pickup_delivery_route.getActivities().get(0), newAct, pickup_delivery_route.getActivities().get(1), 0.);
-        assertEquals(HardActivityConstraint.ConstraintsStatus.NOT_FULFILLED_BREAK, status);
+        Assertions.assertEquals(HardActivityConstraint.ConstraintsStatus.NOT_FULFILLED_BREAK, status);
     }
 
     @Test
@@ -440,7 +441,7 @@ class LoadConstraintTest {
         JobInsertionContext context = new JobInsertionContext(pickup_delivery_route, s, pickup_delivery_route.getVehicle(), null, 0.);
         DeliverService newAct = new DeliverService(s);
         HardActivityConstraint.ConstraintsStatus status = loadConstraint.fulfilled(context, pickup_delivery_route.getActivities().get(1), newAct, pickup_delivery_route.getEnd(), 0.);
-        assertEquals(HardActivityConstraint.ConstraintsStatus.FULFILLED, status);
+        Assertions.assertEquals(HardActivityConstraint.ConstraintsStatus.FULFILLED, status);
     }
 
     @Test
@@ -452,7 +453,7 @@ class LoadConstraintTest {
         JobInsertionContext context = new JobInsertionContext(pickup_delivery_route, s, pickup_delivery_route.getVehicle(), null, 0.);
         DeliverService newAct = new DeliverService(s);
         HardActivityConstraint.ConstraintsStatus status = loadConstraint.fulfilled(context, pickup_delivery_route.getActivities().get(1), newAct, pickup_delivery_route.getEnd(), 0.);
-        assertEquals(HardActivityConstraint.ConstraintsStatus.NOT_FULFILLED_BREAK, status);
+        Assertions.assertEquals(HardActivityConstraint.ConstraintsStatus.NOT_FULFILLED_BREAK, status);
     }
 
     @Test
@@ -467,7 +468,7 @@ class LoadConstraintTest {
         when(newAct.getSize()).thenReturn(size);
         when(newAct.getJob()).thenReturn(s);
         HardActivityConstraint.ConstraintsStatus status = loadConstraint.fulfilled(context, serviceRoute.getActivities().get(0), newAct, serviceRoute.getActivities().get(1), 0.);
-        assertEquals(HardActivityConstraint.ConstraintsStatus.FULFILLED, status);
+        Assertions.assertEquals(HardActivityConstraint.ConstraintsStatus.FULFILLED, status);
     }
 
     @Test
@@ -482,7 +483,7 @@ class LoadConstraintTest {
         when(newAct.getSize()).thenReturn(size);
         when(newAct.getJob()).thenReturn(s);
         HardActivityConstraint.ConstraintsStatus status = loadConstraint.fulfilled(context, serviceRoute.getActivities().get(1), newAct, serviceRoute.getEnd(), 0.);
-        assertEquals(HardActivityConstraint.ConstraintsStatus.FULFILLED, status);
+        Assertions.assertEquals(HardActivityConstraint.ConstraintsStatus.FULFILLED, status);
     }
 
     /*
@@ -500,7 +501,7 @@ class LoadConstraintTest {
         when(newAct.getSize()).thenReturn(size);
         when(newAct.getJob()).thenReturn(s);
         HardActivityConstraint.ConstraintsStatus status = loadConstraint.fulfilled(context, serviceRoute.getStart(), newAct, serviceRoute.getActivities().get(0), 0.);
-        assertEquals(HardActivityConstraint.ConstraintsStatus.NOT_FULFILLED, status);
+        Assertions.assertEquals(HardActivityConstraint.ConstraintsStatus.NOT_FULFILLED, status);
     }
 
     @Test
@@ -515,7 +516,7 @@ class LoadConstraintTest {
         when(newAct.getSize()).thenReturn(size);
         when(newAct.getJob()).thenReturn(s);
         HardActivityConstraint.ConstraintsStatus status = loadConstraint.fulfilled(context, serviceRoute.getActivities().get(0), newAct, serviceRoute.getActivities().get(1), 0.);
-        assertEquals(HardActivityConstraint.ConstraintsStatus.NOT_FULFILLED, status);
+        Assertions.assertEquals(HardActivityConstraint.ConstraintsStatus.NOT_FULFILLED, status);
     }
 
     @Test
@@ -530,7 +531,7 @@ class LoadConstraintTest {
         when(newAct.getSize()).thenReturn(size);
         when(newAct.getJob()).thenReturn(s);
         HardActivityConstraint.ConstraintsStatus status = loadConstraint.fulfilled(context, serviceRoute.getActivities().get(1), newAct, serviceRoute.getEnd(), 0.);
-        assertEquals(HardActivityConstraint.ConstraintsStatus.NOT_FULFILLED, status);
+        Assertions.assertEquals(HardActivityConstraint.ConstraintsStatus.NOT_FULFILLED, status);
     }
 
     @Test
@@ -540,7 +541,7 @@ class LoadConstraintTest {
         Service s = createMock(Capacity.Builder.newInstance().addDimension(0, 6).build());
         ServiceLoadRouteLevelConstraint loadconstraint = new ServiceLoadRouteLevelConstraint(stateManager);
         JobInsertionContext context = new JobInsertionContext(serviceRoute, s, serviceRoute.getVehicle(), null, 0.);
-        assertFalse(loadconstraint.fulfilled(context));
+        Assertions.assertFalse(loadconstraint.fulfilled(context));
     }
 
     /*
@@ -560,7 +561,7 @@ pickup(s1) pickup(s2) delivery(s2) deliver(s1)
         PickupShipment newAct = new PickupShipment(s);
         PickupAndDeliverShipmentLoadActivityLevelConstraint loadConstraint = new PickupAndDeliverShipmentLoadActivityLevelConstraint(stateManager);
         HardActivityConstraint.ConstraintsStatus status = loadConstraint.fulfilled(context, shipment_route.getStart(), newAct, shipment_route.getActivities().get(0), 0.);
-        assertEquals(HardActivityConstraint.ConstraintsStatus.FULFILLED, status);
+        Assertions.assertEquals(HardActivityConstraint.ConstraintsStatus.FULFILLED, status);
     }
 
     @Test
@@ -573,7 +574,7 @@ pickup(s1) pickup(s2) delivery(s2) deliver(s1)
         PickupShipment newAct = new PickupShipment(s);
         PickupAndDeliverShipmentLoadActivityLevelConstraint loadConstraint = new PickupAndDeliverShipmentLoadActivityLevelConstraint(stateManager);
         HardActivityConstraint.ConstraintsStatus status = loadConstraint.fulfilled(context, shipment_route.getStart(), newAct, shipment_route.getActivities().get(0), 0.);
-        assertEquals(HardActivityConstraint.ConstraintsStatus.NOT_FULFILLED, status);
+        Assertions.assertEquals(HardActivityConstraint.ConstraintsStatus.NOT_FULFILLED, status);
     }
 
     @Test
@@ -586,7 +587,7 @@ pickup(s1) pickup(s2) delivery(s2) deliver(s1)
         PickupShipment newAct = new PickupShipment(s);
         PickupAndDeliverShipmentLoadActivityLevelConstraint loadConstraint = new PickupAndDeliverShipmentLoadActivityLevelConstraint(stateManager);
         HardActivityConstraint.ConstraintsStatus status = loadConstraint.fulfilled(context, shipment_route.getActivities().get(0), newAct, shipment_route.getActivities().get(1), 0.);
-        assertEquals(HardActivityConstraint.ConstraintsStatus.FULFILLED, status);
+        Assertions.assertEquals(HardActivityConstraint.ConstraintsStatus.FULFILLED, status);
     }
 
     @Test
@@ -599,7 +600,7 @@ pickup(s1) pickup(s2) delivery(s2) deliver(s1)
         PickupShipment newAct = new PickupShipment(s);
         PickupAndDeliverShipmentLoadActivityLevelConstraint loadConstraint = new PickupAndDeliverShipmentLoadActivityLevelConstraint(stateManager);
         HardActivityConstraint.ConstraintsStatus status = loadConstraint.fulfilled(context, shipment_route.getActivities().get(0), newAct, shipment_route.getActivities().get(1), 0.);
-        assertEquals(HardActivityConstraint.ConstraintsStatus.NOT_FULFILLED, status);
+        Assertions.assertEquals(HardActivityConstraint.ConstraintsStatus.NOT_FULFILLED, status);
     }
 
     @Test
@@ -612,7 +613,7 @@ pickup(s1) pickup(s2) delivery(s2) deliver(s1)
         PickupShipment newAct = new PickupShipment(s);
         PickupAndDeliverShipmentLoadActivityLevelConstraint loadConstraint = new PickupAndDeliverShipmentLoadActivityLevelConstraint(stateManager);
         HardActivityConstraint.ConstraintsStatus status = loadConstraint.fulfilled(context, shipment_route.getActivities().get(1), newAct, shipment_route.getActivities().get(2), 0.);
-        assertEquals(HardActivityConstraint.ConstraintsStatus.FULFILLED, status);
+        Assertions.assertEquals(HardActivityConstraint.ConstraintsStatus.FULFILLED, status);
     }
 
     @Test
@@ -625,7 +626,7 @@ pickup(s1) pickup(s2) delivery(s2) deliver(s1)
         PickupShipment newAct = new PickupShipment(s);
         PickupAndDeliverShipmentLoadActivityLevelConstraint loadConstraint = new PickupAndDeliverShipmentLoadActivityLevelConstraint(stateManager);
         HardActivityConstraint.ConstraintsStatus status = loadConstraint.fulfilled(context, shipment_route.getActivities().get(1), newAct, shipment_route.getActivities().get(2), 0.);
-        assertEquals(HardActivityConstraint.ConstraintsStatus.NOT_FULFILLED, status);
+        Assertions.assertEquals(HardActivityConstraint.ConstraintsStatus.NOT_FULFILLED, status);
     }
 
     @Test
@@ -638,7 +639,7 @@ pickup(s1) pickup(s2) delivery(s2) deliver(s1)
         PickupShipment newAct = new PickupShipment(s);
         PickupAndDeliverShipmentLoadActivityLevelConstraint loadConstraint = new PickupAndDeliverShipmentLoadActivityLevelConstraint(stateManager);
         HardActivityConstraint.ConstraintsStatus status = loadConstraint.fulfilled(context, shipment_route.getActivities().get(2), newAct, shipment_route.getActivities().get(3), 0.);
-        assertEquals(HardActivityConstraint.ConstraintsStatus.FULFILLED, status);
+        Assertions.assertEquals(HardActivityConstraint.ConstraintsStatus.FULFILLED, status);
     }
 
     @Test
@@ -651,7 +652,7 @@ pickup(s1) pickup(s2) delivery(s2) deliver(s1)
         PickupShipment newAct = new PickupShipment(s);
         PickupAndDeliverShipmentLoadActivityLevelConstraint loadConstraint = new PickupAndDeliverShipmentLoadActivityLevelConstraint(stateManager);
         HardActivityConstraint.ConstraintsStatus status = loadConstraint.fulfilled(context, shipment_route.getActivities().get(2), newAct, shipment_route.getActivities().get(3), 0.);
-        assertEquals(HardActivityConstraint.ConstraintsStatus.NOT_FULFILLED, status);
+        Assertions.assertEquals(HardActivityConstraint.ConstraintsStatus.NOT_FULFILLED, status);
     }
 
     @Test
@@ -664,7 +665,7 @@ pickup(s1) pickup(s2) delivery(s2) deliver(s1)
         PickupShipment newAct = new PickupShipment(s);
         PickupAndDeliverShipmentLoadActivityLevelConstraint loadConstraint = new PickupAndDeliverShipmentLoadActivityLevelConstraint(stateManager);
         HardActivityConstraint.ConstraintsStatus status = loadConstraint.fulfilled(context, shipment_route.getActivities().get(3), newAct, shipment_route.getEnd(), 0.);
-        assertEquals(HardActivityConstraint.ConstraintsStatus.FULFILLED, status);
+        Assertions.assertEquals(HardActivityConstraint.ConstraintsStatus.FULFILLED, status);
     }
 
     @Test
@@ -677,7 +678,7 @@ pickup(s1) pickup(s2) delivery(s2) deliver(s1)
         PickupShipment newAct = new PickupShipment(s);
         PickupAndDeliverShipmentLoadActivityLevelConstraint loadConstraint = new PickupAndDeliverShipmentLoadActivityLevelConstraint(stateManager);
         HardActivityConstraint.ConstraintsStatus status = loadConstraint.fulfilled(context, shipment_route.getActivities().get(3), newAct, shipment_route.getEnd(), 0.);
-        assertEquals(HardActivityConstraint.ConstraintsStatus.NOT_FULFILLED, status);
+        Assertions.assertEquals(HardActivityConstraint.ConstraintsStatus.NOT_FULFILLED, status);
     }
 
     /*
@@ -693,7 +694,7 @@ pickup(s1) pickup(s2) delivery(s2) deliver(s1)
         DeliverShipment newAct = new DeliverShipment(s);
         PickupAndDeliverShipmentLoadActivityLevelConstraint loadConstraint = new PickupAndDeliverShipmentLoadActivityLevelConstraint(stateManager);
         HardActivityConstraint.ConstraintsStatus status = loadConstraint.fulfilled(context, shipment_route.getStart(), newAct, shipment_route.getActivities().get(0), 0.);
-        assertEquals(HardActivityConstraint.ConstraintsStatus.FULFILLED, status);
+        Assertions.assertEquals(HardActivityConstraint.ConstraintsStatus.FULFILLED, status);
     }
 
     @Test
@@ -706,7 +707,7 @@ pickup(s1) pickup(s2) delivery(s2) deliver(s1)
         DeliverShipment newAct = new DeliverShipment(s);
         PickupAndDeliverShipmentLoadActivityLevelConstraint loadConstraint = new PickupAndDeliverShipmentLoadActivityLevelConstraint(stateManager);
         HardActivityConstraint.ConstraintsStatus status = loadConstraint.fulfilled(context, shipment_route.getStart(), newAct, shipment_route.getActivities().get(0), 0.);
-        assertEquals(HardActivityConstraint.ConstraintsStatus.NOT_FULFILLED_BREAK, status);
+        Assertions.assertEquals(HardActivityConstraint.ConstraintsStatus.NOT_FULFILLED_BREAK, status);
     }
 
     @Test
@@ -719,7 +720,7 @@ pickup(s1) pickup(s2) delivery(s2) deliver(s1)
         DeliverShipment newAct = new DeliverShipment(s);
         PickupAndDeliverShipmentLoadActivityLevelConstraint loadConstraint = new PickupAndDeliverShipmentLoadActivityLevelConstraint(stateManager);
         HardActivityConstraint.ConstraintsStatus status = loadConstraint.fulfilled(context, shipment_route.getActivities().get(0), newAct, shipment_route.getActivities().get(1), 0.);
-        assertEquals(HardActivityConstraint.ConstraintsStatus.FULFILLED, status);
+        Assertions.assertEquals(HardActivityConstraint.ConstraintsStatus.FULFILLED, status);
     }
 
     @Test
@@ -732,7 +733,7 @@ pickup(s1) pickup(s2) delivery(s2) deliver(s1)
         DeliverShipment newAct = new DeliverShipment(s);
         PickupAndDeliverShipmentLoadActivityLevelConstraint loadConstraint = new PickupAndDeliverShipmentLoadActivityLevelConstraint(stateManager);
         HardActivityConstraint.ConstraintsStatus status = loadConstraint.fulfilled(context, shipment_route.getActivities().get(0), newAct, shipment_route.getActivities().get(1), 0.);
-        assertEquals(HardActivityConstraint.ConstraintsStatus.NOT_FULFILLED_BREAK, status);
+        Assertions.assertEquals(HardActivityConstraint.ConstraintsStatus.NOT_FULFILLED_BREAK, status);
     }
 
     @Test
@@ -745,7 +746,7 @@ pickup(s1) pickup(s2) delivery(s2) deliver(s1)
         DeliverShipment newAct = new DeliverShipment(s);
         PickupAndDeliverShipmentLoadActivityLevelConstraint loadConstraint = new PickupAndDeliverShipmentLoadActivityLevelConstraint(stateManager);
         HardActivityConstraint.ConstraintsStatus status = loadConstraint.fulfilled(context, shipment_route.getActivities().get(1), newAct, shipment_route.getActivities().get(2), 0.);
-        assertEquals(HardActivityConstraint.ConstraintsStatus.FULFILLED, status);
+        Assertions.assertEquals(HardActivityConstraint.ConstraintsStatus.FULFILLED, status);
     }
 
     @Test
@@ -758,7 +759,7 @@ pickup(s1) pickup(s2) delivery(s2) deliver(s1)
         DeliverShipment newAct = new DeliverShipment(s);
         PickupAndDeliverShipmentLoadActivityLevelConstraint loadConstraint = new PickupAndDeliverShipmentLoadActivityLevelConstraint(stateManager);
         HardActivityConstraint.ConstraintsStatus status = loadConstraint.fulfilled(context, shipment_route.getActivities().get(1), newAct, shipment_route.getActivities().get(2), 0.);
-        assertEquals(HardActivityConstraint.ConstraintsStatus.NOT_FULFILLED_BREAK, status);
+        Assertions.assertEquals(HardActivityConstraint.ConstraintsStatus.NOT_FULFILLED_BREAK, status);
     }
 
     @Test
@@ -771,7 +772,7 @@ pickup(s1) pickup(s2) delivery(s2) deliver(s1)
         DeliverShipment newAct = new DeliverShipment(s);
         PickupAndDeliverShipmentLoadActivityLevelConstraint loadConstraint = new PickupAndDeliverShipmentLoadActivityLevelConstraint(stateManager);
         HardActivityConstraint.ConstraintsStatus status = loadConstraint.fulfilled(context, shipment_route.getActivities().get(2), newAct, shipment_route.getActivities().get(3), 0.);
-        assertEquals(HardActivityConstraint.ConstraintsStatus.FULFILLED, status);
+        Assertions.assertEquals(HardActivityConstraint.ConstraintsStatus.FULFILLED, status);
     }
 
     @Test
@@ -784,7 +785,7 @@ pickup(s1) pickup(s2) delivery(s2) deliver(s1)
         DeliverShipment newAct = new DeliverShipment(s);
         PickupAndDeliverShipmentLoadActivityLevelConstraint loadConstraint = new PickupAndDeliverShipmentLoadActivityLevelConstraint(stateManager);
         HardActivityConstraint.ConstraintsStatus status = loadConstraint.fulfilled(context, shipment_route.getActivities().get(2), newAct, shipment_route.getActivities().get(3), 0.);
-        assertEquals(HardActivityConstraint.ConstraintsStatus.NOT_FULFILLED_BREAK, status);
+        Assertions.assertEquals(HardActivityConstraint.ConstraintsStatus.NOT_FULFILLED_BREAK, status);
     }
 
     @Test
@@ -797,7 +798,7 @@ pickup(s1) pickup(s2) delivery(s2) deliver(s1)
         DeliverShipment newAct = new DeliverShipment(s);
         PickupAndDeliverShipmentLoadActivityLevelConstraint loadConstraint = new PickupAndDeliverShipmentLoadActivityLevelConstraint(stateManager);
         HardActivityConstraint.ConstraintsStatus status = loadConstraint.fulfilled(context, shipment_route.getActivities().get(3), newAct, shipment_route.getEnd(), 0.);
-        assertEquals(HardActivityConstraint.ConstraintsStatus.FULFILLED, status);
+        Assertions.assertEquals(HardActivityConstraint.ConstraintsStatus.FULFILLED, status);
     }
 
     @Test
@@ -810,6 +811,6 @@ pickup(s1) pickup(s2) delivery(s2) deliver(s1)
         DeliverShipment newAct = new DeliverShipment(s);
         PickupAndDeliverShipmentLoadActivityLevelConstraint loadConstraint = new PickupAndDeliverShipmentLoadActivityLevelConstraint(stateManager);
         HardActivityConstraint.ConstraintsStatus status = loadConstraint.fulfilled(context, shipment_route.getActivities().get(3), newAct, shipment_route.getEnd(), 0.);
-        assertEquals(HardActivityConstraint.ConstraintsStatus.NOT_FULFILLED_BREAK, status);
+        Assertions.assertEquals(HardActivityConstraint.ConstraintsStatus.NOT_FULFILLED_BREAK, status);
     }
 }

--- a/jsprit-core/src/test/java/com/graphhopper/jsprit/core/problem/constraint/MaxTimeInVehicleConstraintTest.java
+++ b/jsprit-core/src/test/java/com/graphhopper/jsprit/core/problem/constraint/MaxTimeInVehicleConstraintTest.java
@@ -269,8 +269,9 @@ class MaxTimeInVehicleConstraintTest {
         Assertions.assertTrue(true);
     }
 
-    // @Test(expected = UnsupportedOperationException.class)
+    // @Test
     // public void insertingPickupShouldWork(){
+	// Assertions.assertThrows(UnsupportedOperationException.class, () -> {
     // ini(30, Double.MAX_VALUE, 30);
     // VehicleRoute r = VehicleRoute.Builder.newInstance(v).setJobActivityFactory(vrp.getJobActivityFactory())
     // .addPickup(p1).addPickup(s1).addDelivery(s1).build();
@@ -288,10 +289,25 @@ class MaxTimeInVehicleConstraintTest {
     // c.getAssociatedActivities().add(acts.get(0));
     //
     //
-    // Assert.assertEquals("p2 cannot be done at first pos. due to its own max in-vehicle time restriction",HardActivityConstraint.ConstraintsStatus.NOT_FULFILLED, constraint.fulfilled(c, r.getStart(), acts.get(0), r.getActivities().get(0), 0));
-    // Assert.assertEquals("p2 cannot be done at second pos. due to its own max in-vehicle time restriction",HardActivityConstraint.ConstraintsStatus.NOT_FULFILLED, constraint.fulfilled(c, r.getActivities().get(0), acts.get(0), r.getActivities().get(1), 10));
-    // Assert.assertEquals("p2 cannot be done at third pos. due to its own max in-vehicle time restriction", HardActivityConstraint.ConstraintsStatus.NOT_FULFILLED, constraint.fulfilled(c, r.getActivities().get(1), acts.get(0), r.getActivities().get(2), 20));
-    // Assert.assertEquals("p2 can be done at last", HardActivityConstraint.ConstraintsStatus.FULFILLED, constraint.fulfilled(c, r.getActivities().get(2), acts.get(0), r.getEnd(), 40));
+	// Assertions.assertEquals("p2 cannot be done at first pos. due to its own max
+	// in-vehicle time
+	// restriction",HardActivityConstraint.ConstraintsStatus.NOT_FULFILLED,
+	// constraint.fulfilled(c, r.getStart(), acts.get(0), r.getActivities().get(0),
+	// 0));
+	// Assertions.assertEquals("p2 cannot be done at second pos. due to its own max
+	// in-vehicle time
+	// restriction",HardActivityConstraint.ConstraintsStatus.NOT_FULFILLED,
+	// constraint.fulfilled(c, r.getActivities().get(0), acts.get(0),
+	// r.getActivities().get(1), 10));
+	// Assertions.assertEquals("p2 cannot be done at third pos. due to its own max
+	// in-vehicle time restriction",
+	// HardActivityConstraint.ConstraintsStatus.NOT_FULFILLED,
+	// constraint.fulfilled(c, r.getActivities().get(1), acts.get(0),
+	// r.getActivities().get(2), 20));
+	// Assertions.assertEquals("p2 can be done at last",
+	// HardActivityConstraint.ConstraintsStatus.FULFILLED, constraint.fulfilled(c,
+	// r.getActivities().get(2), acts.get(0), r.getEnd(), 40));
+	// });
     // }
     @Test
     @DisplayName("When Pickup Is Inserted At 0 _ inserting Delivery Shipment Should Fail Where Constraint Is Broken")
@@ -344,6 +360,8 @@ class MaxTimeInVehicleConstraintTest {
         c.setRelatedActivityContext(ac);
         Assertions.assertEquals(HardActivityConstraint.ConstraintsStatus.FULFILLED, constraint.fulfilled(c, acts.get(0), acts.get(1), r.getActivities().get(1), 20));
         Assertions.assertEquals(HardActivityConstraint.ConstraintsStatus.NOT_FULFILLED, constraint.fulfilled(c, r.getActivities().get(1), acts.get(1), r.getEnd(), 40));
-        // Assert.assertEquals(HardActivityConstraint.ConstraintsStatus.NOT_FULFILLED, constraint.fulfilled(c, r.getActivities().get(1), acts.get(1), r.getEnd(), 40));
+		// Assertions.assertEquals(HardActivityConstraint.ConstraintsStatus.NOT_FULFILLED,
+		// constraint.fulfilled(c, r.getActivities().get(1), acts.get(1), r.getEnd(),
+		// 40));
     }
 }

--- a/jsprit-core/src/test/java/com/graphhopper/jsprit/core/problem/constraint/ServiceLoadRouteLevelConstraintTest.java
+++ b/jsprit-core/src/test/java/com/graphhopper/jsprit/core/problem/constraint/ServiceLoadRouteLevelConstraintTest.java
@@ -33,6 +33,8 @@ import com.graphhopper.jsprit.core.problem.vehicle.Vehicle;
 import com.graphhopper.jsprit.core.problem.vehicle.VehicleImpl;
 import com.graphhopper.jsprit.core.problem.vehicle.VehicleType;
 import com.graphhopper.jsprit.core.problem.vehicle.VehicleTypeImpl;
+
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -111,7 +113,7 @@ class ServiceLoadRouteLevelConstraintTest {
         when(iContext.getJob()).thenReturn(service);
         when(iContext.getRoute()).thenReturn(route);
         when(iContext.getNewVehicle()).thenReturn(vehicle);
-        assertTrue(constraint.fulfilled(iContext));
+        Assertions.assertTrue(constraint.fulfilled(iContext));
     }
 
     @Test
@@ -122,7 +124,7 @@ class ServiceLoadRouteLevelConstraintTest {
         when(iContext.getJob()).thenReturn(service);
         when(iContext.getRoute()).thenReturn(route);
         when(iContext.getNewVehicle()).thenReturn(vehicle);
-        assertFalse(constraint.fulfilled(iContext));
+        Assertions.assertFalse(constraint.fulfilled(iContext));
     }
 
     @Test
@@ -133,7 +135,7 @@ class ServiceLoadRouteLevelConstraintTest {
         when(iContext.getJob()).thenReturn(service);
         when(iContext.getRoute()).thenReturn(route);
         when(iContext.getNewVehicle()).thenReturn(vehicle);
-        assertFalse(constraint.fulfilled(iContext));
+        Assertions.assertFalse(constraint.fulfilled(iContext));
     }
 
     @Test
@@ -144,7 +146,7 @@ class ServiceLoadRouteLevelConstraintTest {
         when(iContext.getJob()).thenReturn(service);
         when(iContext.getRoute()).thenReturn(route);
         when(iContext.getNewVehicle()).thenReturn(vehicle);
-        assertTrue(constraint.fulfilled(iContext));
+        Assertions.assertTrue(constraint.fulfilled(iContext));
     }
 
     @Test
@@ -155,7 +157,7 @@ class ServiceLoadRouteLevelConstraintTest {
         when(iContext.getJob()).thenReturn(service);
         when(iContext.getRoute()).thenReturn(route);
         when(iContext.getNewVehicle()).thenReturn(vehicle);
-        assertTrue(constraint.fulfilled(iContext));
+        Assertions.assertTrue(constraint.fulfilled(iContext));
     }
 
     @Test
@@ -166,7 +168,7 @@ class ServiceLoadRouteLevelConstraintTest {
         when(iContext.getJob()).thenReturn(service);
         when(iContext.getRoute()).thenReturn(route);
         when(iContext.getNewVehicle()).thenReturn(vehicle);
-        assertFalse(constraint.fulfilled(iContext));
+        Assertions.assertFalse(constraint.fulfilled(iContext));
     }
 
     @Test
@@ -177,7 +179,7 @@ class ServiceLoadRouteLevelConstraintTest {
         when(iContext.getJob()).thenReturn(service);
         when(iContext.getRoute()).thenReturn(route);
         when(iContext.getNewVehicle()).thenReturn(vehicle);
-        assertFalse(constraint.fulfilled(iContext));
+        Assertions.assertFalse(constraint.fulfilled(iContext));
     }
 
     @Test
@@ -188,7 +190,7 @@ class ServiceLoadRouteLevelConstraintTest {
         when(iContext.getJob()).thenReturn(service);
         when(iContext.getRoute()).thenReturn(route);
         when(iContext.getNewVehicle()).thenReturn(vehicle);
-        assertTrue(constraint.fulfilled(iContext));
+        Assertions.assertTrue(constraint.fulfilled(iContext));
     }
 
     @Test
@@ -199,7 +201,7 @@ class ServiceLoadRouteLevelConstraintTest {
         when(iContext.getJob()).thenReturn(service);
         when(iContext.getRoute()).thenReturn(route);
         when(iContext.getNewVehicle()).thenReturn(vehicle);
-        assertTrue(constraint.fulfilled(iContext));
+        Assertions.assertTrue(constraint.fulfilled(iContext));
     }
 
     @Test
@@ -210,7 +212,7 @@ class ServiceLoadRouteLevelConstraintTest {
         when(iContext.getJob()).thenReturn(service);
         when(iContext.getRoute()).thenReturn(route);
         when(iContext.getNewVehicle()).thenReturn(vehicle);
-        assertFalse(constraint.fulfilled(iContext));
+        Assertions.assertFalse(constraint.fulfilled(iContext));
     }
 
     @Test
@@ -221,7 +223,7 @@ class ServiceLoadRouteLevelConstraintTest {
         when(iContext.getJob()).thenReturn(service);
         when(iContext.getRoute()).thenReturn(route);
         when(iContext.getNewVehicle()).thenReturn(vehicle);
-        assertFalse(constraint.fulfilled(iContext));
+        Assertions.assertFalse(constraint.fulfilled(iContext));
     }
 
     @Test
@@ -232,7 +234,7 @@ class ServiceLoadRouteLevelConstraintTest {
         when(iContext.getJob()).thenReturn(service);
         when(iContext.getRoute()).thenReturn(route);
         when(iContext.getNewVehicle()).thenReturn(vehicle);
-        assertTrue(constraint.fulfilled(iContext));
+        Assertions.assertTrue(constraint.fulfilled(iContext));
     }
 
     @Test
@@ -254,7 +256,7 @@ class ServiceLoadRouteLevelConstraintTest {
         when(vehicle.getType()).thenReturn(type);
         when(iContext.getNewVehicle()).thenReturn(vehicle);
         ServiceLoadRouteLevelConstraint constraint = new ServiceLoadRouteLevelConstraint(stateGetter);
-        assertFalse(constraint.fulfilled(iContext));
+        Assertions.assertFalse(constraint.fulfilled(iContext));
     }
 
     @Test
@@ -276,7 +278,7 @@ class ServiceLoadRouteLevelConstraintTest {
         when(vehicle.getType()).thenReturn(type);
         when(iContext.getNewVehicle()).thenReturn(vehicle);
         ServiceLoadRouteLevelConstraint constraint = new ServiceLoadRouteLevelConstraint(stateGetter);
-        assertFalse(constraint.fulfilled(iContext));
+        Assertions.assertFalse(constraint.fulfilled(iContext));
     }
 
     @Test
@@ -298,7 +300,7 @@ class ServiceLoadRouteLevelConstraintTest {
         when(vehicle.getType()).thenReturn(type);
         when(iContext.getNewVehicle()).thenReturn(vehicle);
         ServiceLoadRouteLevelConstraint constraint = new ServiceLoadRouteLevelConstraint(stateGetter);
-        assertFalse(constraint.fulfilled(iContext));
+        Assertions.assertFalse(constraint.fulfilled(iContext));
     }
 
     @Test
@@ -312,7 +314,7 @@ class ServiceLoadRouteLevelConstraintTest {
         VehicleRoute route = VehicleRoute.Builder.newInstance(vehicle).setJobActivityFactory(vrp.getJobActivityFactory()).addService(pickup2).build();
         stateManager.informInsertionStarts(Collections.singletonList(route), null);
         JobInsertionContext iContext = new JobInsertionContext(route, pickup, vehicle, null, 0.);
-        assertFalse(new ServiceLoadRouteLevelConstraint(stateManager).fulfilled(iContext));
+        Assertions.assertFalse(new ServiceLoadRouteLevelConstraint(stateManager).fulfilled(iContext));
     }
 
     @Test
@@ -326,7 +328,7 @@ class ServiceLoadRouteLevelConstraintTest {
         VehicleRoute route = VehicleRoute.Builder.newInstance(vehicle).setJobActivityFactory(vrp.getJobActivityFactory()).addService(serviceInRoute).build();
         stateManager.informInsertionStarts(Collections.singletonList(route), null);
         JobInsertionContext iContext = new JobInsertionContext(route, service, vehicle, null, 0.);
-        assertFalse(new ServiceLoadRouteLevelConstraint(stateManager).fulfilled(iContext));
+        Assertions.assertFalse(new ServiceLoadRouteLevelConstraint(stateManager).fulfilled(iContext));
     }
 
     private Service createPickup(String string, int i) {

--- a/jsprit-core/src/test/java/com/graphhopper/jsprit/core/problem/constraint/SkillConstraintTest.java
+++ b/jsprit-core/src/test/java/com/graphhopper/jsprit/core/problem/constraint/SkillConstraintTest.java
@@ -26,6 +26,8 @@ import com.graphhopper.jsprit.core.problem.solution.route.VehicleRoute;
 import com.graphhopper.jsprit.core.problem.vehicle.VehicleImpl;
 import com.graphhopper.jsprit.core.problem.vehicle.VehicleType;
 import com.graphhopper.jsprit.core.problem.vehicle.VehicleTypeImpl;
+
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -69,34 +71,34 @@ class SkillConstraintTest {
     @DisplayName("When Job To Be Inserted Requires Skills That New Vehicle Does Not Have _ it Should Return False")
     void whenJobToBeInsertedRequiresSkillsThatNewVehicleDoesNotHave_itShouldReturnFalse() {
         JobInsertionContext insertionContext = new JobInsertionContext(route, vrp.getJobs().get("s3"), vehicle, route.getDriver(), 0.);
-        assertFalse(skillConstraint.fulfilled(insertionContext));
+        Assertions.assertFalse(skillConstraint.fulfilled(insertionContext));
     }
 
     @Test
     @DisplayName("When Job To Be Inserted Requires Skills That Vehicle Have _ it Should Return True")
     void whenJobToBeInsertedRequiresSkillsThatVehicleHave_itShouldReturnTrue() {
         JobInsertionContext insertionContext = new JobInsertionContext(route, vrp.getJobs().get("s4"), vehicle, route.getDriver(), 0.);
-        assertTrue(skillConstraint.fulfilled(insertionContext));
+        Assertions.assertTrue(skillConstraint.fulfilled(insertionContext));
     }
 
     @Test
     @DisplayName("When Route To Be Overtaken Requires Skills That Vehicle Does Not Have _ it Should Return False")
     void whenRouteToBeOvertakenRequiresSkillsThatVehicleDoesNotHave_itShouldReturnFalse() {
         JobInsertionContext insertionContext = new JobInsertionContext(route, vrp.getJobs().get("s3"), vehicle2, route.getDriver(), 0.);
-        assertFalse(skillConstraint.fulfilled(insertionContext));
+        Assertions.assertFalse(skillConstraint.fulfilled(insertionContext));
     }
 
     @Test
     @DisplayName("When Route To Be Overtaken Requires Skills That Vehicle Does Not Have 2 _ it Should Return False")
     void whenRouteToBeOvertakenRequiresSkillsThatVehicleDoesNotHave2_itShouldReturnFalse() {
         JobInsertionContext insertionContext = new JobInsertionContext(route, vrp.getJobs().get("s4"), vehicle2, route.getDriver(), 0.);
-        assertFalse(skillConstraint.fulfilled(insertionContext));
+        Assertions.assertFalse(skillConstraint.fulfilled(insertionContext));
     }
 
     @Test
     @DisplayName("When Route To Be Overtaken Requires Skills That Vehicle Does Have _ it Should Return True")
     void whenRouteToBeOvertakenRequiresSkillsThatVehicleDoesHave_itShouldReturnTrue() {
         JobInsertionContext insertionContext = new JobInsertionContext(route, vrp.getJobs().get("s4"), vehicle, route.getDriver(), 0.);
-        assertTrue(skillConstraint.fulfilled(insertionContext));
+        Assertions.assertTrue(skillConstraint.fulfilled(insertionContext));
     }
 }

--- a/jsprit-core/src/test/java/com/graphhopper/jsprit/core/problem/constraint/SoftActivityConstraintManagerTest.java
+++ b/jsprit-core/src/test/java/com/graphhopper/jsprit/core/problem/constraint/SoftActivityConstraintManagerTest.java
@@ -19,6 +19,8 @@ package com.graphhopper.jsprit.core.problem.constraint;
 
 import com.graphhopper.jsprit.core.problem.misc.JobInsertionContext;
 import com.graphhopper.jsprit.core.problem.solution.route.activity.TourActivity;
+
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
@@ -34,9 +36,9 @@ class SoftActivityConstraintManagerTest {
     void whenAddingSoftConstraint_managerShouldHaveIt() {
         SoftActivityConstraint c = mock(SoftActivityConstraint.class);
         SoftActivityConstraintManager man = new SoftActivityConstraintManager();
-        assertEquals(0, man.getConstraints().size());
+        Assertions.assertEquals(0, man.getConstraints().size());
         man.addConstraint(c);
-        assertEquals(1, man.getConstraints().size());
+        Assertions.assertEquals(1, man.getConstraints().size());
     }
 
     @Test
@@ -45,10 +47,10 @@ class SoftActivityConstraintManagerTest {
         SoftActivityConstraint c1 = mock(SoftActivityConstraint.class);
         SoftActivityConstraint c2 = mock(SoftActivityConstraint.class);
         SoftActivityConstraintManager man = new SoftActivityConstraintManager();
-        assertEquals(0, man.getConstraints().size());
+        Assertions.assertEquals(0, man.getConstraints().size());
         man.addConstraint(c1);
         man.addConstraint(c2);
-        assertEquals(2, man.getConstraints().size());
+        Assertions.assertEquals(2, man.getConstraints().size());
     }
 
     @Test
@@ -65,6 +67,6 @@ class SoftActivityConstraintManagerTest {
         SoftActivityConstraintManager man = new SoftActivityConstraintManager();
         man.addConstraint(c1);
         man.addConstraint(c2);
-        assertEquals(3.0, man.getCosts(iContext, act_i, act_k, act_j, 0.0), 0.01);
+        Assertions.assertEquals(3.0, man.getCosts(iContext, act_i, act_k, act_j, 0.0), 0.01);
     }
 }

--- a/jsprit-core/src/test/java/com/graphhopper/jsprit/core/problem/constraint/SoftRouteConstraintManagerTest.java
+++ b/jsprit-core/src/test/java/com/graphhopper/jsprit/core/problem/constraint/SoftRouteConstraintManagerTest.java
@@ -18,6 +18,8 @@
 package com.graphhopper.jsprit.core.problem.constraint;
 
 import com.graphhopper.jsprit.core.problem.misc.JobInsertionContext;
+
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
@@ -33,9 +35,9 @@ class SoftRouteConstraintManagerTest {
     void whenAddingSoftRouteConstraint_managerShouldHaveIt() {
         SoftRouteConstraint c = mock(SoftRouteConstraint.class);
         SoftRouteConstraintManager man = new SoftRouteConstraintManager();
-        assertEquals(0, man.getConstraints().size());
+        Assertions.assertEquals(0, man.getConstraints().size());
         man.addConstraint(c);
-        assertEquals(1, man.getConstraints().size());
+        Assertions.assertEquals(1, man.getConstraints().size());
     }
 
     @Test
@@ -44,10 +46,10 @@ class SoftRouteConstraintManagerTest {
         SoftRouteConstraint c1 = mock(SoftRouteConstraint.class);
         SoftRouteConstraint c2 = mock(SoftRouteConstraint.class);
         SoftRouteConstraintManager man = new SoftRouteConstraintManager();
-        assertEquals(0, man.getConstraints().size());
+        Assertions.assertEquals(0, man.getConstraints().size());
         man.addConstraint(c1);
         man.addConstraint(c2);
-        assertEquals(2, man.getConstraints().size());
+        Assertions.assertEquals(2, man.getConstraints().size());
     }
 
     @Test
@@ -61,6 +63,6 @@ class SoftRouteConstraintManagerTest {
         SoftRouteConstraintManager man = new SoftRouteConstraintManager();
         man.addConstraint(c1);
         man.addConstraint(c2);
-        assertEquals(3.0, man.getCosts(iContext), 0.01);
+        Assertions.assertEquals(3.0, man.getCosts(iContext), 0.01);
     }
 }

--- a/jsprit-core/src/test/java/com/graphhopper/jsprit/core/problem/constraint/TestConstraintManager.java
+++ b/jsprit-core/src/test/java/com/graphhopper/jsprit/core/problem/constraint/TestConstraintManager.java
@@ -19,12 +19,12 @@ package com.graphhopper.jsprit.core.problem.constraint;
 
 import com.graphhopper.jsprit.core.problem.VehicleRoutingProblem;
 import com.graphhopper.jsprit.core.problem.solution.route.state.RouteAndActivityStateGetter;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.util.ArrayList;
 import java.util.List;
 
-import static org.junit.Assert.assertEquals;
+import org.junit.jupiter.api.Assertions;
 import static org.mockito.Mockito.mock;
 
 public class TestConstraintManager {
@@ -35,7 +35,7 @@ public class TestConstraintManager {
         constraints.add(new ServiceDeliveriesFirstConstraint());
         constraints.add(mock(HardRouteConstraint.class));
         ConstraintManager cManager = new ConstraintManager(mock(VehicleRoutingProblem.class), mock(RouteAndActivityStateGetter.class), constraints);
-        assertEquals(2, cManager.getConstraints().size());
+		Assertions.assertEquals(2, cManager.getConstraints().size());
     }
 
     @Test
@@ -44,16 +44,16 @@ public class TestConstraintManager {
         constraints.add(new ServiceDeliveriesFirstConstraint());
         constraints.add(mock(Constraint.class));
         ConstraintManager cManager = new ConstraintManager(mock(VehicleRoutingProblem.class), mock(RouteAndActivityStateGetter.class), constraints);
-        assertEquals(1, cManager.getConstraints().size());
+		Assertions.assertEquals(1, cManager.getConstraints().size());
     }
 
     @Test
     public void whenAddingSoftRouteConstraint_managerShouldHaveIt() {
         SoftRouteConstraint c = mock(SoftRouteConstraint.class);
         ConstraintManager man = new ConstraintManager(mock(VehicleRoutingProblem.class), mock(RouteAndActivityStateGetter.class));
-        assertEquals(0, man.getConstraints().size());
+		Assertions.assertEquals(0, man.getConstraints().size());
         man.addConstraint(c);
-        assertEquals(1, man.getConstraints().size());
+		Assertions.assertEquals(1, man.getConstraints().size());
     }
 
     @Test
@@ -61,19 +61,19 @@ public class TestConstraintManager {
         SoftRouteConstraint c1 = mock(SoftRouteConstraint.class);
         SoftRouteConstraint c2 = mock(SoftRouteConstraint.class);
         ConstraintManager man = new ConstraintManager(mock(VehicleRoutingProblem.class), mock(RouteAndActivityStateGetter.class));
-        assertEquals(0, man.getConstraints().size());
+		Assertions.assertEquals(0, man.getConstraints().size());
         man.addConstraint(c1);
         man.addConstraint(c2);
-        assertEquals(2, man.getConstraints().size());
+		Assertions.assertEquals(2, man.getConstraints().size());
     }
 
     @Test
     public void whenAddingSoftActivityConstraint_managerShouldHaveIt() {
         SoftActivityConstraint c = mock(SoftActivityConstraint.class);
         ConstraintManager man = new ConstraintManager(mock(VehicleRoutingProblem.class), mock(RouteAndActivityStateGetter.class));
-        assertEquals(0, man.getConstraints().size());
+		Assertions.assertEquals(0, man.getConstraints().size());
         man.addConstraint(c);
-        assertEquals(1, man.getConstraints().size());
+		Assertions.assertEquals(1, man.getConstraints().size());
     }
 
     @Test
@@ -81,10 +81,10 @@ public class TestConstraintManager {
         SoftActivityConstraint c1 = mock(SoftActivityConstraint.class);
         SoftActivityConstraint c2 = mock(SoftActivityConstraint.class);
         ConstraintManager man = new ConstraintManager(mock(VehicleRoutingProblem.class), mock(RouteAndActivityStateGetter.class));
-        assertEquals(0, man.getConstraints().size());
+		Assertions.assertEquals(0, man.getConstraints().size());
         man.addConstraint(c1);
         man.addConstraint(c2);
-        assertEquals(2, man.getConstraints().size());
+		Assertions.assertEquals(2, man.getConstraints().size());
     }
 
 }

--- a/jsprit-core/src/test/java/com/graphhopper/jsprit/core/problem/constraint/VehicleDependentTimeWindowTest.java
+++ b/jsprit-core/src/test/java/com/graphhopper/jsprit/core/problem/constraint/VehicleDependentTimeWindowTest.java
@@ -32,13 +32,13 @@ import com.graphhopper.jsprit.core.problem.solution.route.VehicleRoute;
 import com.graphhopper.jsprit.core.problem.solution.route.activity.PickupService;
 import com.graphhopper.jsprit.core.problem.vehicle.*;
 import com.graphhopper.jsprit.core.util.CostFactory;
+
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
 import java.util.*;
-
-import static org.junit.jupiter.api.Assertions.*;
 
 /**
  * unit tests to test vehicle dependent time-windows
@@ -120,19 +120,22 @@ class VehicleDependentTimeWindowTest {
     @Test
     @DisplayName("State Manager Should Have Memorized Correct Latest End Of Act 3")
     void stateManagerShouldHaveMemorizedCorrectLatestEndOfAct3() {
-        assertEquals(70., stateManager.getActivityState(route.getActivities().get(2), vehicle, InternalStates.LATEST_OPERATION_START_TIME, Double.class), 0.01);
+        Assertions.assertEquals(70., stateManager.getActivityState(route.getActivities().get(2), vehicle,
+                InternalStates.LATEST_OPERATION_START_TIME, Double.class), 0.01);
     }
 
     @Test
     @DisplayName("State Manager Should Have Memorized Correct Latest End Of Act 2")
     void stateManagerShouldHaveMemorizedCorrectLatestEndOfAct2() {
-        assertEquals(60., stateManager.getActivityState(route.getActivities().get(1), vehicle, InternalStates.LATEST_OPERATION_START_TIME, Double.class), 0.01);
+        Assertions.assertEquals(60., stateManager.getActivityState(route.getActivities().get(1), vehicle,
+                InternalStates.LATEST_OPERATION_START_TIME, Double.class), 0.01);
     }
 
     @Test
     @DisplayName("State Manager Should Have Memorized Correct Latest End Of Act 1")
     void stateManagerShouldHaveMemorizedCorrectLatestEndOfAct1() {
-        assertEquals(50., stateManager.getActivityState(route.getActivities().get(0), vehicle, InternalStates.LATEST_OPERATION_START_TIME, Double.class), 0.01);
+        Assertions.assertEquals(50., stateManager.getActivityState(route.getActivities().get(0), vehicle,
+                InternalStates.LATEST_OPERATION_START_TIME, Double.class), 0.01);
     }
 
     @Test
@@ -143,7 +146,7 @@ class VehicleDependentTimeWindowTest {
         JobInsertionContext insertionContext = new JobInsertionContext(route, s4, vehicle, route.getDriver(), 0.);
         HardActivityConstraint twConstraint = new VehicleDependentTimeWindowConstraints(stateManager, routingCosts, activityCosts);
         HardActivityConstraint.ConstraintsStatus status = twConstraint.fulfilled(insertionContext, route.getActivities().get(2), serviceAct, route.getEnd(), 30.);
-        assertTrue(status.equals(HardActivityConstraint.ConstraintsStatus.FULFILLED));
+        Assertions.assertTrue(status.equals(HardActivityConstraint.ConstraintsStatus.FULFILLED));
     }
 
     @Test
@@ -154,7 +157,7 @@ class VehicleDependentTimeWindowTest {
         JobInsertionContext insertionContext = new JobInsertionContext(route, s4, vehicle, route.getDriver(), 0.);
         HardActivityConstraint twConstraint = new VehicleDependentTimeWindowConstraints(stateManager, routingCosts, activityCosts);
         HardActivityConstraint.ConstraintsStatus status = twConstraint.fulfilled(insertionContext, route.getActivities().get(2), serviceAct, route.getEnd(), 30.);
-        assertFalse(status.equals(HardActivityConstraint.ConstraintsStatus.FULFILLED));
+        Assertions.assertFalse(status.equals(HardActivityConstraint.ConstraintsStatus.FULFILLED));
     }
 
     @Test
@@ -169,7 +172,7 @@ class VehicleDependentTimeWindowTest {
          */
         // System.out.println("latest act1 " + stateManager.getActivityState());
         HardActivityConstraint.ConstraintsStatus status = twConstraint.fulfilled(insertionContext, route.getActivities().get(1), serviceAct, route.getActivities().get(2), 20.);
-        assertTrue(status.equals(HardActivityConstraint.ConstraintsStatus.FULFILLED));
+        Assertions.assertTrue(status.equals(HardActivityConstraint.ConstraintsStatus.FULFILLED));
     }
 
     @Test
@@ -183,90 +186,90 @@ class VehicleDependentTimeWindowTest {
          */
         HardActivityConstraint twConstraint = new VehicleDependentTimeWindowConstraints(stateManager, routingCosts, activityCosts);
         HardActivityConstraint.ConstraintsStatus status = twConstraint.fulfilled(insertionContext, route.getActivities().get(1), serviceAct, route.getActivities().get(2), 20.);
-        assertFalse(status.equals(HardActivityConstraint.ConstraintsStatus.FULFILLED));
+        Assertions.assertFalse(status.equals(HardActivityConstraint.ConstraintsStatus.FULFILLED));
     }
 
     @Test
     @DisplayName("When Job Is Inserted Along With New Vehicle That Needs To Be Home At 60 _ it Should Return False")
     void whenJobIsInsertedAlongWithNewVehicleThatNeedsToBeHomeAt60_itShouldReturnFalse() {
-        assertEquals(60., route.getEnd().getArrTime(), 0.01);
+        Assertions.assertEquals(60., route.getEnd().getArrTime(), 0.01);
         Service s4 = Service.Builder.newInstance("s4").setLocation(Location.newInstance("40,0")).build();
         PickupService serviceAct = new PickupService(s4);
         JobInsertionContext insertionContext = new JobInsertionContext(route, s4, v2, route.getDriver(), 0.);
         HardActivityConstraint twConstraint = new VehicleDependentTimeWindowConstraints(stateManager, routingCosts, activityCosts);
         HardActivityConstraint.ConstraintsStatus status = twConstraint.fulfilled(insertionContext, route.getActivities().get(2), serviceAct, route.getEnd(), 30.);
-        assertFalse(status.equals(HardActivityConstraint.ConstraintsStatus.FULFILLED));
+        Assertions.assertFalse(status.equals(HardActivityConstraint.ConstraintsStatus.FULFILLED));
     }
 
     @Test
     @DisplayName("When Job Is Inserted Along With New Vehicle That Needs To Be Home At 50 _ it Should Return False")
     void whenJobIsInsertedAlongWithNewVehicleThatNeedsToBeHomeAt50_itShouldReturnFalse() {
-        assertEquals(60., route.getEnd().getArrTime(), 0.01);
+        Assertions.assertEquals(60., route.getEnd().getArrTime(), 0.01);
         Service s4 = Service.Builder.newInstance("s4").setLocation(Location.newInstance("40,0")).build();
         PickupService serviceAct = new PickupService(s4);
         JobInsertionContext insertionContext = new JobInsertionContext(route, s4, v3, route.getDriver(), 0.);
         HardActivityConstraint twConstraint = new VehicleDependentTimeWindowConstraints(stateManager, routingCosts, activityCosts);
         HardActivityConstraint.ConstraintsStatus status = twConstraint.fulfilled(insertionContext, route.getActivities().get(2), serviceAct, route.getEnd(), 30.);
-        assertFalse(status.equals(HardActivityConstraint.ConstraintsStatus.FULFILLED));
+        Assertions.assertFalse(status.equals(HardActivityConstraint.ConstraintsStatus.FULFILLED));
     }
 
     @Test
     @DisplayName("When Job Is Inserted Along With New Vehicle That Needs To Be Home At 10 _ it Should Return False")
     void whenJobIsInsertedAlongWithNewVehicleThatNeedsToBeHomeAt10_itShouldReturnFalse() {
-        assertEquals(60., route.getEnd().getArrTime(), 0.01);
+        Assertions.assertEquals(60., route.getEnd().getArrTime(), 0.01);
         Service s4 = Service.Builder.newInstance("s4").setLocation(Location.newInstance("40,0")).build();
         PickupService serviceAct = new PickupService(s4);
         JobInsertionContext insertionContext = new JobInsertionContext(route, s4, v4, route.getDriver(), 0.);
         HardActivityConstraint twConstraint = new VehicleDependentTimeWindowConstraints(stateManager, routingCosts, activityCosts);
         HardActivityConstraint.ConstraintsStatus status = twConstraint.fulfilled(insertionContext, route.getActivities().get(2), serviceAct, route.getEnd(), 30.);
-        assertFalse(status.equals(HardActivityConstraint.ConstraintsStatus.FULFILLED));
+        Assertions.assertFalse(status.equals(HardActivityConstraint.ConstraintsStatus.FULFILLED));
     }
 
     @Test
     @DisplayName("When Job Is Inserted Along With V 6 Between S 2 And S 3 _ it Should Return False")
     void whenJobIsInsertedAlongWithV6BetweenS2AndS3_itShouldReturnFalse() {
-        assertEquals(60., route.getEnd().getArrTime(), 0.01);
+        Assertions.assertEquals(60., route.getEnd().getArrTime(), 0.01);
         Service s4 = Service.Builder.newInstance("s4").setLocation(Location.newInstance("40,0")).build();
         PickupService serviceAct = new PickupService(s4);
         JobInsertionContext insertionContext = new JobInsertionContext(route, s4, v6, route.getDriver(), 0.);
         HardActivityConstraint twConstraint = new VehicleDependentTimeWindowConstraints(stateManager, routingCosts, activityCosts);
         HardActivityConstraint.ConstraintsStatus status = twConstraint.fulfilled(insertionContext, route.getActivities().get(1), serviceAct, route.getActivities().get(2), 30.);
-        assertFalse(status.equals(HardActivityConstraint.ConstraintsStatus.FULFILLED));
+        Assertions.assertFalse(status.equals(HardActivityConstraint.ConstraintsStatus.FULFILLED));
     }
 
     @Test
     @DisplayName("When Job Is Inserted Along With V 6 Between S 1 And S 2 _ it Should Return False")
     void whenJobIsInsertedAlongWithV6BetweenS1AndS2_itShouldReturnFalse() {
-        assertEquals(60., route.getEnd().getArrTime(), 0.01);
+        Assertions.assertEquals(60., route.getEnd().getArrTime(), 0.01);
         Service s4 = Service.Builder.newInstance("s4").setLocation(Location.newInstance("40,0")).build();
         PickupService serviceAct = new PickupService(s4);
         JobInsertionContext insertionContext = new JobInsertionContext(route, s4, v6, route.getDriver(), 0.);
         HardActivityConstraint twConstraint = new VehicleDependentTimeWindowConstraints(stateManager, routingCosts, activityCosts);
         HardActivityConstraint.ConstraintsStatus status = twConstraint.fulfilled(insertionContext, route.getActivities().get(0), serviceAct, route.getActivities().get(1), 10.);
-        assertFalse(status.equals(HardActivityConstraint.ConstraintsStatus.FULFILLED));
+        Assertions.assertFalse(status.equals(HardActivityConstraint.ConstraintsStatus.FULFILLED));
     }
 
     @Test
     @DisplayName("When Job Is Inserted Along With V 6 At The End Of Route _ it Should Return True")
     void whenJobIsInsertedAlongWithV6AtTheEndOfRoute_itShouldReturnTrue() {
-        assertEquals(60., route.getEnd().getArrTime(), 0.01);
+        Assertions.assertEquals(60., route.getEnd().getArrTime(), 0.01);
         Service s4 = Service.Builder.newInstance("s4").setLocation(Location.newInstance("40,0")).build();
         PickupService serviceAct = new PickupService(s4);
         JobInsertionContext insertionContext = new JobInsertionContext(route, s4, v6, route.getDriver(), 0.);
         HardActivityConstraint twConstraint = new VehicleDependentTimeWindowConstraints(stateManager, routingCosts, activityCosts);
         HardActivityConstraint.ConstraintsStatus status = twConstraint.fulfilled(insertionContext, route.getActivities().get(2), serviceAct, route.getEnd(), 30.);
-        assertTrue(status.equals(HardActivityConstraint.ConstraintsStatus.FULFILLED));
+        Assertions.assertTrue(status.equals(HardActivityConstraint.ConstraintsStatus.FULFILLED));
     }
 
     @Test
     @DisplayName("When Job Is Inserted Along With New Vehicle That Can Only Start At 60 _ it Should Return False")
     void whenJobIsInsertedAlongWithNewVehicleThatCanOnlyStartAt60_itShouldReturnFalse() {
-        assertEquals(60., route.getEnd().getArrTime(), 0.01);
+        Assertions.assertEquals(60., route.getEnd().getArrTime(), 0.01);
         Service s4 = Service.Builder.newInstance("s4").setLocation(Location.newInstance("40,0")).build();
         PickupService serviceAct = new PickupService(s4);
         JobInsertionContext insertionContext = new JobInsertionContext(route, s4, v5, route.getDriver(), 60.);
         HardActivityConstraint twConstraint = new VehicleDependentTimeWindowConstraints(stateManager, routingCosts, activityCosts);
         HardActivityConstraint.ConstraintsStatus status = twConstraint.fulfilled(insertionContext, route.getActivities().get(2), serviceAct, route.getEnd(), 90.);
-        assertFalse(status.equals(HardActivityConstraint.ConstraintsStatus.FULFILLED));
+        Assertions.assertFalse(status.equals(HardActivityConstraint.ConstraintsStatus.FULFILLED));
     }
 }

--- a/jsprit-core/src/test/java/com/graphhopper/jsprit/core/problem/constraint/VehicleDependentTimeWindowWithStartTimeAndMaxOperationTimeTest.java
+++ b/jsprit-core/src/test/java/com/graphhopper/jsprit/core/problem/constraint/VehicleDependentTimeWindowWithStartTimeAndMaxOperationTimeTest.java
@@ -32,13 +32,13 @@ import com.graphhopper.jsprit.core.problem.solution.route.VehicleRoute;
 import com.graphhopper.jsprit.core.problem.solution.route.activity.PickupService;
 import com.graphhopper.jsprit.core.problem.vehicle.*;
 import com.graphhopper.jsprit.core.util.CostFactory;
+
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
 import java.util.*;
-
-import static org.junit.jupiter.api.Assertions.*;
 
 /**
  * unit tests to test vehicle dependent time-windows
@@ -121,19 +121,22 @@ class VehicleDependentTimeWindowWithStartTimeAndMaxOperationTimeTest {
     @Test
     @DisplayName("State Manager Should Have Memorized Correct Latest End Of Act 3")
     void stateManagerShouldHaveMemorizedCorrectLatestEndOfAct3() {
-        assertEquals(70., stateManager.getActivityState(route.getActivities().get(2), vehicle, InternalStates.LATEST_OPERATION_START_TIME, Double.class), 0.01);
+        Assertions.assertEquals(70., stateManager.getActivityState(route.getActivities().get(2), vehicle,
+                InternalStates.LATEST_OPERATION_START_TIME, Double.class), 0.01);
     }
 
     @Test
     @DisplayName("State Manager Should Have Memorized Correct Latest End Of Act 2")
     void stateManagerShouldHaveMemorizedCorrectLatestEndOfAct2() {
-        assertEquals(60., stateManager.getActivityState(route.getActivities().get(1), vehicle, InternalStates.LATEST_OPERATION_START_TIME, Double.class), 0.01);
+        Assertions.assertEquals(60., stateManager.getActivityState(route.getActivities().get(1), vehicle,
+                InternalStates.LATEST_OPERATION_START_TIME, Double.class), 0.01);
     }
 
     @Test
     @DisplayName("State Manager Should Have Memorized Correct Latest End Of Act 1")
     void stateManagerShouldHaveMemorizedCorrectLatestEndOfAct1() {
-        assertEquals(50., stateManager.getActivityState(route.getActivities().get(0), vehicle, InternalStates.LATEST_OPERATION_START_TIME, Double.class), 0.01);
+        Assertions.assertEquals(50., stateManager.getActivityState(route.getActivities().get(0), vehicle,
+                InternalStates.LATEST_OPERATION_START_TIME, Double.class), 0.01);
     }
 
     @Test
@@ -144,7 +147,7 @@ class VehicleDependentTimeWindowWithStartTimeAndMaxOperationTimeTest {
         JobInsertionContext insertionContext = new JobInsertionContext(route, s4, vehicle, route.getDriver(), 0.);
         HardActivityConstraint twConstraint = new VehicleDependentTimeWindowConstraints(stateManager, routingCosts, activityCosts);
         HardActivityConstraint.ConstraintsStatus status = twConstraint.fulfilled(insertionContext, route.getActivities().get(2), serviceAct, route.getEnd(), 30.);
-        assertTrue(status.equals(HardActivityConstraint.ConstraintsStatus.FULFILLED));
+        Assertions.assertTrue(status.equals(HardActivityConstraint.ConstraintsStatus.FULFILLED));
     }
 
     @Test
@@ -155,7 +158,7 @@ class VehicleDependentTimeWindowWithStartTimeAndMaxOperationTimeTest {
         JobInsertionContext insertionContext = new JobInsertionContext(route, s4, vehicle, route.getDriver(), 0.);
         HardActivityConstraint twConstraint = new VehicleDependentTimeWindowConstraints(stateManager, routingCosts, activityCosts);
         HardActivityConstraint.ConstraintsStatus status = twConstraint.fulfilled(insertionContext, route.getActivities().get(2), serviceAct, route.getEnd(), 30.);
-        assertFalse(status.equals(HardActivityConstraint.ConstraintsStatus.FULFILLED));
+        Assertions.assertFalse(status.equals(HardActivityConstraint.ConstraintsStatus.FULFILLED));
     }
 
     @Test
@@ -170,7 +173,7 @@ class VehicleDependentTimeWindowWithStartTimeAndMaxOperationTimeTest {
          */
         // System.out.println("latest act1 " + stateManager.getActivityState());
         HardActivityConstraint.ConstraintsStatus status = twConstraint.fulfilled(insertionContext, route.getActivities().get(1), serviceAct, route.getActivities().get(2), 20.);
-        assertTrue(status.equals(HardActivityConstraint.ConstraintsStatus.FULFILLED));
+        Assertions.assertTrue(status.equals(HardActivityConstraint.ConstraintsStatus.FULFILLED));
     }
 
     @Test
@@ -184,90 +187,90 @@ class VehicleDependentTimeWindowWithStartTimeAndMaxOperationTimeTest {
          */
         HardActivityConstraint twConstraint = new VehicleDependentTimeWindowConstraints(stateManager, routingCosts, activityCosts);
         HardActivityConstraint.ConstraintsStatus status = twConstraint.fulfilled(insertionContext, route.getActivities().get(1), serviceAct, route.getActivities().get(2), 20.);
-        assertFalse(status.equals(HardActivityConstraint.ConstraintsStatus.FULFILLED));
+        Assertions.assertFalse(status.equals(HardActivityConstraint.ConstraintsStatus.FULFILLED));
     }
 
     @Test
     @DisplayName("When Job Is Inserted Along With New Vehicle That Needs To Be Home At 60 _ it Should Return False")
     void whenJobIsInsertedAlongWithNewVehicleThatNeedsToBeHomeAt60_itShouldReturnFalse() {
-        assertEquals(60., route.getEnd().getArrTime(), 0.01);
+        Assertions.assertEquals(60., route.getEnd().getArrTime(), 0.01);
         Service s4 = Service.Builder.newInstance("s4").setLocation(Location.newInstance("40,0")).build();
         PickupService serviceAct = new PickupService(s4);
         JobInsertionContext insertionContext = new JobInsertionContext(route, s4, v2, route.getDriver(), 0.);
         HardActivityConstraint twConstraint = new VehicleDependentTimeWindowConstraints(stateManager, routingCosts, activityCosts);
         HardActivityConstraint.ConstraintsStatus status = twConstraint.fulfilled(insertionContext, route.getActivities().get(2), serviceAct, route.getEnd(), 30.);
-        assertFalse(status.equals(HardActivityConstraint.ConstraintsStatus.FULFILLED));
+        Assertions.assertFalse(status.equals(HardActivityConstraint.ConstraintsStatus.FULFILLED));
     }
 
     @Test
     @DisplayName("When Job Is Inserted Along With New Vehicle That Needs To Be Home At 50 _ it Should Return False")
     void whenJobIsInsertedAlongWithNewVehicleThatNeedsToBeHomeAt50_itShouldReturnFalse() {
-        assertEquals(60., route.getEnd().getArrTime(), 0.01);
+        Assertions.assertEquals(60., route.getEnd().getArrTime(), 0.01);
         Service s4 = Service.Builder.newInstance("s4").setLocation(Location.newInstance("40,0")).build();
         PickupService serviceAct = new PickupService(s4);
         JobInsertionContext insertionContext = new JobInsertionContext(route, s4, v3, route.getDriver(), 0.);
         HardActivityConstraint twConstraint = new VehicleDependentTimeWindowConstraints(stateManager, routingCosts, activityCosts);
         HardActivityConstraint.ConstraintsStatus status = twConstraint.fulfilled(insertionContext, route.getActivities().get(2), serviceAct, route.getEnd(), 30.);
-        assertFalse(status.equals(HardActivityConstraint.ConstraintsStatus.FULFILLED));
+        Assertions.assertFalse(status.equals(HardActivityConstraint.ConstraintsStatus.FULFILLED));
     }
 
     @Test
     @DisplayName("When Job Is Inserted Along With New Vehicle That Needs To Be Home At 10 _ it Should Return False")
     void whenJobIsInsertedAlongWithNewVehicleThatNeedsToBeHomeAt10_itShouldReturnFalse() {
-        assertEquals(60., route.getEnd().getArrTime(), 0.01);
+        Assertions.assertEquals(60., route.getEnd().getArrTime(), 0.01);
         Service s4 = Service.Builder.newInstance("s4").setLocation(Location.newInstance("40,0")).build();
         PickupService serviceAct = new PickupService(s4);
         JobInsertionContext insertionContext = new JobInsertionContext(route, s4, v4, route.getDriver(), 0.);
         HardActivityConstraint twConstraint = new VehicleDependentTimeWindowConstraints(stateManager, routingCosts, activityCosts);
         HardActivityConstraint.ConstraintsStatus status = twConstraint.fulfilled(insertionContext, route.getActivities().get(2), serviceAct, route.getEnd(), 30.);
-        assertFalse(status.equals(HardActivityConstraint.ConstraintsStatus.FULFILLED));
+        Assertions.assertFalse(status.equals(HardActivityConstraint.ConstraintsStatus.FULFILLED));
     }
 
     @Test
     @DisplayName("When Job Is Inserted Along With V 6 Between S 2 And S 3 _ it Should Return False")
     void whenJobIsInsertedAlongWithV6BetweenS2AndS3_itShouldReturnFalse() {
-        assertEquals(60., route.getEnd().getArrTime(), 0.01);
+        Assertions.assertEquals(60., route.getEnd().getArrTime(), 0.01);
         Service s4 = Service.Builder.newInstance("s4").setLocation(Location.newInstance("40,0")).build();
         PickupService serviceAct = new PickupService(s4);
         JobInsertionContext insertionContext = new JobInsertionContext(route, s4, v6, route.getDriver(), 0.);
         HardActivityConstraint twConstraint = new VehicleDependentTimeWindowConstraints(stateManager, routingCosts, activityCosts);
         HardActivityConstraint.ConstraintsStatus status = twConstraint.fulfilled(insertionContext, route.getActivities().get(1), serviceAct, route.getActivities().get(2), 30.);
-        assertFalse(status.equals(HardActivityConstraint.ConstraintsStatus.FULFILLED));
+        Assertions.assertFalse(status.equals(HardActivityConstraint.ConstraintsStatus.FULFILLED));
     }
 
     @Test
     @DisplayName("When Job Is Inserted Along With V 6 Between S 1 And S 2 _ it Should Return False")
     void whenJobIsInsertedAlongWithV6BetweenS1AndS2_itShouldReturnFalse() {
-        assertEquals(60., route.getEnd().getArrTime(), 0.01);
+        Assertions.assertEquals(60., route.getEnd().getArrTime(), 0.01);
         Service s4 = Service.Builder.newInstance("s4").setLocation(Location.newInstance("40,0")).build();
         PickupService serviceAct = new PickupService(s4);
         JobInsertionContext insertionContext = new JobInsertionContext(route, s4, v6, route.getDriver(), 0.);
         HardActivityConstraint twConstraint = new VehicleDependentTimeWindowConstraints(stateManager, routingCosts, activityCosts);
         HardActivityConstraint.ConstraintsStatus status = twConstraint.fulfilled(insertionContext, route.getActivities().get(0), serviceAct, route.getActivities().get(1), 10.);
-        assertFalse(status.equals(HardActivityConstraint.ConstraintsStatus.FULFILLED));
+        Assertions.assertFalse(status.equals(HardActivityConstraint.ConstraintsStatus.FULFILLED));
     }
 
     @Test
     @DisplayName("When Job Is Inserted Along With V 6 At The End Of Route _ it Should Return True")
     void whenJobIsInsertedAlongWithV6AtTheEndOfRoute_itShouldReturnTrue() {
-        assertEquals(60., route.getEnd().getArrTime(), 0.01);
+        Assertions.assertEquals(60., route.getEnd().getArrTime(), 0.01);
         Service s4 = Service.Builder.newInstance("s4").setLocation(Location.newInstance("40,0")).build();
         PickupService serviceAct = new PickupService(s4);
         JobInsertionContext insertionContext = new JobInsertionContext(route, s4, v6, route.getDriver(), 0.);
         HardActivityConstraint twConstraint = new VehicleDependentTimeWindowConstraints(stateManager, routingCosts, activityCosts);
         HardActivityConstraint.ConstraintsStatus status = twConstraint.fulfilled(insertionContext, route.getActivities().get(2), serviceAct, route.getEnd(), 30.);
-        assertTrue(status.equals(HardActivityConstraint.ConstraintsStatus.FULFILLED));
+        Assertions.assertTrue(status.equals(HardActivityConstraint.ConstraintsStatus.FULFILLED));
     }
 
     @Test
     @DisplayName("When Job Is Inserted Along With New Vehicle That Can Only Start At 60 _ it Should Return False")
     void whenJobIsInsertedAlongWithNewVehicleThatCanOnlyStartAt60_itShouldReturnFalse() {
-        assertEquals(60., route.getEnd().getArrTime(), 0.01);
+        Assertions.assertEquals(60., route.getEnd().getArrTime(), 0.01);
         Service s4 = Service.Builder.newInstance("s4").setLocation(Location.newInstance("40,0")).build();
         PickupService serviceAct = new PickupService(s4);
         JobInsertionContext insertionContext = new JobInsertionContext(route, s4, v5, route.getDriver(), 60.);
         HardActivityConstraint twConstraint = new VehicleDependentTimeWindowConstraints(stateManager, routingCosts, activityCosts);
         HardActivityConstraint.ConstraintsStatus status = twConstraint.fulfilled(insertionContext, route.getActivities().get(2), serviceAct, route.getEnd(), 90.);
-        assertFalse(status.equals(HardActivityConstraint.ConstraintsStatus.FULFILLED));
+        Assertions.assertFalse(status.equals(HardActivityConstraint.ConstraintsStatus.FULFILLED));
     }
 }

--- a/jsprit-core/src/test/java/com/graphhopper/jsprit/core/problem/job/DeliveryTest.java
+++ b/jsprit-core/src/test/java/com/graphhopper/jsprit/core/problem/job/DeliveryTest.java
@@ -18,6 +18,8 @@
 package com.graphhopper.jsprit.core.problem.job;
 
 import com.graphhopper.jsprit.core.problem.Location;
+
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
@@ -41,84 +43,84 @@ class DeliveryTest {
     @DisplayName("When Adding Two Cap Dimension _ nu Of Dims Should Be Two")
     void whenAddingTwoCapDimension_nuOfDimsShouldBeTwo() {
         Delivery one = Delivery.Builder.newInstance("s").setLocation(Location.newInstance("foofoo")).addSizeDimension(0, 2).addSizeDimension(1, 4).build();
-        assertEquals(2, one.getSize().getNuOfDimensions());
-        assertEquals(2, one.getSize().get(0));
-        assertEquals(4, one.getSize().get(1));
+        Assertions.assertEquals(2, one.getSize().getNuOfDimensions());
+        Assertions.assertEquals(2, one.getSize().get(0));
+        Assertions.assertEquals(4, one.getSize().get(1));
     }
 
     @Test
     @DisplayName("When Pickup Is Built Without Specifying Capacity _ it Should Hv Cap With One Dim And Dim Val Of Zero")
     void whenPickupIsBuiltWithoutSpecifyingCapacity_itShouldHvCapWithOneDimAndDimValOfZero() {
         Delivery one = Delivery.Builder.newInstance("s").setLocation(Location.newInstance("foofoo")).build();
-        assertEquals(1, one.getSize().getNuOfDimensions());
-        assertEquals(0, one.getSize().get(0));
+        Assertions.assertEquals(1, one.getSize().getNuOfDimensions());
+        Assertions.assertEquals(0, one.getSize().get(0));
     }
 
     @Test
     @DisplayName("When Pickup Is Built With Constructor Where Size Is Specified _ capacity Should Be Set Correctly")
     void whenPickupIsBuiltWithConstructorWhereSizeIsSpecified_capacityShouldBeSetCorrectly() {
         Delivery one = Delivery.Builder.newInstance("s").addSizeDimension(0, 1).setLocation(Location.newInstance("foofoo")).build();
-        assertEquals(1, one.getSize().getNuOfDimensions());
-        assertEquals(1, one.getSize().get(0));
+        Assertions.assertEquals(1, one.getSize().getNuOfDimensions());
+        Assertions.assertEquals(1, one.getSize().get(0));
     }
 
     @Test
     @DisplayName("When Adding Skills _ they Should Be Added Correctly")
     void whenAddingSkills_theyShouldBeAddedCorrectly() {
         Delivery s = Delivery.Builder.newInstance("s").setLocation(Location.newInstance("loc")).addRequiredSkill("drill").addRequiredSkill("screwdriver").build();
-        assertTrue(s.getRequiredSkills().containsSkill("drill"));
-        assertTrue(s.getRequiredSkills().containsSkill("ScrewDriver"));
+        Assertions.assertTrue(s.getRequiredSkills().containsSkill("drill"));
+        Assertions.assertTrue(s.getRequiredSkills().containsSkill("ScrewDriver"));
     }
 
     @Test
     @DisplayName("When Adding Skills Case Sens _ they Should Be Added Correctly")
     void whenAddingSkillsCaseSens_theyShouldBeAddedCorrectly() {
         Delivery s = Delivery.Builder.newInstance("s").setLocation(Location.newInstance("loc")).addRequiredSkill("DriLl").addRequiredSkill("screwDriver").build();
-        assertTrue(s.getRequiredSkills().containsSkill("drill"));
-        assertTrue(s.getRequiredSkills().containsSkill("drilL"));
+        Assertions.assertTrue(s.getRequiredSkills().containsSkill("drill"));
+        Assertions.assertTrue(s.getRequiredSkills().containsSkill("drilL"));
     }
 
     @Test
     @DisplayName("When Adding Skills Case Sens V 2 _ they Should Be Added Correctly")
     void whenAddingSkillsCaseSensV2_theyShouldBeAddedCorrectly() {
         Delivery s = Delivery.Builder.newInstance("s").setLocation(Location.newInstance("loc")).addRequiredSkill("screwDriver").build();
-        assertFalse(s.getRequiredSkills().containsSkill("drill"));
-        assertFalse(s.getRequiredSkills().containsSkill("drilL"));
+        Assertions.assertFalse(s.getRequiredSkills().containsSkill("drill"));
+        Assertions.assertFalse(s.getRequiredSkills().containsSkill("drilL"));
     }
 
     @Test
     @DisplayName("Name Should Be Assigned")
     void nameShouldBeAssigned() {
         Delivery s = Delivery.Builder.newInstance("s").setLocation(Location.newInstance("loc")).setName("name").build();
-        assertEquals(s.getName(), "name");
+        Assertions.assertEquals(s.getName(), "name");
     }
 
     @Test
     @DisplayName("When Setting Priorities _ it Should Be Set Correctly")
     void whenSettingPriorities_itShouldBeSetCorrectly() {
         Delivery s = Delivery.Builder.newInstance("s").setLocation(Location.newInstance("loc")).setPriority(3).build();
-        assertEquals(3, s.getPriority());
+        Assertions.assertEquals(3, s.getPriority());
     }
 
     @Test
     @DisplayName("When Not Setting Priorities _ default Should Be")
     void whenNotSettingPriorities_defaultShouldBe() {
         Delivery s = Delivery.Builder.newInstance("s").setLocation(Location.newInstance("loc")).build();
-        assertEquals(2, s.getPriority());
+        Assertions.assertEquals(2, s.getPriority());
     }
 
     @Test
     @DisplayName("When Adding Max Time In Vehicle _ it Should Be Set")
     void whenAddingMaxTimeInVehicle_itShouldBeSet() {
         Delivery s = Delivery.Builder.newInstance("s").setLocation(Location.newInstance("loc")).setMaxTimeInVehicle(10).build();
-        assertEquals(10, s.getMaxTimeInVehicle(), 0.001);
+        Assertions.assertEquals(10, s.getMaxTimeInVehicle(), 0.001);
     }
 
     @Test
     @DisplayName("When Not Adding Max Time In Vehicle _ it Should Be Default")
     void whenNotAddingMaxTimeInVehicle_itShouldBeDefault() {
         Delivery s = Delivery.Builder.newInstance("s").setLocation(Location.newInstance("loc")).build();
-        assertEquals(Double.MAX_VALUE, s.getMaxTimeInVehicle(), 0.001);
+        Assertions.assertEquals(Double.MAX_VALUE, s.getMaxTimeInVehicle(), 0.001);
     }
 
     @Test
@@ -127,8 +129,8 @@ class DeliveryTest {
         Delivery one = Delivery.Builder.newInstance("s").setLocation(Location.newInstance("loc")).setUserData(new HashMap<String, Object>()).build();
         Delivery two = Delivery.Builder.newInstance("s2").setLocation(Location.newInstance("loc")).setUserData(42).build();
         Delivery three = Delivery.Builder.newInstance("s3").setLocation(Location.newInstance("loc")).build();
-        assertTrue(one.getUserData() instanceof Map);
-        assertEquals(42, two.getUserData());
+        Assertions.assertTrue(one.getUserData() instanceof Map);
+        Assertions.assertEquals(42, two.getUserData());
         assertNull(three.getUserData());
     }
 }

--- a/jsprit-core/src/test/java/com/graphhopper/jsprit/core/problem/job/PickupTest.java
+++ b/jsprit-core/src/test/java/com/graphhopper/jsprit/core/problem/job/PickupTest.java
@@ -18,6 +18,8 @@
 package com.graphhopper.jsprit.core.problem.job;
 
 import com.graphhopper.jsprit.core.problem.Location;
+
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
@@ -41,71 +43,71 @@ class PickupTest {
     @DisplayName("When Adding Two Cap Dimension _ nu Of Dims Should Be Two")
     void whenAddingTwoCapDimension_nuOfDimsShouldBeTwo() {
         Pickup one = Pickup.Builder.newInstance("s").setLocation(Location.newInstance("foofoo")).addSizeDimension(0, 2).addSizeDimension(1, 4).build();
-        assertEquals(2, one.getSize().getNuOfDimensions());
-        assertEquals(2, one.getSize().get(0));
-        assertEquals(4, one.getSize().get(1));
+        Assertions.assertEquals(2, one.getSize().getNuOfDimensions());
+        Assertions.assertEquals(2, one.getSize().get(0));
+        Assertions.assertEquals(4, one.getSize().get(1));
     }
 
     @Test
     @DisplayName("When Pickup Is Built Without Specifying Capacity _ it Should Hv Cap With One Dim And Dim Val Of Zero")
     void whenPickupIsBuiltWithoutSpecifyingCapacity_itShouldHvCapWithOneDimAndDimValOfZero() {
         Pickup one = Pickup.Builder.newInstance("s").setLocation(Location.newInstance("foofoo")).build();
-        assertEquals(1, one.getSize().getNuOfDimensions());
-        assertEquals(0, one.getSize().get(0));
+        Assertions.assertEquals(1, one.getSize().getNuOfDimensions());
+        Assertions.assertEquals(0, one.getSize().get(0));
     }
 
     @Test
     @DisplayName("When Pickup Is Built With Constructor Where Size Is Specified _ capacity Should Be Set Correctly")
     void whenPickupIsBuiltWithConstructorWhereSizeIsSpecified_capacityShouldBeSetCorrectly() {
         Pickup one = Pickup.Builder.newInstance("s").addSizeDimension(0, 1).setLocation(Location.newInstance("foofoo")).build();
-        assertEquals(1, one.getSize().getNuOfDimensions());
-        assertEquals(1, one.getSize().get(0));
+        Assertions.assertEquals(1, one.getSize().getNuOfDimensions());
+        Assertions.assertEquals(1, one.getSize().get(0));
     }
 
     @Test
     @DisplayName("When Adding Skills _ they Should Be Added Correctly")
     void whenAddingSkills_theyShouldBeAddedCorrectly() {
         Pickup s = Pickup.Builder.newInstance("s").setLocation(Location.newInstance("loc")).addRequiredSkill("drill").addRequiredSkill("screwdriver").build();
-        assertTrue(s.getRequiredSkills().containsSkill("drill"));
-        assertTrue(s.getRequiredSkills().containsSkill("drill"));
-        assertTrue(s.getRequiredSkills().containsSkill("ScrewDriver"));
+        Assertions.assertTrue(s.getRequiredSkills().containsSkill("drill"));
+        Assertions.assertTrue(s.getRequiredSkills().containsSkill("drill"));
+        Assertions.assertTrue(s.getRequiredSkills().containsSkill("ScrewDriver"));
     }
 
     @Test
     @DisplayName("When Adding Skills Case Sens _ they Should Be Added Correctly")
     void whenAddingSkillsCaseSens_theyShouldBeAddedCorrectly() {
         Pickup s = Pickup.Builder.newInstance("s").setLocation(Location.newInstance("loc")).addRequiredSkill("DriLl").addRequiredSkill("screwDriver").build();
-        assertTrue(s.getRequiredSkills().containsSkill("drill"));
-        assertTrue(s.getRequiredSkills().containsSkill("drilL"));
+        Assertions.assertTrue(s.getRequiredSkills().containsSkill("drill"));
+        Assertions.assertTrue(s.getRequiredSkills().containsSkill("drilL"));
     }
 
     @Test
     @DisplayName("When Adding Skills Case Sens V 2 _ they Should Be Added Correctly")
     void whenAddingSkillsCaseSensV2_theyShouldBeAddedCorrectly() {
         Pickup s = Pickup.Builder.newInstance("s").setLocation(Location.newInstance("loc")).addRequiredSkill("screwDriver").build();
-        assertFalse(s.getRequiredSkills().containsSkill("drill"));
-        assertFalse(s.getRequiredSkills().containsSkill("drilL"));
+        Assertions.assertFalse(s.getRequiredSkills().containsSkill("drill"));
+        Assertions.assertFalse(s.getRequiredSkills().containsSkill("drilL"));
     }
 
     @Test
     @DisplayName("Name Should Be Assigned")
     void nameShouldBeAssigned() {
         Pickup s = Pickup.Builder.newInstance("s").setLocation(Location.newInstance("loc")).setName("name").build();
-        assertEquals(s.getName(), "name");
+        Assertions.assertEquals(s.getName(), "name");
     }
 
     @Test
     @DisplayName("When Setting Priorities _ it Should Be Set Correctly")
     void whenSettingPriorities_itShouldBeSetCorrectly() {
         Pickup s = Pickup.Builder.newInstance("s").setLocation(Location.newInstance("loc")).setPriority(3).build();
-        assertEquals(3, s.getPriority());
+        Assertions.assertEquals(3, s.getPriority());
     }
 
     @Test
     @DisplayName("When Not Setting Priorities _ default Should Be")
     void whenNotSettingPriorities_defaultShouldBe() {
         Pickup s = Pickup.Builder.newInstance("s").setLocation(Location.newInstance("loc")).build();
-        assertEquals(2, s.getPriority());
+        Assertions.assertEquals(2, s.getPriority());
     }
 
     @Test
@@ -114,8 +116,8 @@ class PickupTest {
         Pickup one = Pickup.Builder.newInstance("s").setLocation(Location.newInstance("loc")).setUserData(new HashMap<String, Object>()).build();
         Pickup two = Pickup.Builder.newInstance("s2").setLocation(Location.newInstance("loc")).setUserData(42).build();
         Pickup three = Pickup.Builder.newInstance("s3").setLocation(Location.newInstance("loc")).build();
-        assertTrue(one.getUserData() instanceof Map);
-        assertEquals(42, two.getUserData());
+        Assertions.assertTrue(one.getUserData() instanceof Map);
+        Assertions.assertEquals(42, two.getUserData());
         assertNull(three.getUserData());
     }
 
@@ -131,6 +133,6 @@ class PickupTest {
     @DisplayName("When Not Adding Max Time In Vehicle _ it Should Be Default")
     void whenNotAddingMaxTimeInVehicle_itShouldBeDefault() {
         Pickup s = Pickup.Builder.newInstance("s").setLocation(Location.newInstance("loc")).build();
-        assertEquals(Double.MAX_VALUE, s.getMaxTimeInVehicle(), 0.001);
+        Assertions.assertEquals(Double.MAX_VALUE, s.getMaxTimeInVehicle(), 0.001);
     }
 }

--- a/jsprit-core/src/test/java/com/graphhopper/jsprit/core/problem/job/ServiceTest.java
+++ b/jsprit-core/src/test/java/com/graphhopper/jsprit/core/problem/job/ServiceTest.java
@@ -19,6 +19,8 @@ package com.graphhopper.jsprit.core.problem.job;
 
 import com.graphhopper.jsprit.core.problem.Location;
 import com.graphhopper.jsprit.core.problem.solution.route.activity.TimeWindow;
+
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
@@ -26,11 +28,6 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
-
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.core.Is.is;
-import static org.hamcrest.core.IsCollectionContaining.hasItem;
-import static org.junit.jupiter.api.Assertions.*;
 
 @DisplayName("Service Test")
 class ServiceTest {
@@ -40,7 +37,7 @@ class ServiceTest {
     void whenTwoServicesHaveTheSameId_theirReferencesShouldBeUnEqual() {
         Service one = Service.Builder.newInstance("service").addSizeDimension(0, 10).setLocation(Location.newInstance("foo")).build();
         Service two = Service.Builder.newInstance("service").addSizeDimension(0, 10).setLocation(Location.newInstance("fo")).build();
-        assertTrue(one != two);
+        Assertions.assertTrue(one != two);
     }
 
     @Test
@@ -48,7 +45,7 @@ class ServiceTest {
     void whenTwoServicesHaveTheSameId_theyShouldBeEqual() {
         Service one = Service.Builder.newInstance("service").addSizeDimension(0, 10).setLocation(Location.newInstance("foo")).build();
         Service two = Service.Builder.newInstance("service").addSizeDimension(0, 10).setLocation(Location.newInstance("fo")).build();
-        assertTrue(one.equals(two));
+        Assertions.assertTrue(one.equals(two));
     }
 
     @Test
@@ -60,13 +57,13 @@ class ServiceTest {
         serviceSet.add(one);
         // assertTrue(serviceSet.contains(two));
         serviceSet.remove(two);
-        assertTrue(serviceSet.isEmpty());
+        Assertions.assertTrue(serviceSet.isEmpty());
     }
 
     @Test
     @DisplayName("When Capacity Dim Value Is Negative _ throw Illegal State Expception")
     void whenCapacityDimValueIsNegative_throwIllegalStateExpception() {
-        assertThrows(IllegalArgumentException.class, () -> {
+        Assertions.assertThrows(IllegalArgumentException.class, () -> {
             @SuppressWarnings("unused")
             Service s = Service.Builder.newInstance("s").setLocation(Location.newInstance("foo")).addSizeDimension(0, -10).build();
         });
@@ -76,74 +73,76 @@ class ServiceTest {
     @DisplayName("When Adding Two Cap Dimension _ nu Of Dims Should Be Two")
     void whenAddingTwoCapDimension_nuOfDimsShouldBeTwo() {
         Service one = Service.Builder.newInstance("s").setLocation(Location.newInstance("foofoo")).addSizeDimension(0, 2).addSizeDimension(1, 4).build();
-        assertEquals(2, one.getSize().getNuOfDimensions());
+        Assertions.assertEquals(2, one.getSize().getNuOfDimensions());
     }
 
     @Test
     @DisplayName("When Shipment Is Built Without Specifying Capacity _ it Should Hv Cap With One Dim And Dim Val Of Zero")
     void whenShipmentIsBuiltWithoutSpecifyingCapacity_itShouldHvCapWithOneDimAndDimValOfZero() {
         Service one = Service.Builder.newInstance("s").setLocation(Location.newInstance("foofoo")).build();
-        assertEquals(1, one.getSize().getNuOfDimensions());
-        assertEquals(0, one.getSize().get(0));
+        Assertions.assertEquals(1, one.getSize().getNuOfDimensions());
+        Assertions.assertEquals(0, one.getSize().get(0));
     }
 
     @Test
     @DisplayName("When Shipment Is Built With Constructor Where Size Is Specified _ capacity Should Be Set Correctly")
     void whenShipmentIsBuiltWithConstructorWhereSizeIsSpecified_capacityShouldBeSetCorrectly() {
         Service one = Service.Builder.newInstance("s").addSizeDimension(0, 1).setLocation(Location.newInstance("foofoo")).build();
-        assertEquals(1, one.getSize().getNuOfDimensions());
-        assertEquals(1, one.getSize().get(0));
+        Assertions.assertEquals(1, one.getSize().getNuOfDimensions());
+        Assertions.assertEquals(1, one.getSize().get(0));
     }
 
     @Test
     @DisplayName("When Calling For New Instance Of Builder _ it Should Return Builder Correctly")
     void whenCallingForNewInstanceOfBuilder_itShouldReturnBuilderCorrectly() {
         Service.Builder builder = Service.Builder.newInstance("s");
-        assertNotNull(builder);
+        Assertions.assertNotNull(builder);
     }
 
     @Test
     @DisplayName("When Setting No Type _ it Should Return _ service")
     void whenSettingNoType_itShouldReturn_service() {
         Service s = Service.Builder.newInstance("s").setLocation(Location.newInstance("loc")).build();
-        assertEquals(s.getType(), "service");
+        Assertions.assertEquals(s.getType(), "service");
     }
 
     @Test
     @DisplayName("When Setting Location _ it Should Be Set Correctly")
     void whenSettingLocation_itShouldBeSetCorrectly() {
         Service s = Service.Builder.newInstance("s").setLocation(Location.newInstance("loc")).build();
-        assertEquals(s.getLocation().getId(), "loc");
-        assertEquals(s.getLocation().getId(), "loc");
+        Assertions.assertEquals(s.getLocation().getId(), "loc");
+        Assertions.assertEquals(s.getLocation().getId(), "loc");
     }
 
     @Test
     @DisplayName("When Setting Location _ it Should Work")
     void whenSettingLocation_itShouldWork() {
         Service s = Service.Builder.newInstance("s").setLocation(Location.Builder.newInstance().setId("loc").build()).build();
-        assertEquals(s.getLocation().getId(), "loc");
-        assertEquals(s.getLocation().getId(), "loc");
+        Assertions.assertEquals(s.getLocation().getId(), "loc");
+        Assertions.assertEquals(s.getLocation().getId(), "loc");
     }
 
     @Test
     @DisplayName("When Setting Location Coord _ it Should Be Set Correctly")
     void whenSettingLocationCoord_itShouldBeSetCorrectly() {
         Service s = Service.Builder.newInstance("s").setLocation(Location.newInstance(1, 2)).build();
-        assertEquals(1.0, s.getLocation().getCoordinate().getX(), 0.01);
-        assertEquals(2.0, s.getLocation().getCoordinate().getY(), 0.01);
-        assertEquals(1.0, s.getLocation().getCoordinate().getX(), 0.01);
-        assertEquals(2.0, s.getLocation().getCoordinate().getY(), 0.01);
+        Assertions.assertEquals(1.0, s.getLocation().getCoordinate().getX(), 0.01);
+        Assertions.assertEquals(2.0, s.getLocation().getCoordinate().getY(), 0.01);
+        Assertions.assertEquals(1.0, s.getLocation().getCoordinate().getX(), 0.01);
+        Assertions.assertEquals(2.0, s.getLocation().getCoordinate().getY(), 0.01);
     }
 
-    // @Test(expected = IllegalArgumentException.class)
+    // @Test
     // public void whenSettingNeitherLocationIdNorCoord_throwsException() {
+    // Assertions.assertThrows(IllegalArgumentException.class, () -> {
     // @SuppressWarnings("unused")
     // Service s = Service.Builder.newInstance("s").build();
+    // });
     // }
     @Test
     @DisplayName("When Service Time Smaller Zero _ throw Illegal State Exception")
     void whenServiceTimeSmallerZero_throwIllegalStateException() {
-        assertThrows(IllegalArgumentException.class, () -> {
+        Assertions.assertThrows(IllegalArgumentException.class, () -> {
             @SuppressWarnings("unused")
             Service s = Service.Builder.newInstance("s").setLocation(Location.newInstance("loc")).setServiceTime(-1).build();
         });
@@ -153,13 +152,13 @@ class ServiceTest {
     @DisplayName("When Setting Service Time _ it Should Be Set Correctly")
     void whenSettingServiceTime_itShouldBeSetCorrectly() {
         Service s = Service.Builder.newInstance("s").setLocation(Location.newInstance("loc")).setServiceTime(1).build();
-        assertEquals(1.0, s.getServiceDuration(), 0.01);
+        Assertions.assertEquals(1.0, s.getServiceDuration(), 0.01);
     }
 
     @Test
     @DisplayName("When Time Window Is Null _ throw Exception")
     void whenTimeWindowIsNull_throwException() {
-        assertThrows(IllegalArgumentException.class, () -> {
+        Assertions.assertThrows(IllegalArgumentException.class, () -> {
             @SuppressWarnings("unused")
             Service s = Service.Builder.newInstance("s").setLocation(Location.newInstance("loc")).setTimeWindow(null).build();
         });
@@ -169,25 +168,25 @@ class ServiceTest {
     @DisplayName("When Setting Time Window _ it Should Be Set Correctly")
     void whenSettingTimeWindow_itShouldBeSetCorrectly() {
         Service s = Service.Builder.newInstance("s").setLocation(Location.newInstance("loc")).setTimeWindow(TimeWindow.newInstance(1.0, 2.0)).build();
-        assertEquals(1.0, s.getTimeWindow().getStart(), 0.01);
-        assertEquals(2.0, s.getTimeWindow().getEnd(), 0.01);
+        Assertions.assertEquals(1.0, s.getTimeWindow().getStart(), 0.01);
+        Assertions.assertEquals(2.0, s.getTimeWindow().getEnd(), 0.01);
     }
 
     @Test
     @DisplayName("When Adding Skills _ they Should Be Added Correctly")
     void whenAddingSkills_theyShouldBeAddedCorrectly() {
         Service s = Service.Builder.newInstance("s").setLocation(Location.newInstance("loc")).addRequiredSkill("drill").addRequiredSkill("screwdriver").build();
-        assertTrue(s.getRequiredSkills().containsSkill("drill"));
-        assertTrue(s.getRequiredSkills().containsSkill("drill"));
-        assertTrue(s.getRequiredSkills().containsSkill("ScrewDriver"));
+        Assertions.assertTrue(s.getRequiredSkills().containsSkill("drill"));
+        Assertions.assertTrue(s.getRequiredSkills().containsSkill("drill"));
+        Assertions.assertTrue(s.getRequiredSkills().containsSkill("ScrewDriver"));
     }
 
     @Test
     @DisplayName("When Adding Skills Case Sens _ they Should Be Added Correctly")
     void whenAddingSkillsCaseSens_theyShouldBeAddedCorrectly() {
         Service s = Service.Builder.newInstance("s").setLocation(Location.newInstance("loc")).addRequiredSkill("DriLl").addRequiredSkill("screwDriver").build();
-        assertTrue(s.getRequiredSkills().containsSkill("drill"));
-        assertTrue(s.getRequiredSkills().containsSkill("drilL"));
+        Assertions.assertTrue(s.getRequiredSkills().containsSkill("drill"));
+        Assertions.assertTrue(s.getRequiredSkills().containsSkill("drilL"));
     }
 
     @Test
@@ -196,45 +195,45 @@ class ServiceTest {
         TimeWindow tw1 = TimeWindow.newInstance(1.0, 2.0);
         TimeWindow tw2 = TimeWindow.newInstance(3.0, 5.0);
         Service s = Service.Builder.newInstance("s").setLocation(Location.newInstance("loc")).addTimeWindow(tw1).addTimeWindow(tw2).build();
-        assertEquals(2, s.getTimeWindows().size());
-        assertThat(s.getTimeWindows(), hasItem(is(tw1)));
-        assertThat(s.getTimeWindows(), hasItem(is(tw2)));
+        Assertions.assertEquals(2, s.getTimeWindows().size());
+        Assertions.assertTrue(s.getTimeWindows().contains(tw1));
+        Assertions.assertTrue(s.getTimeWindows().contains(tw2));
     }
 
     @Test
     @DisplayName("When Adding Time Window _ it Should Be Set Correctly")
     void whenAddingTimeWindow_itShouldBeSetCorrectly() {
         Service s = Service.Builder.newInstance("s").setLocation(Location.newInstance("loc")).addTimeWindow(TimeWindow.newInstance(1.0, 2.0)).build();
-        assertEquals(1.0, s.getTimeWindow().getStart(), 0.01);
-        assertEquals(2.0, s.getTimeWindow().getEnd(), 0.01);
+        Assertions.assertEquals(1.0, s.getTimeWindow().getStart(), 0.01);
+        Assertions.assertEquals(2.0, s.getTimeWindow().getEnd(), 0.01);
     }
 
     @Test
     @DisplayName("When Adding Skills Case Sens V 2 _ they Should Be Added Correctly")
     void whenAddingSkillsCaseSensV2_theyShouldBeAddedCorrectly() {
         Service s = Service.Builder.newInstance("s").setLocation(Location.newInstance("loc")).addRequiredSkill("screwDriver").build();
-        assertFalse(s.getRequiredSkills().containsSkill("drill"));
-        assertFalse(s.getRequiredSkills().containsSkill("drilL"));
+        Assertions.assertFalse(s.getRequiredSkills().containsSkill("drill"));
+        Assertions.assertFalse(s.getRequiredSkills().containsSkill("drilL"));
     }
 
     @Test
     @DisplayName("Name Should Be Assigned")
     void nameShouldBeAssigned() {
         Service s = Service.Builder.newInstance("s").setLocation(Location.newInstance("loc")).setName("name").build();
-        assertEquals(s.getName(), "name");
+        Assertions.assertEquals(s.getName(), "name");
     }
 
     @Test
     @DisplayName("Should Know Multiple Time Windows")
     void shouldKnowMultipleTimeWindows() {
         Service s = Service.Builder.newInstance("s").setLocation(Location.newInstance("loc")).addTimeWindow(TimeWindow.newInstance(0., 10.)).addTimeWindow(TimeWindow.newInstance(20., 30.)).setName("name").build();
-        assertEquals(2, s.getTimeWindows().size());
+        Assertions.assertEquals(2, s.getTimeWindows().size());
     }
 
     @Test
     @DisplayName("When Multiple TW Overlap _ throw Ex")
     void whenMultipleTWOverlap_throwEx() {
-        assertThrows(IllegalArgumentException.class, () -> {
+        Assertions.assertThrows(IllegalArgumentException.class, () -> {
             Service s = Service.Builder.newInstance("s").setLocation(Location.newInstance("loc")).addTimeWindow(TimeWindow.newInstance(0., 10.)).addTimeWindow(TimeWindow.newInstance(5., 30.)).setName("name").build();
         });
     }
@@ -242,7 +241,7 @@ class ServiceTest {
     @Test
     @DisplayName("When Multiple TW Overlap 2 _ throw Ex")
     void whenMultipleTWOverlap2_throwEx() {
-        assertThrows(IllegalArgumentException.class, () -> {
+        Assertions.assertThrows(IllegalArgumentException.class, () -> {
             Service s = Service.Builder.newInstance("s").setLocation(Location.newInstance("loc")).addTimeWindow(TimeWindow.newInstance(20., 30.)).addTimeWindow(TimeWindow.newInstance(0., 25.)).setName("name").build();
         });
     }
@@ -251,34 +250,34 @@ class ServiceTest {
     @DisplayName("When Setting Priorities _ it Should Be Set Correctly")
     void whenSettingPriorities_itShouldBeSetCorrectly() {
         Service s = Service.Builder.newInstance("s").setLocation(Location.newInstance("loc")).setPriority(1).build();
-        assertEquals(1, s.getPriority());
+        Assertions.assertEquals(1, s.getPriority());
     }
 
     @Test
     @DisplayName("When Setting Priorities _ it Should Be Set Correctly 2")
     void whenSettingPriorities_itShouldBeSetCorrectly2() {
         Service s = Service.Builder.newInstance("s").setLocation(Location.newInstance("loc")).setPriority(3).build();
-        assertEquals(3, s.getPriority());
+        Assertions.assertEquals(3, s.getPriority());
     }
 
     @Test
     @DisplayName("When Setting Priorities _ it Should Be Set Correctly 3")
     void whenSettingPriorities_itShouldBeSetCorrectly3() {
         Service s = Service.Builder.newInstance("s").setLocation(Location.newInstance("loc")).setPriority(10).build();
-        assertEquals(10, s.getPriority());
+        Assertions.assertEquals(10, s.getPriority());
     }
 
     @Test
     @DisplayName("When Not Setting Priorities _ default Should Be 2")
     void whenNotSettingPriorities_defaultShouldBe2() {
         Service s = Service.Builder.newInstance("s").setLocation(Location.newInstance("loc")).build();
-        assertEquals(2, s.getPriority());
+        Assertions.assertEquals(2, s.getPriority());
     }
 
     @Test
     @DisplayName("When Setting Incorrect Priorities _ it Should Throw Exception")
     void whenSettingIncorrectPriorities_itShouldThrowException() {
-        assertThrows(IllegalArgumentException.class, () -> {
+        Assertions.assertThrows(IllegalArgumentException.class, () -> {
             Service s = Service.Builder.newInstance("s").setLocation(Location.newInstance("loc")).setPriority(30).build();
         });
     }
@@ -286,7 +285,7 @@ class ServiceTest {
     @Test
     @DisplayName("When Setting Incorrect Priorities _ it Should Throw Exception 2")
     void whenSettingIncorrectPriorities_itShouldThrowException2() {
-        assertThrows(IllegalArgumentException.class, () -> {
+        Assertions.assertThrows(IllegalArgumentException.class, () -> {
             Service s = Service.Builder.newInstance("s").setLocation(Location.newInstance("loc")).setPriority(0).build();
         });
     }
@@ -294,7 +293,7 @@ class ServiceTest {
     @Test
     @DisplayName("When Adding Max Time In Vehicle _ it Should Throw Ex")
     void whenAddingMaxTimeInVehicle_itShouldThrowEx() {
-        assertThrows(UnsupportedOperationException.class, () -> {
+        Assertions.assertThrows(UnsupportedOperationException.class, () -> {
             Service s = Service.Builder.newInstance("s").setLocation(Location.newInstance("loc")).setMaxTimeInVehicle(10).build();
         });
     }
@@ -303,7 +302,7 @@ class ServiceTest {
     @DisplayName("When Not Adding Max Time In Vehicle _ it Should Be Default")
     void whenNotAddingMaxTimeInVehicle_itShouldBeDefault() {
         Service s = Service.Builder.newInstance("s").setLocation(Location.newInstance("loc")).build();
-        assertEquals(Double.MAX_VALUE, s.getMaxTimeInVehicle(), 0.001);
+        Assertions.assertEquals(Double.MAX_VALUE, s.getMaxTimeInVehicle(), 0.001);
     }
 
     @Test
@@ -312,16 +311,16 @@ class ServiceTest {
         Service one = Service.Builder.newInstance("s").setLocation(Location.newInstance("loc")).setUserData(new HashMap<String, Object>()).build();
         Service two = Service.Builder.newInstance("s2").setLocation(Location.newInstance("loc")).setUserData(42).build();
         Service three = Service.Builder.newInstance("s3").setLocation(Location.newInstance("loc")).build();
-        assertTrue(one.getUserData() instanceof Map);
-        assertEquals(42, two.getUserData());
-        assertNull(three.getUserData());
+        Assertions.assertTrue(one.getUserData() instanceof Map);
+        Assertions.assertEquals(42, two.getUserData());
+        Assertions.assertNull(three.getUserData());
     }
 
     @Test
     @DisplayName("Test Service Activity")
     void testServiceActivity() {
         Service one = Service.Builder.newInstance("s").setLocation(Location.newInstance("loc")).build();
-        assertEquals(1, one.getActivities().size());
-        assertEquals(Activity.Type.SERVICE, one.getActivities().get(0).getActivityType());
+        Assertions.assertEquals(1, one.getActivities().size());
+        Assertions.assertEquals(Activity.Type.SERVICE, one.getActivities().get(0).getActivityType());
     }
 }

--- a/jsprit-core/src/test/java/com/graphhopper/jsprit/core/problem/job/ShipmentTest.java
+++ b/jsprit-core/src/test/java/com/graphhopper/jsprit/core/problem/job/ShipmentTest.java
@@ -21,16 +21,13 @@ import com.graphhopper.jsprit.core.problem.Location;
 import com.graphhopper.jsprit.core.problem.solution.route.activity.TimeWindow;
 import com.graphhopper.jsprit.core.util.Coordinate;
 import com.graphhopper.jsprit.core.util.TestUtils;
+
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
 import java.util.HashMap;
 import java.util.Map;
-
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.core.Is.is;
-import static org.hamcrest.core.IsCollectionContaining.hasItem;
-import static org.junit.jupiter.api.Assertions.*;
 
 @DisplayName("Shipment Test")
 class ShipmentTest {
@@ -40,7 +37,7 @@ class ShipmentTest {
     void whenTwoShipmentsHaveTheSameId_theyReferencesShouldBeUnEqual() {
         Shipment one = Shipment.Builder.newInstance("s").addSizeDimension(0, 10).setPickupLocation(Location.Builder.newInstance().setId("foo").build()).setDeliveryLocation(TestUtils.loc("foofoo")).setPickupServiceTime(10).setDeliveryServiceTime(20).build();
         Shipment two = Shipment.Builder.newInstance("s").addSizeDimension(0, 10).setPickupLocation(Location.Builder.newInstance().setId("foo").build()).setDeliveryLocation(TestUtils.loc("foofoo")).setPickupServiceTime(10).setDeliveryServiceTime(20).build();
-        assertTrue(one != two);
+        Assertions.assertTrue(one != two);
     }
 
     @Test
@@ -48,20 +45,20 @@ class ShipmentTest {
     void whenTwoShipmentsHaveTheSameId_theyShouldBeEqual() {
         Shipment one = Shipment.Builder.newInstance("s").addSizeDimension(0, 10).setPickupLocation(Location.Builder.newInstance().setId("foo").build()).setDeliveryLocation(TestUtils.loc("foofoo")).setPickupServiceTime(10).setDeliveryServiceTime(20).build();
         Shipment two = Shipment.Builder.newInstance("s").addSizeDimension(0, 10).setPickupLocation(Location.Builder.newInstance().setId("foo").build()).setDeliveryLocation(TestUtils.loc("foofoo")).setPickupServiceTime(10).setDeliveryServiceTime(20).build();
-        assertTrue(one.equals(two));
+        Assertions.assertTrue(one.equals(two));
     }
 
     @Test
     @DisplayName("When Shipment Is Instantiated With A Size Of 10 _ the Size Should Be 10")
     void whenShipmentIsInstantiatedWithASizeOf10_theSizeShouldBe10() {
         Shipment one = Shipment.Builder.newInstance("s").addSizeDimension(0, 10).setPickupLocation(Location.Builder.newInstance().setId("foo").build()).setDeliveryLocation(TestUtils.loc("foofoo")).setPickupServiceTime(10).setDeliveryServiceTime(20).build();
-        assertEquals(10, one.getSize().get(0));
+        Assertions.assertEquals(10, one.getSize().get(0));
     }
 
     @Test
     @DisplayName("When Shipment Is Built With Negative Demand _ it Should Throw Exception")
     void whenShipmentIsBuiltWithNegativeDemand_itShouldThrowException() {
-        assertThrows(IllegalArgumentException.class, () -> {
+        Assertions.assertThrows(IllegalArgumentException.class, () -> {
             @SuppressWarnings("unused")
             Shipment one = Shipment.Builder.newInstance("s").addSizeDimension(0, -10).setPickupLocation(Location.Builder.newInstance().setId("foo").build()).setDeliveryLocation(TestUtils.loc("foofoo")).build();
         });
@@ -70,7 +67,7 @@ class ShipmentTest {
     @Test
     @DisplayName("When Shipment Is Built With Negative Demand _ it Should Throw Exception _ v 2")
     void whenShipmentIsBuiltWithNegativeDemand_itShouldThrowException_v2() {
-        assertThrows(IllegalArgumentException.class, () -> {
+        Assertions.assertThrows(IllegalArgumentException.class, () -> {
             @SuppressWarnings("unused")
             Shipment one = Shipment.Builder.newInstance("s").addSizeDimension(0, -10).setPickupLocation(Location.Builder.newInstance().setId("foo").build()).setDeliveryLocation(TestUtils.loc("foofoo")).build();
         });
@@ -79,7 +76,7 @@ class ShipmentTest {
     @Test
     @DisplayName("When Id Is Null _ it Should Throw Exception")
     void whenIdIsNull_itShouldThrowException() {
-        assertThrows(IllegalArgumentException.class, () -> {
+        Assertions.assertThrows(IllegalArgumentException.class, () -> {
             @SuppressWarnings("unused")
             Shipment one = Shipment.Builder.newInstance(null).addSizeDimension(0, 10).setPickupLocation(Location.Builder.newInstance().setId("foo").build()).setDeliveryLocation(TestUtils.loc("foofoo")).build();
         });
@@ -89,13 +86,13 @@ class ShipmentTest {
     @DisplayName("When Calling For A New Builder Instance _ it Should Return Builder Correctly")
     void whenCallingForANewBuilderInstance_itShouldReturnBuilderCorrectly() {
         Shipment.Builder builder = Shipment.Builder.newInstance("s");
-        assertNotNull(builder);
+        Assertions.assertNotNull(builder);
     }
 
     @Test
     @DisplayName("When Neither Pickup Location Id Nor Pickup Coord _ it Throws Exception")
     void whenNeitherPickupLocationIdNorPickupCoord_itThrowsException() {
-        assertThrows(IllegalArgumentException.class, () -> {
+        Assertions.assertThrows(IllegalArgumentException.class, () -> {
             @SuppressWarnings("unused")
             Shipment s = Shipment.Builder.newInstance("s").setDeliveryLocation(TestUtils.loc("delLoc")).build();
         });
@@ -104,7 +101,7 @@ class ShipmentTest {
     @Test
     @DisplayName("When Neither Delivery Location Id Nor Delivery Coord _ it Throws Exception")
     void whenNeitherDeliveryLocationIdNorDeliveryCoord_itThrowsException() {
-        assertThrows(IllegalArgumentException.class, () -> {
+        Assertions.assertThrows(IllegalArgumentException.class, () -> {
             @SuppressWarnings("unused")
             Shipment s = Shipment.Builder.newInstance("s").setPickupLocation(Location.Builder.newInstance().setId("pickLoc").build()).build();
         });
@@ -114,14 +111,14 @@ class ShipmentTest {
     @DisplayName("When Pickup Location Id Is Set _ it Should Be Done Correctly")
     void whenPickupLocationIdIsSet_itShouldBeDoneCorrectly() {
         Shipment s = Shipment.Builder.newInstance("s").setDeliveryLocation(TestUtils.loc("delLoc")).setPickupLocation(Location.Builder.newInstance().setId("pickLoc").build()).build();
-        assertEquals(s.getPickupLocation().getId(), "pickLoc");
-        assertEquals(s.getPickupLocation().getId(), "pickLoc");
+        Assertions.assertEquals(s.getPickupLocation().getId(), "pickLoc");
+        Assertions.assertEquals(s.getPickupLocation().getId(), "pickLoc");
     }
 
     @Test
     @DisplayName("When Pickup Location Is Null _ it Throws Exception")
     void whenPickupLocationIsNull_itThrowsException() {
-        assertThrows(IllegalArgumentException.class, () -> {
+        Assertions.assertThrows(IllegalArgumentException.class, () -> {
             @SuppressWarnings("unused")
             Shipment.Builder builder = Shipment.Builder.newInstance("s").setPickupLocation(Location.Builder.newInstance().setId(null).build());
         });
@@ -131,55 +128,55 @@ class ShipmentTest {
     @DisplayName("When Pickup Coord Is Set _ it Should Be Done Correctly")
     void whenPickupCoordIsSet_itShouldBeDoneCorrectly() {
         Shipment s = Shipment.Builder.newInstance("s").setDeliveryLocation(TestUtils.loc("delLoc")).setPickupLocation(Location.Builder.newInstance().setId("pickLoc").setCoordinate(Coordinate.newInstance(1, 2)).build()).build();
-        assertEquals(1.0, s.getPickupLocation().getCoordinate().getX(), 0.01);
-        assertEquals(2.0, s.getPickupLocation().getCoordinate().getY(), 0.01);
-        assertEquals(1.0, s.getPickupLocation().getCoordinate().getX(), 0.01);
-        assertEquals(2.0, s.getPickupLocation().getCoordinate().getY(), 0.01);
+        Assertions.assertEquals(1.0, s.getPickupLocation().getCoordinate().getX(), 0.01);
+        Assertions.assertEquals(2.0, s.getPickupLocation().getCoordinate().getY(), 0.01);
+        Assertions.assertEquals(1.0, s.getPickupLocation().getCoordinate().getX(), 0.01);
+        Assertions.assertEquals(2.0, s.getPickupLocation().getCoordinate().getY(), 0.01);
     }
 
     @Test
     @DisplayName("When Delivery Location Id Is Set _ it Should Be Done Correctly")
     void whenDeliveryLocationIdIsSet_itShouldBeDoneCorrectly() {
         Shipment s = Shipment.Builder.newInstance("s").setDeliveryLocation(TestUtils.loc("delLoc")).setPickupLocation(Location.Builder.newInstance().setId("pickLoc").build()).build();
-        assertEquals(s.getDeliveryLocation().getId(), "delLoc");
-        assertEquals(s.getDeliveryLocation().getId(), "delLoc");
+        Assertions.assertEquals(s.getDeliveryLocation().getId(), "delLoc");
+        Assertions.assertEquals(s.getDeliveryLocation().getId(), "delLoc");
     }
 
     @Test
     @DisplayName("When Delivery Coord Is Set _ it Should Be Done Correctly")
     void whenDeliveryCoordIsSet_itShouldBeDoneCorrectly() {
         Shipment s = Shipment.Builder.newInstance("s").setDeliveryLocation(TestUtils.loc("delLoc", Coordinate.newInstance(1, 2))).setPickupLocation(Location.Builder.newInstance().setId("pickLoc").build()).build();
-        assertEquals(1.0, s.getDeliveryLocation().getCoordinate().getX(), 0.01);
-        assertEquals(2.0, s.getDeliveryLocation().getCoordinate().getY(), 0.01);
-        assertEquals(1.0, s.getDeliveryLocation().getCoordinate().getX(), 0.01);
-        assertEquals(2.0, s.getDeliveryLocation().getCoordinate().getY(), 0.01);
+        Assertions.assertEquals(1.0, s.getDeliveryLocation().getCoordinate().getX(), 0.01);
+        Assertions.assertEquals(2.0, s.getDeliveryLocation().getCoordinate().getY(), 0.01);
+        Assertions.assertEquals(1.0, s.getDeliveryLocation().getCoordinate().getX(), 0.01);
+        Assertions.assertEquals(2.0, s.getDeliveryLocation().getCoordinate().getY(), 0.01);
     }
 
     @Test
     @DisplayName("When Pickup Service Time Is Not Set _ it Should Be Zero")
     void whenPickupServiceTimeIsNotSet_itShouldBeZero() {
         Shipment s = Shipment.Builder.newInstance("s").setDeliveryLocation(TestUtils.loc("delLoc")).setPickupLocation(Location.Builder.newInstance().setId("pickLoc").build()).build();
-        assertEquals(0.0, s.getPickupServiceTime(), 0.01);
+        Assertions.assertEquals(0.0, s.getPickupServiceTime(), 0.01);
     }
 
     @Test
     @DisplayName("When Delivery Service Time Is Not Set _ it Should Be Zero")
     void whenDeliveryServiceTimeIsNotSet_itShouldBeZero() {
         Shipment s = Shipment.Builder.newInstance("s").setDeliveryLocation(TestUtils.loc("delLoc")).setPickupLocation(Location.Builder.newInstance().setId("pickLoc").build()).build();
-        assertEquals(0.0, s.getDeliveryServiceTime(), 0.01);
+        Assertions.assertEquals(0.0, s.getDeliveryServiceTime(), 0.01);
     }
 
     @Test
     @DisplayName("When Pickup Service Time Is Set _ it Should Be Done Correctly")
     void whenPickupServiceTimeIsSet_itShouldBeDoneCorrectly() {
         Shipment s = Shipment.Builder.newInstance("s").setPickupServiceTime(2.0).setDeliveryLocation(TestUtils.loc("delLoc")).setPickupLocation(Location.Builder.newInstance().setId("pickLoc").build()).build();
-        assertEquals(2.0, s.getPickupServiceTime(), 0.01);
+        Assertions.assertEquals(2.0, s.getPickupServiceTime(), 0.01);
     }
 
     @Test
     @DisplayName("When Pickup Service Is Smaller Than Zero _ it Should Throw Exception")
     void whenPickupServiceIsSmallerThanZero_itShouldThrowException() {
-        assertThrows(IllegalArgumentException.class, () -> {
+        Assertions.assertThrows(IllegalArgumentException.class, () -> {
             @SuppressWarnings("unused")
             Shipment s = Shipment.Builder.newInstance("s").setPickupServiceTime(-2.0).setDeliveryLocation(TestUtils.loc("delLoc")).setPickupLocation(Location.Builder.newInstance().setId("pickLoc").build()).build();
         });
@@ -189,13 +186,13 @@ class ShipmentTest {
     @DisplayName("When Delivery Service Time Is Set _ it Should Be Done Correctly")
     void whenDeliveryServiceTimeIsSet_itShouldBeDoneCorrectly() {
         Shipment s = Shipment.Builder.newInstance("s").setDeliveryServiceTime(2.0).setDeliveryLocation(TestUtils.loc("delLoc")).setPickupLocation(Location.Builder.newInstance().setId("pickLoc").build()).build();
-        assertEquals(2.0, s.getDeliveryServiceTime(), 0.01);
+        Assertions.assertEquals(2.0, s.getDeliveryServiceTime(), 0.01);
     }
 
     @Test
     @DisplayName("When Delivery Service Is Smaller Than Zero _ it Should Throw Exception")
     void whenDeliveryServiceIsSmallerThanZero_itShouldThrowException() {
-        assertThrows(IllegalArgumentException.class, () -> {
+        Assertions.assertThrows(IllegalArgumentException.class, () -> {
             @SuppressWarnings("unused")
             Shipment s = Shipment.Builder.newInstance("s").setDeliveryServiceTime(-2.0).setDeliveryLocation(TestUtils.loc("delLoc")).setPickupLocation(Location.Builder.newInstance().setId("pickLoc").build()).build();
         });
@@ -205,14 +202,14 @@ class ShipmentTest {
     @DisplayName("When Pickup Time Window Is Not Set _ it Should Be The Default One")
     void whenPickupTimeWindowIsNotSet_itShouldBeTheDefaultOne() {
         Shipment s = Shipment.Builder.newInstance("s").setDeliveryLocation(TestUtils.loc("delLoc")).setPickupLocation(Location.Builder.newInstance().setId("pickLoc").build()).build();
-        assertEquals(0.0, s.getPickupTimeWindow().getStart(), 0.01);
-        assertEquals(Double.MAX_VALUE, s.getPickupTimeWindow().getEnd(), 0.01);
+        Assertions.assertEquals(0.0, s.getPickupTimeWindow().getStart(), 0.01);
+        Assertions.assertEquals(Double.MAX_VALUE, s.getPickupTimeWindow().getEnd(), 0.01);
     }
 
     @Test
     @DisplayName("When Pickup Time Window Is Null _ it Should Throw Exception")
     void whenPickupTimeWindowIsNull_itShouldThrowException() {
-        assertThrows(IllegalArgumentException.class, () -> {
+        Assertions.assertThrows(IllegalArgumentException.class, () -> {
             @SuppressWarnings("unused")
             Shipment s = Shipment.Builder.newInstance("s").setPickupTimeWindow(null).setDeliveryLocation(TestUtils.loc("delLoc")).setPickupLocation(Location.Builder.newInstance().setId("pickLoc").build()).build();
         });
@@ -222,22 +219,22 @@ class ShipmentTest {
     @DisplayName("When Pickup Time Window Is Set _ it Should Be Done Correctly")
     void whenPickupTimeWindowIsSet_itShouldBeDoneCorrectly() {
         Shipment s = Shipment.Builder.newInstance("s").setPickupTimeWindow(TimeWindow.newInstance(1, 2)).setDeliveryLocation(TestUtils.loc("delLoc")).setPickupLocation(Location.Builder.newInstance().setId("pickLoc").build()).build();
-        assertEquals(1.0, s.getPickupTimeWindow().getStart(), 0.01);
-        assertEquals(2.0, s.getPickupTimeWindow().getEnd(), 0.01);
+        Assertions.assertEquals(1.0, s.getPickupTimeWindow().getStart(), 0.01);
+        Assertions.assertEquals(2.0, s.getPickupTimeWindow().getEnd(), 0.01);
     }
 
     @Test
     @DisplayName("When Delivery Time Window Is Not Set _ it Should Be The Default One")
     void whenDeliveryTimeWindowIsNotSet_itShouldBeTheDefaultOne() {
         Shipment s = Shipment.Builder.newInstance("s").setDeliveryLocation(TestUtils.loc("delLoc")).setPickupLocation(Location.Builder.newInstance().setId("pickLoc").build()).build();
-        assertEquals(0.0, s.getDeliveryTimeWindow().getStart(), 0.01);
-        assertEquals(Double.MAX_VALUE, s.getDeliveryTimeWindow().getEnd(), 0.01);
+        Assertions.assertEquals(0.0, s.getDeliveryTimeWindow().getStart(), 0.01);
+        Assertions.assertEquals(Double.MAX_VALUE, s.getDeliveryTimeWindow().getEnd(), 0.01);
     }
 
     @Test
     @DisplayName("When Delivery Time Window Is Null _ it Should Throw Exception")
     void whenDeliveryTimeWindowIsNull_itShouldThrowException() {
-        assertThrows(IllegalArgumentException.class, () -> {
+        Assertions.assertThrows(IllegalArgumentException.class, () -> {
             @SuppressWarnings("unused")
             Shipment s = Shipment.Builder.newInstance("s").setDeliveryTimeWindow(null).setDeliveryLocation(TestUtils.loc("delLoc")).setPickupLocation(Location.Builder.newInstance().setId("pickLoc").build()).build();
         });
@@ -247,24 +244,24 @@ class ShipmentTest {
     @DisplayName("When Delivery Time Window Is Set _ it Should Be Done Correctly")
     void whenDeliveryTimeWindowIsSet_itShouldBeDoneCorrectly() {
         Shipment s = Shipment.Builder.newInstance("s").setDeliveryTimeWindow(TimeWindow.newInstance(1, 2)).setDeliveryLocation(TestUtils.loc("delLoc")).setPickupLocation(Location.Builder.newInstance().setId("pickLoc").build()).build();
-        assertEquals(1.0, s.getDeliveryTimeWindow().getStart(), 0.01);
-        assertEquals(2.0, s.getDeliveryTimeWindow().getEnd(), 0.01);
+        Assertions.assertEquals(1.0, s.getDeliveryTimeWindow().getStart(), 0.01);
+        Assertions.assertEquals(2.0, s.getDeliveryTimeWindow().getEnd(), 0.01);
     }
 
     @Test
     @DisplayName("When Using Add Delivery Time Window _ it Should Be Done Correctly")
     void whenUsingAddDeliveryTimeWindow_itShouldBeDoneCorrectly() {
         Shipment s = Shipment.Builder.newInstance("s").addDeliveryTimeWindow(TimeWindow.newInstance(1, 2)).setDeliveryLocation(TestUtils.loc("delLoc")).setPickupLocation(Location.Builder.newInstance().setId("pickLoc").build()).build();
-        assertEquals(1.0, s.getDeliveryTimeWindow().getStart(), 0.01);
-        assertEquals(2.0, s.getDeliveryTimeWindow().getEnd(), 0.01);
+        Assertions.assertEquals(1.0, s.getDeliveryTimeWindow().getStart(), 0.01);
+        Assertions.assertEquals(2.0, s.getDeliveryTimeWindow().getEnd(), 0.01);
     }
 
     @Test
     @DisplayName("When Using Add Delivery Time Window 2 _ it Should Be Done Correctly")
     void whenUsingAddDeliveryTimeWindow2_itShouldBeDoneCorrectly() {
         Shipment s = Shipment.Builder.newInstance("s").addDeliveryTimeWindow(1, 2).setDeliveryLocation(TestUtils.loc("delLoc")).setPickupLocation(Location.Builder.newInstance().setId("pickLoc").build()).build();
-        assertEquals(1.0, s.getDeliveryTimeWindow().getStart(), 0.01);
-        assertEquals(2.0, s.getDeliveryTimeWindow().getEnd(), 0.01);
+        Assertions.assertEquals(1.0, s.getDeliveryTimeWindow().getStart(), 0.01);
+        Assertions.assertEquals(2.0, s.getDeliveryTimeWindow().getEnd(), 0.01);
     }
 
     @Test
@@ -273,18 +270,18 @@ class ShipmentTest {
         TimeWindow tw1 = TimeWindow.newInstance(1, 2);
         TimeWindow tw2 = TimeWindow.newInstance(4, 5);
         Shipment s = Shipment.Builder.newInstance("s").addDeliveryTimeWindow(tw1).addDeliveryTimeWindow(tw2).setDeliveryLocation(TestUtils.loc("delLoc")).setPickupLocation(Location.Builder.newInstance().setId("pickLoc").build()).build();
-        assertEquals(s.getDeliveryTimeWindows().size(), 2);
-        assertThat(s.getDeliveryTimeWindows(), hasItem(is(tw1)));
-        assertThat(s.getDeliveryTimeWindows(), hasItem(is(tw2)));
+        Assertions.assertEquals(s.getDeliveryTimeWindows().size(), 2);
+        Assertions.assertTrue(s.getDeliveryTimeWindows().contains(tw1));
+        Assertions.assertTrue(s.getDeliveryTimeWindows().contains(tw2));
     }
 
     @Test
     @DisplayName("When Adding Multiple Overlapping Delivery Time Windows _ it Should Throw Exception")
     void whenAddingMultipleOverlappingDeliveryTimeWindows_itShouldThrowException() {
-        assertThrows(IllegalArgumentException.class, () -> {
+        Assertions.assertThrows(IllegalArgumentException.class, () -> {
             Shipment s = Shipment.Builder.newInstance("s").addDeliveryTimeWindow(1, 3).addDeliveryTimeWindow(2, 5).setDeliveryLocation(TestUtils.loc("delLoc")).setPickupLocation(Location.Builder.newInstance().setId("pickLoc").build()).build();
-            assertEquals(1.0, s.getDeliveryTimeWindow().getStart(), 0.01);
-            assertEquals(2.0, s.getDeliveryTimeWindow().getEnd(), 0.01);
+            Assertions.assertEquals(1.0, s.getDeliveryTimeWindow().getStart(), 0.01);
+            Assertions.assertEquals(2.0, s.getDeliveryTimeWindow().getEnd(), 0.01);
         });
     }
 
@@ -292,16 +289,16 @@ class ShipmentTest {
     @DisplayName("When Using Add Pickup Time Window _ it Should Be Done Correctly")
     void whenUsingAddPickupTimeWindow_itShouldBeDoneCorrectly() {
         Shipment s = Shipment.Builder.newInstance("s").addPickupTimeWindow(TimeWindow.newInstance(1, 2)).setDeliveryLocation(TestUtils.loc("delLoc")).setPickupLocation(Location.Builder.newInstance().setId("pickLoc").build()).build();
-        assertEquals(1.0, s.getPickupTimeWindow().getStart(), 0.01);
-        assertEquals(2.0, s.getPickupTimeWindow().getEnd(), 0.01);
+        Assertions.assertEquals(1.0, s.getPickupTimeWindow().getStart(), 0.01);
+        Assertions.assertEquals(2.0, s.getPickupTimeWindow().getEnd(), 0.01);
     }
 
     @Test
     @DisplayName("When Using Add Pickup Time Window 2 _ it Should Be Done Correctly")
     void whenUsingAddPickupTimeWindow2_itShouldBeDoneCorrectly() {
         Shipment s = Shipment.Builder.newInstance("s").addPickupTimeWindow(1, 2).setDeliveryLocation(TestUtils.loc("delLoc")).setPickupLocation(Location.Builder.newInstance().setId("pickLoc").build()).build();
-        assertEquals(1.0, s.getPickupTimeWindow().getStart(), 0.01);
-        assertEquals(2.0, s.getPickupTimeWindow().getEnd(), 0.01);
+        Assertions.assertEquals(1.0, s.getPickupTimeWindow().getStart(), 0.01);
+        Assertions.assertEquals(2.0, s.getPickupTimeWindow().getEnd(), 0.01);
     }
 
     @Test
@@ -310,25 +307,25 @@ class ShipmentTest {
         TimeWindow tw1 = TimeWindow.newInstance(1, 2);
         TimeWindow tw2 = TimeWindow.newInstance(4, 5);
         Shipment s = Shipment.Builder.newInstance("s").addPickupTimeWindow(tw1).addPickupTimeWindow(tw2).setDeliveryLocation(TestUtils.loc("delLoc")).setPickupLocation(Location.Builder.newInstance().setId("pickLoc").build()).build();
-        assertEquals(s.getPickupTimeWindows().size(), 2);
-        assertThat(s.getPickupTimeWindows(), hasItem(is(tw1)));
-        assertThat(s.getPickupTimeWindows(), hasItem(is(tw2)));
+        Assertions.assertEquals(s.getPickupTimeWindows().size(), 2);
+        Assertions.assertTrue(s.getPickupTimeWindows().contains(tw1));
+        Assertions.assertTrue(s.getPickupTimeWindows().contains(tw2));
     }
 
     @Test
     @DisplayName("When Adding Multiple Overlapping Pickup Time Windows _ it Should Throw Exception")
     void whenAddingMultipleOverlappingPickupTimeWindows_itShouldThrowException() {
-        assertThrows(IllegalArgumentException.class, () -> {
+        Assertions.assertThrows(IllegalArgumentException.class, () -> {
             Shipment s = Shipment.Builder.newInstance("s").addPickupTimeWindow(1, 3).addPickupTimeWindow(2, 5).setDeliveryLocation(TestUtils.loc("delLoc")).setPickupLocation(Location.Builder.newInstance().setId("pickLoc").build()).build();
-            assertEquals(1.0, s.getPickupTimeWindow().getStart(), 0.01);
-            assertEquals(2.0, s.getPickupTimeWindow().getEnd(), 0.01);
+            Assertions.assertEquals(1.0, s.getPickupTimeWindow().getStart(), 0.01);
+            Assertions.assertEquals(2.0, s.getPickupTimeWindow().getEnd(), 0.01);
         });
     }
 
     @Test
     @DisplayName("When Shipment Has Negative Capacity Val _ throw Illegal State Expception")
     void whenShipmentHasNegativeCapacityVal_throwIllegalStateExpception() {
-        assertThrows(IllegalArgumentException.class, () -> {
+        Assertions.assertThrows(IllegalArgumentException.class, () -> {
             @SuppressWarnings("unused")
             Shipment one = Shipment.Builder.newInstance("s").setPickupLocation(Location.Builder.newInstance().setId("foo").build()).setDeliveryLocation(TestUtils.loc("foofoo")).addSizeDimension(0, -2).build();
         });
@@ -338,99 +335,99 @@ class ShipmentTest {
     @DisplayName("When Adding Two Cap Dimension _ nu Of Dims Should Be Two")
     void whenAddingTwoCapDimension_nuOfDimsShouldBeTwo() {
         Shipment one = Shipment.Builder.newInstance("s").setPickupLocation(Location.Builder.newInstance().setId("foo").build()).setDeliveryLocation(TestUtils.loc("foofoo")).addSizeDimension(0, 2).addSizeDimension(1, 4).build();
-        assertEquals(2, one.getSize().getNuOfDimensions());
+        Assertions.assertEquals(2, one.getSize().getNuOfDimensions());
     }
 
     @Test
     @DisplayName("When Shipment Is Built Without Specifying Capacity _ it Should Hv Cap With One Dim And Dim Val Of Zero")
     void whenShipmentIsBuiltWithoutSpecifyingCapacity_itShouldHvCapWithOneDimAndDimValOfZero() {
         Shipment one = Shipment.Builder.newInstance("s").setPickupLocation(Location.Builder.newInstance().setId("foo").setCoordinate(Coordinate.newInstance(0, 0)).build()).setDeliveryLocation(TestUtils.loc("foofoo")).build();
-        assertEquals(1, one.getSize().getNuOfDimensions());
-        assertEquals(0, one.getSize().get(0));
+        Assertions.assertEquals(1, one.getSize().getNuOfDimensions());
+        Assertions.assertEquals(0, one.getSize().get(0));
     }
 
     @Test
     @DisplayName("When Shipment Is Built With Constructor Where Size Is Specified _ capacity Should Be Set Correctly")
     void whenShipmentIsBuiltWithConstructorWhereSizeIsSpecified_capacityShouldBeSetCorrectly() {
         Shipment one = Shipment.Builder.newInstance("s").addSizeDimension(0, 1).setPickupLocation(Location.Builder.newInstance().setId("foo").setCoordinate(Coordinate.newInstance(0, 0)).build()).setDeliveryLocation(TestUtils.loc("foofoo")).build();
-        assertEquals(1, one.getSize().getNuOfDimensions());
-        assertEquals(1, one.getSize().get(0));
+        Assertions.assertEquals(1, one.getSize().getNuOfDimensions());
+        Assertions.assertEquals(1, one.getSize().get(0));
     }
 
     @Test
     @DisplayName("When Adding Skills _ they Should Be Added Correctly")
     void whenAddingSkills_theyShouldBeAddedCorrectly() {
         Shipment s = Shipment.Builder.newInstance("s").setPickupLocation(Location.Builder.newInstance().setId("loc").build()).setDeliveryLocation(TestUtils.loc("delLoc")).addRequiredSkill("drill").addRequiredSkill("screwdriver").build();
-        assertTrue(s.getRequiredSkills().containsSkill("drill"));
-        assertTrue(s.getRequiredSkills().containsSkill("drill"));
-        assertTrue(s.getRequiredSkills().containsSkill("ScrewDriver"));
+        Assertions.assertTrue(s.getRequiredSkills().containsSkill("drill"));
+        Assertions.assertTrue(s.getRequiredSkills().containsSkill("drill"));
+        Assertions.assertTrue(s.getRequiredSkills().containsSkill("ScrewDriver"));
     }
 
     @Test
     @DisplayName("When Adding Skills Case Sens _ they Should Be Added Correctly")
     void whenAddingSkillsCaseSens_theyShouldBeAddedCorrectly() {
         Shipment s = Shipment.Builder.newInstance("s").setPickupLocation(Location.Builder.newInstance().setId("pick").build()).setDeliveryLocation(TestUtils.loc("del")).addRequiredSkill("DriLl").addRequiredSkill("screwDriver").build();
-        assertTrue(s.getRequiredSkills().containsSkill("drill"));
-        assertTrue(s.getRequiredSkills().containsSkill("drilL"));
+        Assertions.assertTrue(s.getRequiredSkills().containsSkill("drill"));
+        Assertions.assertTrue(s.getRequiredSkills().containsSkill("drilL"));
     }
 
     @Test
     @DisplayName("When Adding Skills Case Sens V 2 _ they Should Be Added Correctly")
     void whenAddingSkillsCaseSensV2_theyShouldBeAddedCorrectly() {
         Shipment s = Shipment.Builder.newInstance("s").setPickupLocation(Location.Builder.newInstance().setId("loc").build()).setDeliveryLocation(TestUtils.loc("del")).addRequiredSkill("screwDriver").build();
-        assertFalse(s.getRequiredSkills().containsSkill("drill"));
-        assertFalse(s.getRequiredSkills().containsSkill("drilL"));
+        Assertions.assertFalse(s.getRequiredSkills().containsSkill("drill"));
+        Assertions.assertFalse(s.getRequiredSkills().containsSkill("drilL"));
     }
 
     @Test
     @DisplayName("Name Should Be Assigned")
     void nameShouldBeAssigned() {
         Shipment s = Shipment.Builder.newInstance("s").setPickupLocation(Location.Builder.newInstance().setId("loc").build()).setDeliveryLocation(TestUtils.loc("del")).setName("name").build();
-        assertEquals(s.getName(), "name");
+        Assertions.assertEquals(s.getName(), "name");
     }
 
     @Test
     @DisplayName("When Setting Location _ it Should Work")
     void whenSettingLocation_itShouldWork() {
         Shipment s = Shipment.Builder.newInstance("s").setPickupLocation(Location.Builder.newInstance().setId("loc").build()).setDeliveryLocation(Location.Builder.newInstance().setId("del").build()).build();
-        assertEquals(s.getPickupLocation().getId(), "loc");
-        assertEquals(s.getPickupLocation().getId(), "loc");
-        assertEquals(s.getDeliveryLocation().getId(), "del");
-        assertEquals(s.getDeliveryLocation().getId(), "del");
+        Assertions.assertEquals(s.getPickupLocation().getId(), "loc");
+        Assertions.assertEquals(s.getPickupLocation().getId(), "loc");
+        Assertions.assertEquals(s.getDeliveryLocation().getId(), "del");
+        Assertions.assertEquals(s.getDeliveryLocation().getId(), "del");
     }
 
     @Test
     @DisplayName("When Setting Priorities _ it Should Be Set Correctly")
     void whenSettingPriorities_itShouldBeSetCorrectly() {
         Shipment s = Shipment.Builder.newInstance("s").setPickupLocation(Location.newInstance("loc")).setDeliveryLocation(Location.newInstance("loc")).setPriority(1).build();
-        assertEquals(1, s.getPriority());
+        Assertions.assertEquals(1, s.getPriority());
     }
 
     @Test
     @DisplayName("When Setting Priorities _ it Should Be Set Correctly 2")
     void whenSettingPriorities_itShouldBeSetCorrectly2() {
         Shipment s = Shipment.Builder.newInstance("s").setPickupLocation(Location.newInstance("loc")).setDeliveryLocation(Location.newInstance("loc")).setPriority(3).build();
-        assertEquals(3, s.getPriority());
+        Assertions.assertEquals(3, s.getPriority());
     }
 
     @Test
     @DisplayName("When Setting Priorities _ it Should Be Set Correctly 3")
     void whenSettingPriorities_itShouldBeSetCorrectly3() {
         Shipment s = Shipment.Builder.newInstance("s").setPickupLocation(Location.newInstance("loc")).setDeliveryLocation(Location.newInstance("loc")).setPriority(10).build();
-        assertEquals(10, s.getPriority());
+        Assertions.assertEquals(10, s.getPriority());
     }
 
     @Test
     @DisplayName("When Not Setting Priorities _ default Should Be 2")
     void whenNotSettingPriorities_defaultShouldBe2() {
         Shipment s = Shipment.Builder.newInstance("s").setPickupLocation(Location.newInstance("loc")).setDeliveryLocation(Location.newInstance("loc")).build();
-        assertEquals(2, s.getPriority());
+        Assertions.assertEquals(2, s.getPriority());
     }
 
     @Test
     @DisplayName("When Setting Incorrect Priorities _ it Should Throw Exception")
     void whenSettingIncorrectPriorities_itShouldThrowException() {
-        assertThrows(IllegalArgumentException.class, () -> {
+        Assertions.assertThrows(IllegalArgumentException.class, () -> {
             Shipment s = Shipment.Builder.newInstance("s").setPickupLocation(Location.newInstance("loc")).setDeliveryLocation(Location.newInstance("loc")).setPriority(30).build();
         });
     }
@@ -438,7 +435,7 @@ class ShipmentTest {
     @Test
     @DisplayName("When Setting Incorrect Priorities _ it Should Throw Exception 2")
     void whenSettingIncorrectPriorities_itShouldThrowException2() {
-        assertThrows(IllegalArgumentException.class, () -> {
+        Assertions.assertThrows(IllegalArgumentException.class, () -> {
             Shipment s = Shipment.Builder.newInstance("s").setPickupLocation(Location.newInstance("loc")).setDeliveryLocation(Location.newInstance("loc")).setPriority(0).build();
         });
     }
@@ -449,31 +446,31 @@ class ShipmentTest {
         Shipment one = Shipment.Builder.newInstance("s").setPickupLocation(Location.newInstance("loc")).setDeliveryLocation(Location.newInstance("loc")).setUserData(new HashMap<String, Object>()).build();
         Shipment two = Shipment.Builder.newInstance("s2").setPickupLocation(Location.newInstance("loc")).setDeliveryLocation(Location.newInstance("loc")).setUserData(42).build();
         Shipment three = Shipment.Builder.newInstance("s3").setPickupLocation(Location.newInstance("loc")).setDeliveryLocation(Location.newInstance("loc")).build();
-        assertTrue(one.getUserData() instanceof Map);
-        assertEquals(42, two.getUserData());
-        assertNull(three.getUserData());
+        Assertions.assertTrue(one.getUserData() instanceof Map);
+        Assertions.assertEquals(42, two.getUserData());
+        Assertions.assertNull(three.getUserData());
     }
 
     @Test
     @DisplayName("When Adding Max Time In Vehicle _ it Should Be Set")
     void whenAddingMaxTimeInVehicle_itShouldBeSet() {
         Shipment s = Shipment.Builder.newInstance("s").setPickupLocation(Location.newInstance("loc")).setDeliveryLocation(Location.newInstance("loc")).setMaxTimeInVehicle(10).build();
-        assertEquals(10, s.getMaxTimeInVehicle(), 0.001);
+        Assertions.assertEquals(10, s.getMaxTimeInVehicle(), 0.001);
     }
 
     @Test
     @DisplayName("When Not Adding Max Time In Vehicle _ it Should Be Default")
     void whenNotAddingMaxTimeInVehicle_itShouldBeDefault() {
         Shipment s = Shipment.Builder.newInstance("s").setPickupLocation(Location.newInstance("loc")).setDeliveryLocation(Location.newInstance("loc")).build();
-        assertEquals(Double.MAX_VALUE, s.getMaxTimeInVehicle(), 0.001);
+        Assertions.assertEquals(Double.MAX_VALUE, s.getMaxTimeInVehicle(), 0.001);
     }
 
     @Test
     @DisplayName("Test Shipment Activities")
     void testShipmentActivities() {
         Job job = Shipment.Builder.newInstance("s").setPickupLocation(Location.newInstance("loc")).setDeliveryLocation(Location.newInstance("loc")).build();
-        assertEquals(2, job.getActivities().size());
-        assertEquals(Activity.Type.PICKUP, job.getActivities().get(0).getActivityType());
-        assertEquals(Activity.Type.DELIVERY, job.getActivities().get(1).getActivityType());
+        Assertions.assertEquals(2, job.getActivities().size());
+        Assertions.assertEquals(Activity.Type.PICKUP, job.getActivities().get(0).getActivityType());
+        Assertions.assertEquals(Activity.Type.DELIVERY, job.getActivities().get(1).getActivityType());
     }
 }

--- a/jsprit-core/src/test/java/com/graphhopper/jsprit/core/problem/misc/JobInsertionContextTest.java
+++ b/jsprit-core/src/test/java/com/graphhopper/jsprit/core/problem/misc/JobInsertionContextTest.java
@@ -22,6 +22,8 @@ import com.graphhopper.jsprit.core.problem.job.Job;
 import com.graphhopper.jsprit.core.problem.solution.route.VehicleRoute;
 import com.graphhopper.jsprit.core.problem.solution.route.activity.TourActivity;
 import com.graphhopper.jsprit.core.problem.vehicle.Vehicle;
+
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -58,31 +60,31 @@ class JobInsertionContextTest {
     @Test
     @DisplayName("Route Should Be Assigned")
     void routeShouldBeAssigned() {
-        assertEquals(route, context.getRoute());
+        Assertions.assertEquals(route, context.getRoute());
     }
 
     @Test
     @DisplayName("Job Should Be Assigned")
     void jobShouldBeAssigned() {
-        assertEquals(job, context.getJob());
+        Assertions.assertEquals(job, context.getJob());
     }
 
     @Test
     @DisplayName("Vehicle Should Be Assigned")
     void vehicleShouldBeAssigned() {
-        assertEquals(vehicle, context.getNewVehicle());
+        Assertions.assertEquals(vehicle, context.getNewVehicle());
     }
 
     @Test
     @DisplayName("Driver Should Be Assigned")
     void driverShouldBeAssigned() {
-        assertEquals(driver, context.getNewDriver());
+        Assertions.assertEquals(driver, context.getNewDriver());
     }
 
     @Test
     @DisplayName("Dep Time Should Be Assigned")
     void depTimeShouldBeAssigned() {
-        assertEquals(0., context.getNewDepTime(), 0.001);
+        Assertions.assertEquals(0., context.getNewDepTime(), 0.001);
     }
 
     @Test
@@ -90,7 +92,7 @@ class JobInsertionContextTest {
     void relatedActivitiesShouldBeAssigned() {
         context.getAssociatedActivities().add(mock(TourActivity.class));
         context.getAssociatedActivities().add(mock(TourActivity.class));
-        assertEquals(2, context.getAssociatedActivities().size());
+        Assertions.assertEquals(2, context.getAssociatedActivities().size());
     }
 
     @Test

--- a/jsprit-core/src/test/java/com/graphhopper/jsprit/core/problem/solution/VehicleRoutingProblemSolutionTest.java
+++ b/jsprit-core/src/test/java/com/graphhopper/jsprit/core/problem/solution/VehicleRoutingProblemSolutionTest.java
@@ -40,14 +40,14 @@ class VehicleRoutingProblemSolutionTest {
         VehicleRoute r1 = mock(VehicleRoute.class);
         VehicleRoute r2 = mock(VehicleRoute.class);
         VehicleRoutingProblemSolution sol = new VehicleRoutingProblemSolution(Arrays.asList(r1, r2), 0.0);
-        assertEquals(2, sol.getRoutes().size());
+		Assertions.assertEquals(2, sol.getRoutes().size());
     }
 
     @Test
     @DisplayName("When Setting Solution Costs To 10 _ solution Costs Should Be 10")
     void whenSettingSolutionCostsTo10_solutionCostsShouldBe10() {
         VehicleRoutingProblemSolution sol = new VehicleRoutingProblemSolution(Collections.<VehicleRoute>emptyList(), 10.0);
-        assertEquals(10.0, sol.getCost(), 0.01);
+		Assertions.assertEquals(10.0, sol.getCost(), 0.01);
     }
 
     @Test
@@ -55,7 +55,7 @@ class VehicleRoutingProblemSolutionTest {
     void whenCreatingSolWithCostsOf10AndSettingCostsAfterwardsTo20_solutionCostsShouldBe20() {
         VehicleRoutingProblemSolution sol = new VehicleRoutingProblemSolution(Collections.<VehicleRoute>emptyList(), 10.0);
         sol.setCost(20.0);
-        assertEquals(20.0, sol.getCost(), 0.01);
+		Assertions.assertEquals(20.0, sol.getCost(), 0.01);
     }
 
     @Test
@@ -65,7 +65,7 @@ class VehicleRoutingProblemSolutionTest {
         List<Job> badJobs = new ArrayList<Job>();
         badJobs.add(badJob);
         VehicleRoutingProblemSolution sol = new VehicleRoutingProblemSolution(Collections.<VehicleRoute>emptyList(), badJobs, 10.0);
-        assertEquals(1, sol.getUnassignedJobs().size());
+		Assertions.assertEquals(1, sol.getUnassignedJobs().size());
     }
 
     @Test
@@ -76,7 +76,7 @@ class VehicleRoutingProblemSolutionTest {
         badJobs.add(badJob);
         VehicleRoutingProblemSolution sol = new VehicleRoutingProblemSolution(Collections.<VehicleRoute>emptyList(), 10.0);
         sol.getUnassignedJobs().addAll(badJobs);
-        assertEquals(1, sol.getUnassignedJobs().size());
+		Assertions.assertEquals(1, sol.getUnassignedJobs().size());
     }
 
     @Test

--- a/jsprit-core/src/test/java/com/graphhopper/jsprit/core/problem/solution/route/TestVehicleRoute.java
+++ b/jsprit-core/src/test/java/com/graphhopper/jsprit/core/problem/solution/route/TestVehicleRoute.java
@@ -30,13 +30,12 @@ import com.graphhopper.jsprit.core.problem.solution.route.activity.TourActivity;
 import com.graphhopper.jsprit.core.problem.vehicle.Vehicle;
 import com.graphhopper.jsprit.core.problem.vehicle.VehicleImpl;
 import com.graphhopper.jsprit.core.problem.vehicle.VehicleTypeImpl;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.util.Iterator;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
 
 
 public class TestVehicleRoute {
@@ -44,7 +43,7 @@ public class TestVehicleRoute {
     private VehicleImpl vehicle;
     private NoDriver driver;
 
-    @Before
+    @BeforeEach
     public void doBefore() {
         vehicle = VehicleImpl.Builder.newInstance("v").setStartLocation(Location.newInstance("loc")).setType(VehicleTypeImpl.Builder.newInstance("yo").build()).build();
         driver = DriverImpl.noDriver();
@@ -53,13 +52,13 @@ public class TestVehicleRoute {
     @Test
     public void whenBuildingEmptyRouteCorrectly_go() {
         VehicleRoute route = VehicleRoute.Builder.newInstance(VehicleImpl.createNoVehicle(), DriverImpl.noDriver()).build();
-        assertTrue(route != null);
+        Assertions.assertTrue(route != null);
     }
 
     @Test
     public void whenBuildingEmptyRouteCorrectlyV2_go() {
         VehicleRoute route = VehicleRoute.emptyRoute();
-        assertTrue(route != null);
+        Assertions.assertTrue(route != null);
     }
 
     @Test
@@ -71,13 +70,15 @@ public class TestVehicleRoute {
             iter.next();
             count++;
         }
-        assertEquals(0, count);
+        Assertions.assertEquals(0, count);
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void whenBuildingRouteWithNulls_itThrowsException() {
-        @SuppressWarnings("unused")
-        VehicleRoute route = VehicleRoute.Builder.newInstance(null, null).build();
+        Assertions.assertThrows(IllegalArgumentException.class, () -> {
+            @SuppressWarnings("unused")
+            VehicleRoute route = VehicleRoute.Builder.newInstance(null, null).build();
+        });
     }
 
     @Test
@@ -94,7 +95,7 @@ public class TestVehicleRoute {
                 TourActivity act = iter.next();
                 count++;
             }
-            assertEquals(1, count);
+            Assertions.assertEquals(1, count);
         }
         {
             route.getTourActivities().addActivity(ServiceActivity.newInstance(Service.Builder.newInstance("3").addSizeDimension(0, 30).setLocation(Location.newInstance("1")).build()));
@@ -105,7 +106,7 @@ public class TestVehicleRoute {
                 TourActivity act = iter.next();
                 count++;
             }
-            assertEquals(2, count);
+            Assertions.assertEquals(2, count);
         }
     }
 
@@ -119,7 +120,7 @@ public class TestVehicleRoute {
             TourActivity act = iter.next();
             count++;
         }
-        assertEquals(0, count);
+        Assertions.assertEquals(0, count);
     }
 
     @Test
@@ -134,7 +135,7 @@ public class TestVehicleRoute {
             TourActivity act = iter.next();
             count++;
         }
-        assertEquals(1, count);
+        Assertions.assertEquals(1, count);
     }
 
     @Test
@@ -149,11 +150,11 @@ public class TestVehicleRoute {
             while (iter.hasNext()) {
                 TourActivity act = iter.next();
                 if (count == 0) {
-                    assertEquals("2", act.getLocation().getId());
+                    Assertions.assertEquals("2", act.getLocation().getId());
                 }
                 count++;
             }
-            assertEquals(2, count);
+            Assertions.assertEquals(2, count);
         }
         {
             Iterator<TourActivity> secondIter = route.getTourActivities().reverseActivityIterator();
@@ -161,11 +162,11 @@ public class TestVehicleRoute {
             while (secondIter.hasNext()) {
                 TourActivity act = secondIter.next();
                 if (count == 0) {
-                    assertEquals("2", act.getLocation().getId());
+                    Assertions.assertEquals("2", act.getLocation().getId());
                 }
                 count++;
             }
-            assertEquals(2, count);
+            Assertions.assertEquals(2, count);
         }
     }
 
@@ -173,57 +174,57 @@ public class TestVehicleRoute {
     public void whenBuildingRouteWithVehicleThatHasDifferentStartAndEndLocation_routeMustHaveCorrectStartLocation() {
         Vehicle vehicle = VehicleImpl.Builder.newInstance("v").setStartLocation(Location.newInstance("start")).setEndLocation(Location.newInstance("end")).build();
         VehicleRoute vRoute = VehicleRoute.Builder.newInstance(vehicle, DriverImpl.noDriver()).build();
-        assertTrue(vRoute.getStart().getLocation().getId().equals("start"));
+        Assertions.assertTrue(vRoute.getStart().getLocation().getId().equals("start"));
     }
 
     @Test
     public void whenBuildingRouteWithVehicleThatHasDifferentStartAndEndLocation_routeMustHaveCorrectEndLocation() {
         Vehicle vehicle = VehicleImpl.Builder.newInstance("v").setStartLocation(Location.newInstance("start")).setEndLocation(Location.newInstance("end")).build();
         VehicleRoute vRoute = VehicleRoute.Builder.newInstance(vehicle, DriverImpl.noDriver()).build();
-        assertTrue(vRoute.getEnd().getLocation().getId().equals("end"));
+        Assertions.assertTrue(vRoute.getEnd().getLocation().getId().equals("end"));
     }
 
     @Test
     public void whenBuildingRouteWithVehicleThatHasSameStartAndEndLocation_routeMustHaveCorrectStartLocation() {
         Vehicle vehicle = VehicleImpl.Builder.newInstance("v").setStartLocation(Location.newInstance("start")).setEndLocation(Location.newInstance("end")).build();
         VehicleRoute vRoute = VehicleRoute.Builder.newInstance(vehicle, DriverImpl.noDriver()).build();
-        assertTrue(vRoute.getStart().getLocation().getId().equals("start"));
+        Assertions.assertTrue(vRoute.getStart().getLocation().getId().equals("start"));
     }
 
     @Test
     public void whenBuildingRouteWithVehicleThatHasSameStartAndEndLocation_routeMustHaveCorrectEndLocation() {
         Vehicle vehicle = VehicleImpl.Builder.newInstance("v").setStartLocation(Location.newInstance("start")).setEndLocation(Location.newInstance("start")).build();
         VehicleRoute vRoute = VehicleRoute.Builder.newInstance(vehicle, DriverImpl.noDriver()).build();
-        assertTrue(vRoute.getEnd().getLocation().getId().equals("start"));
+        Assertions.assertTrue(vRoute.getEnd().getLocation().getId().equals("start"));
     }
 
     @Test
     public void whenBuildingRouteWithVehicleThatHasSameStartAndEndLocation_routeMustHaveCorrectStartLocationV2() {
         Vehicle vehicle = VehicleImpl.Builder.newInstance("v").setStartLocation(Location.newInstance("start")).setEndLocation(Location.newInstance("end")).build();
         VehicleRoute vRoute = VehicleRoute.Builder.newInstance(vehicle, DriverImpl.noDriver()).build();
-        assertTrue(vRoute.getStart().getLocation().getId().equals("start"));
+        Assertions.assertTrue(vRoute.getStart().getLocation().getId().equals("start"));
     }
 
     @Test
     public void whenBuildingRouteWithVehicleThatHasSameStartAndEndLocation_routeMustHaveCorrectEndLocationV2() {
         Vehicle vehicle = VehicleImpl.Builder.newInstance("v").setStartLocation(Location.newInstance("start")).setEndLocation(Location.newInstance("start")).build();
         VehicleRoute vRoute = VehicleRoute.Builder.newInstance(vehicle, DriverImpl.noDriver()).build();
-        assertTrue(vRoute.getEnd().getLocation().getId().equals("start"));
+        Assertions.assertTrue(vRoute.getEnd().getLocation().getId().equals("start"));
     }
 
     @Test
     public void whenBuildingRouteWithVehicleThatHasDifferentStartAndEndLocation_routeMustHaveCorrectDepartureTime() {
         Vehicle vehicle = VehicleImpl.Builder.newInstance("v").setEarliestStart(100).setStartLocation(Location.newInstance("start")).setEndLocation(Location.newInstance("end")).build();
         VehicleRoute vRoute = VehicleRoute.Builder.newInstance(vehicle, DriverImpl.noDriver()).build();
-        assertEquals(vRoute.getDepartureTime(), 100.0, 0.01);
-        assertEquals(vRoute.getStart().getEndTime(), 100.0, 0.01);
+        Assertions.assertEquals(vRoute.getDepartureTime(), 100.0, 0.01);
+        Assertions.assertEquals(vRoute.getStart().getEndTime(), 100.0, 0.01);
     }
 
     @Test
     public void whenBuildingRouteWithVehicleThatHasDifferentStartAndEndLocation_routeMustHaveCorrectEndTime() {
         Vehicle vehicle = VehicleImpl.Builder.newInstance("v").setEarliestStart(100).setLatestArrival(200).setStartLocation(Location.newInstance("start")).setEndLocation(Location.newInstance("end")).build();
         VehicleRoute vRoute = VehicleRoute.Builder.newInstance(vehicle, DriverImpl.noDriver()).build();
-        assertEquals(200.0, vRoute.getEnd().getTheoreticalLatestOperationStartTime(), 0.01);
+        Assertions.assertEquals(200.0, vRoute.getEnd().getTheoreticalLatestOperationStartTime(), 0.01);
     }
 
     @Test
@@ -231,8 +232,8 @@ public class TestVehicleRoute {
         Vehicle vehicle = VehicleImpl.Builder.newInstance("v").setEarliestStart(100).setLatestArrival(200).setStartLocation(Location.newInstance("start")).setEndLocation(Location.newInstance("end")).build();
         VehicleRoute vRoute = VehicleRoute.Builder.newInstance(vehicle, DriverImpl.noDriver()).build();
         vRoute.setVehicleAndDepartureTime(vehicle, 150.0);
-        assertEquals(vRoute.getStart().getEndTime(), 150.0, 0.01);
-        assertEquals(vRoute.getDepartureTime(), 150.0, 0.01);
+        Assertions.assertEquals(vRoute.getStart().getEndTime(), 150.0, 0.01);
+        Assertions.assertEquals(vRoute.getDepartureTime(), 150.0, 0.01);
     }
 
     @Test
@@ -240,8 +241,8 @@ public class TestVehicleRoute {
         Vehicle vehicle = VehicleImpl.Builder.newInstance("v").setEarliestStart(100).setLatestArrival(200).setStartLocation(Location.newInstance("start")).setEndLocation(Location.newInstance("end")).build();
         VehicleRoute vRoute = VehicleRoute.Builder.newInstance(vehicle, DriverImpl.noDriver()).build();
         vRoute.setVehicleAndDepartureTime(vehicle, 50.0);
-        assertEquals(vRoute.getStart().getEndTime(), 100.0, 0.01);
-        assertEquals(vRoute.getDepartureTime(), 100.0, 0.01);
+        Assertions.assertEquals(vRoute.getStart().getEndTime(), 100.0, 0.01);
+        Assertions.assertEquals(vRoute.getDepartureTime(), 100.0, 0.01);
     }
 
     @Test
@@ -249,15 +250,15 @@ public class TestVehicleRoute {
         Vehicle vehicle = VehicleImpl.Builder.newInstance("v").setEarliestStart(100).setLatestArrival(200).setStartLocation(Location.newInstance("start")).setEndLocation(Location.newInstance("end")).build();
         VehicleRoute vRoute = VehicleRoute.Builder.newInstance(vehicle, DriverImpl.noDriver()).build();
         vRoute.setVehicleAndDepartureTime(vehicle, 50.0);
-        assertEquals(vRoute.getStart().getEndTime(), 100.0, 0.01);
-        assertEquals(vRoute.getDepartureTime(), 100.0, 0.01);
+        Assertions.assertEquals(vRoute.getStart().getEndTime(), 100.0, 0.01);
+        Assertions.assertEquals(vRoute.getDepartureTime(), 100.0, 0.01);
     }
 
     @Test
     public void whenCreatingEmptyRoute_itMustReturnEmptyRoute() {
         @SuppressWarnings("unused")
         VehicleRoute route = VehicleRoute.emptyRoute();
-        assertTrue(true);
+        Assertions.assertTrue(true);
     }
 
     @Test
@@ -266,7 +267,7 @@ public class TestVehicleRoute {
         Vehicle new_vehicle = VehicleImpl.Builder.newInstance("new_v").setEarliestStart(1000).setLatestArrival(2000).setStartLocation(Location.newInstance("new_start")).setEndLocation(Location.newInstance("new_end")).build();
         VehicleRoute vRoute = VehicleRoute.Builder.newInstance(vehicle, DriverImpl.noDriver()).build();
         vRoute.setVehicleAndDepartureTime(new_vehicle, 50.0);
-        assertEquals("new_start", vRoute.getStart().getLocation().getId());
+        Assertions.assertEquals("new_start", vRoute.getStart().getLocation().getId());
     }
 
     @Test
@@ -275,7 +276,7 @@ public class TestVehicleRoute {
         Vehicle new_vehicle = VehicleImpl.Builder.newInstance("new_v").setEarliestStart(1000).setLatestArrival(2000).setStartLocation(Location.newInstance("new_start")).setEndLocation(Location.newInstance("new_end")).build();
         VehicleRoute vRoute = VehicleRoute.Builder.newInstance(vehicle, DriverImpl.noDriver()).build();
         vRoute.setVehicleAndDepartureTime(new_vehicle, 50.0);
-        assertEquals("new_end", vRoute.getEnd().getLocation().getId());
+        Assertions.assertEquals("new_end", vRoute.getEnd().getLocation().getId());
     }
 
     @Test
@@ -284,7 +285,7 @@ public class TestVehicleRoute {
         Vehicle new_vehicle = VehicleImpl.Builder.newInstance("new_v").setEarliestStart(1000).setLatestArrival(2000).setStartLocation(Location.newInstance("new_start")).setEndLocation(Location.newInstance("new_end")).build();
         VehicleRoute vRoute = VehicleRoute.Builder.newInstance(vehicle, DriverImpl.noDriver()).build();
         vRoute.setVehicleAndDepartureTime(new_vehicle, 50.0);
-        assertEquals(1000.0, vRoute.getDepartureTime(), 0.01);
+        Assertions.assertEquals(1000.0, vRoute.getDepartureTime(), 0.01);
     }
 
     @Test
@@ -293,7 +294,7 @@ public class TestVehicleRoute {
         Vehicle new_vehicle = VehicleImpl.Builder.newInstance("new_v").setEarliestStart(1000).setLatestArrival(2000).setStartLocation(Location.newInstance("new_start")).setEndLocation(Location.newInstance("new_end")).build();
         VehicleRoute vRoute = VehicleRoute.Builder.newInstance(vehicle, DriverImpl.noDriver()).build();
         vRoute.setVehicleAndDepartureTime(new_vehicle, 1500.0);
-        assertEquals(1500.0, vRoute.getDepartureTime(), 0.01);
+        Assertions.assertEquals(1500.0, vRoute.getDepartureTime(), 0.01);
     }
 
     @Test
@@ -304,9 +305,9 @@ public class TestVehicleRoute {
         VehicleRoute route = VehicleRoute.Builder.newInstance(vehicle).addService(pickup).build();
 
         TourActivity act = route.getActivities().get(0);
-        assertTrue(act.getName().equals("pickup"));
-        assertTrue(act instanceof PickupService);
-        assertTrue(((TourActivity.JobActivity) act).getJob().getJobType().isPickup());
+        Assertions.assertTrue(act.getName().equals("pickup"));
+        Assertions.assertTrue(act instanceof PickupService);
+        Assertions.assertTrue(((TourActivity.JobActivity) act).getJob().getJobType().isPickup());
 
     }
 
@@ -318,9 +319,9 @@ public class TestVehicleRoute {
         VehicleRoute route = VehicleRoute.Builder.newInstance(vehicle).addPickup(pickup).build();
 
         TourActivity act = route.getActivities().get(0);
-        assertTrue(act.getName().equals("pickup"));
-        assertTrue(act instanceof PickupService);
-        assertTrue(((TourActivity.JobActivity) act).getJob().getJobType().isPickup());
+        Assertions.assertTrue(act.getName().equals("pickup"));
+        Assertions.assertTrue(act instanceof PickupService);
+        Assertions.assertTrue(((TourActivity.JobActivity) act).getJob().getJobType().isPickup());
 
     }
 
@@ -332,9 +333,9 @@ public class TestVehicleRoute {
         VehicleRoute route = VehicleRoute.Builder.newInstance(vehicle).addService(delivery).build();
 
         TourActivity act = route.getActivities().get(0);
-        assertTrue(act.getName().equals("delivery"));
-        assertTrue(act instanceof DeliverService);
-        assertTrue(((TourActivity.JobActivity) act).getJob().getJobType().isDelivery());
+        Assertions.assertTrue(act.getName().equals("delivery"));
+        Assertions.assertTrue(act instanceof DeliverService);
+        Assertions.assertTrue(((TourActivity.JobActivity) act).getJob().getJobType().isDelivery());
 
     }
 
@@ -346,9 +347,9 @@ public class TestVehicleRoute {
         VehicleRoute route = VehicleRoute.Builder.newInstance(vehicle).addDelivery(delivery).build();
 
         TourActivity act = route.getActivities().get(0);
-        assertTrue(act.getName().equals("delivery"));
-        assertTrue(act instanceof DeliverService);
-        assertTrue(((TourActivity.JobActivity) act).getJob().getJobType().isDelivery());
+        Assertions.assertTrue(act.getName().equals("delivery"));
+        Assertions.assertTrue(act instanceof DeliverService);
+        Assertions.assertTrue(((TourActivity.JobActivity) act).getJob().getJobType().isDelivery());
 
     }
 }

--- a/jsprit-core/src/test/java/com/graphhopper/jsprit/core/problem/solution/route/VehicleRouteBuilderTest.java
+++ b/jsprit-core/src/test/java/com/graphhopper/jsprit/core/problem/solution/route/VehicleRouteBuilderTest.java
@@ -25,6 +25,8 @@ import com.graphhopper.jsprit.core.problem.job.Shipment;
 import com.graphhopper.jsprit.core.problem.solution.route.activity.TimeWindow;
 import com.graphhopper.jsprit.core.problem.vehicle.Vehicle;
 import com.graphhopper.jsprit.core.problem.vehicle.VehicleImpl;
+
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -117,7 +119,7 @@ class VehicleRouteBuilderTest {
         Shipment shipment2 = createMockShipment(null);
         builder.addPickup(shipment1).addPickup(shipment2).addDelivery(shipment1).addDelivery(shipment2);
         VehicleRoute route = builder.build();
-        assertEquals(4, route.getTourActivities().getActivities().size());
+        Assertions.assertEquals(4, route.getTourActivities().getActivities().size());
     }
 
     @Test
@@ -127,7 +129,7 @@ class VehicleRouteBuilderTest {
         Shipment s2 = createMockShipment(null);
         Vehicle vehicle = VehicleImpl.Builder.newInstance("v").setStartLocation(Location.newInstance("vehLoc")).setEndLocation(Location.newInstance("vehLoc")).build();
         VehicleRoute route = VehicleRoute.Builder.newInstance(vehicle, driver).addPickup(s).addPickup(s2).addDelivery(s).addDelivery(s2).build();
-        assertEquals(route.getEnd().getLocation().getId(), "vehLoc");
+        Assertions.assertEquals(route.getEnd().getLocation().getId(), "vehLoc");
     }
 
     @Test
@@ -139,7 +141,7 @@ class VehicleRouteBuilderTest {
         when(vehicle.isReturnToDepot()).thenReturn(false);
         when(vehicle.getStartLocation()).thenReturn(loc("vehLoc"));
         VehicleRoute route = VehicleRoute.Builder.newInstance(vehicle, mock(Driver.class)).addPickup(s).addPickup(s2).addDelivery(s).addDelivery(s2).build();
-        assertEquals(route.getEnd().getLocation().getId(), s2.getDeliveryLocation().getId());
+        Assertions.assertEquals(route.getEnd().getLocation().getId(), s2.getDeliveryLocation().getId());
     }
 
     private Location loc(String delLoc) {
@@ -155,7 +157,7 @@ class VehicleRouteBuilderTest {
         when(vehicle.isReturnToDepot()).thenReturn(false);
         when(vehicle.getStartLocation()).thenReturn(Location.Builder.newInstance().setId("vehLoc").build());
         VehicleRoute route = VehicleRoute.Builder.newInstance(vehicle, mock(Driver.class)).addPickup(s).addPickup(s2).addDelivery(s).addDelivery(s2).setDepartureTime(100).build();
-        assertEquals(100.0, route.getDepartureTime(), 0.01);
-        assertEquals(100.0, route.getStart().getEndTime(), 0.01);
+        Assertions.assertEquals(100.0, route.getDepartureTime(), 0.01);
+        Assertions.assertEquals(100.0, route.getStart().getEndTime(), 0.01);
     }
 }

--- a/jsprit-core/src/test/java/com/graphhopper/jsprit/core/problem/solution/route/activity/BreakActivityTest.java
+++ b/jsprit-core/src/test/java/com/graphhopper/jsprit/core/problem/solution/route/activity/BreakActivityTest.java
@@ -24,7 +24,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
-import static org.junit.jupiter.api.Assertions.*;
+import org.junit.jupiter.api.Assertions;
 
 @DisplayName("Break Activity Test")
 class BreakActivityTest {
@@ -44,49 +44,49 @@ class BreakActivityTest {
     @Test
     @DisplayName("When Calling Capacity _ it Should Return Correct Capacity")
     void whenCallingCapacity_itShouldReturnCorrectCapacity() {
-        assertEquals(0, serviceActivity.getSize().get(0));
+        Assertions.assertEquals(0, serviceActivity.getSize().get(0));
     }
 
     @Test
     @DisplayName("Has Variable Location Should Be True")
     void hasVariableLocationShouldBeTrue() {
         Break aBreak = (Break) serviceActivity.getJob();
-        assertTrue(aBreak.hasVariableLocation());
+        Assertions.assertTrue(aBreak.hasVariableLocation());
     }
 
     @Test
     @DisplayName("When Start Is Ini With Earliest Start _ it Should Be Set Correctly")
     void whenStartIsIniWithEarliestStart_itShouldBeSetCorrectly() {
-        assertEquals(1., serviceActivity.getTheoreticalEarliestOperationStartTime(), 0.01);
+        Assertions.assertEquals(1., serviceActivity.getTheoreticalEarliestOperationStartTime(), 0.01);
     }
 
     @Test
     @DisplayName("When Start Is Ini With Latest Start _ it Should Be Set Correctly")
     void whenStartIsIniWithLatestStart_itShouldBeSetCorrectly() {
-        assertEquals(2., serviceActivity.getTheoreticalLatestOperationStartTime(), 0.01);
+        Assertions.assertEquals(2., serviceActivity.getTheoreticalLatestOperationStartTime(), 0.01);
     }
 
     @Test
     @DisplayName("When Setting Arr Time _ it Should Be Set Correctly")
     void whenSettingArrTime_itShouldBeSetCorrectly() {
         serviceActivity.setArrTime(4.0);
-        assertEquals(4., serviceActivity.getArrTime(), 0.01);
+        Assertions.assertEquals(4., serviceActivity.getArrTime(), 0.01);
     }
 
     @Test
     @DisplayName("When Setting End Time _ it Should Be Set Correctly")
     void whenSettingEndTime_itShouldBeSetCorrectly() {
         serviceActivity.setEndTime(5.0);
-        assertEquals(5., serviceActivity.getEndTime(), 0.01);
+        Assertions.assertEquals(5., serviceActivity.getEndTime(), 0.01);
     }
 
     @Test
     @DisplayName("When Copying Start _ it Should Be Done Correctly")
     void whenCopyingStart_itShouldBeDoneCorrectly() {
         BreakActivity copy = (BreakActivity) serviceActivity.duplicate();
-        assertEquals(1., copy.getTheoreticalEarliestOperationStartTime(), 0.01);
-        assertEquals(2., copy.getTheoreticalLatestOperationStartTime(), 0.01);
-        assertTrue(copy != serviceActivity);
+        Assertions.assertEquals(1., copy.getTheoreticalEarliestOperationStartTime(), 0.01);
+        Assertions.assertEquals(2., copy.getTheoreticalLatestOperationStartTime(), 0.01);
+        Assertions.assertTrue(copy != serviceActivity);
     }
 
     @Test
@@ -96,7 +96,7 @@ class BreakActivityTest {
         Service s2 = Service.Builder.newInstance("s").setLocation(Location.newInstance("loc")).build();
         ServiceActivity d1 = ServiceActivity.newInstance(s1);
         ServiceActivity d2 = ServiceActivity.newInstance(s2);
-        assertTrue(d1.equals(d2));
+        Assertions.assertTrue(d1.equals(d2));
     }
 
     @Test
@@ -106,6 +106,6 @@ class BreakActivityTest {
         Service s2 = Service.Builder.newInstance("s1").setLocation(Location.newInstance("loc")).build();
         ServiceActivity d1 = ServiceActivity.newInstance(s1);
         ServiceActivity d2 = ServiceActivity.newInstance(s2);
-        assertFalse(d1.equals(d2));
+        Assertions.assertFalse(d1.equals(d2));
     }
 }

--- a/jsprit-core/src/test/java/com/graphhopper/jsprit/core/problem/solution/route/activity/DefaultShipmentActivityFactoryTest.java
+++ b/jsprit-core/src/test/java/com/graphhopper/jsprit/core/problem/solution/route/activity/DefaultShipmentActivityFactoryTest.java
@@ -25,6 +25,8 @@ import org.junit.jupiter.api.Test;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import org.junit.jupiter.api.Assertions;
+
 @DisplayName("Default Shipment Activity Factory Test")
 class DefaultShipmentActivityFactoryTest {
 
@@ -35,7 +37,7 @@ class DefaultShipmentActivityFactoryTest {
         Shipment shipment = Shipment.Builder.newInstance("s").setPickupLocation(Location.Builder.newInstance().setId("pLoc").build()).setDeliveryLocation(Location.newInstance("dLoc")).build();
         TourActivity act = factory.createPickup(shipment);
         assertNotNull(act);
-        assertTrue(act instanceof PickupShipment);
+        Assertions.assertTrue(act instanceof PickupShipment);
     }
 
     @Test
@@ -45,6 +47,6 @@ class DefaultShipmentActivityFactoryTest {
         Shipment shipment = Shipment.Builder.newInstance("s").setPickupLocation(Location.Builder.newInstance().setId("pLoc").build()).setDeliveryLocation(Location.newInstance("dLoc")).build();
         TourActivity act = factory.createDelivery(shipment);
         assertNotNull(act);
-        assertTrue(act instanceof DeliverShipment);
+        Assertions.assertTrue(act instanceof DeliverShipment);
     }
 }

--- a/jsprit-core/src/test/java/com/graphhopper/jsprit/core/problem/solution/route/activity/DefaultTourActivityFactoryTest.java
+++ b/jsprit-core/src/test/java/com/graphhopper/jsprit/core/problem/solution/route/activity/DefaultTourActivityFactoryTest.java
@@ -27,6 +27,8 @@ import org.junit.jupiter.api.Test;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import org.junit.jupiter.api.Assertions;
+
 @DisplayName("Default Tour Activity Factory Test")
 class DefaultTourActivityFactoryTest {
 
@@ -37,7 +39,7 @@ class DefaultTourActivityFactoryTest {
         Service service = Service.Builder.newInstance("service").setLocation(Location.newInstance("loc")).build();
         TourActivity act = factory.createActivity(service);
         assertNotNull(act);
-        assertTrue(act instanceof PickupService);
+        Assertions.assertTrue(act instanceof PickupService);
     }
 
     @Test
@@ -47,7 +49,7 @@ class DefaultTourActivityFactoryTest {
         Pickup service = (Pickup) Pickup.Builder.newInstance("service").setLocation(Location.newInstance("loc")).build();
         TourActivity act = factory.createActivity(service);
         assertNotNull(act);
-        assertTrue(act instanceof PickupService);
+        Assertions.assertTrue(act instanceof PickupService);
     }
 
     @Test
@@ -57,6 +59,6 @@ class DefaultTourActivityFactoryTest {
         Delivery service = (Delivery) Delivery.Builder.newInstance("service").setLocation(Location.newInstance("loc")).build();
         TourActivity act = factory.createActivity(service);
         assertNotNull(act);
-        assertTrue(act instanceof DeliverService);
+        Assertions.assertTrue(act instanceof DeliverService);
     }
 }

--- a/jsprit-core/src/test/java/com/graphhopper/jsprit/core/problem/solution/route/activity/DeliverServiceTest.java
+++ b/jsprit-core/src/test/java/com/graphhopper/jsprit/core/problem/solution/route/activity/DeliverServiceTest.java
@@ -26,6 +26,8 @@ import org.junit.jupiter.api.Test;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import org.junit.jupiter.api.Assertions;
+
 @DisplayName("Deliver Service Test")
 class DeliverServiceTest {
 
@@ -44,53 +46,53 @@ class DeliverServiceTest {
     @Test
     @DisplayName("When Calling Capacity _ it Should Return Correct Capacity")
     void whenCallingCapacity_itShouldReturnCorrectCapacity() {
-        assertEquals(-10, deliver.getSize().get(0));
-        assertEquals(-100, deliver.getSize().get(1));
-        assertEquals(-1000, deliver.getSize().get(2));
+        Assertions.assertEquals(-10, deliver.getSize().get(0));
+        Assertions.assertEquals(-100, deliver.getSize().get(1));
+        Assertions.assertEquals(-1000, deliver.getSize().get(2));
     }
 
     @Test
     @DisplayName("When Start Is Ini With Earliest Start _ it Should Be Set Correctly")
     void whenStartIsIniWithEarliestStart_itShouldBeSetCorrectly() {
-        assertEquals(1., deliver.getTheoreticalEarliestOperationStartTime(), 0.01);
+        Assertions.assertEquals(1., deliver.getTheoreticalEarliestOperationStartTime(), 0.01);
     }
 
     @Test
     @DisplayName("When Start Is Ini With Latest Start _ it Should Be Set Correctly")
     void whenStartIsIniWithLatestStart_itShouldBeSetCorrectly() {
-        assertEquals(2., deliver.getTheoreticalLatestOperationStartTime(), 0.01);
+        Assertions.assertEquals(2., deliver.getTheoreticalLatestOperationStartTime(), 0.01);
     }
 
     @Test
     @DisplayName("When Setting Arr Time _ it Should Be Set Correctly")
     void whenSettingArrTime_itShouldBeSetCorrectly() {
         deliver.setArrTime(4.0);
-        assertEquals(4., deliver.getArrTime(), 0.01);
+        Assertions.assertEquals(4., deliver.getArrTime(), 0.01);
     }
 
     @Test
     @DisplayName("When Setting End Time _ it Should Be Set Correctly")
     void whenSettingEndTime_itShouldBeSetCorrectly() {
         deliver.setEndTime(5.0);
-        assertEquals(5., deliver.getEndTime(), 0.01);
+        Assertions.assertEquals(5., deliver.getEndTime(), 0.01);
     }
 
     @Test
     @DisplayName("When Ini Location Id _ it Should Be Set Correctly")
     void whenIniLocationId_itShouldBeSetCorrectly() {
-        assertEquals(deliver.getLocation().getId(), "loc");
+        Assertions.assertEquals(deliver.getLocation().getId(), "loc");
     }
 
     @Test
     @DisplayName("When Copying Start _ it Should Be Done Correctly")
     void whenCopyingStart_itShouldBeDoneCorrectly() {
         DeliverService copy = (DeliverService) deliver.duplicate();
-        assertEquals(1., copy.getTheoreticalEarliestOperationStartTime(), 0.01);
-        assertEquals(2., copy.getTheoreticalLatestOperationStartTime(), 0.01);
-        assertEquals(copy.getLocation().getId(), "loc");
-        assertEquals(-10, copy.getSize().get(0));
-        assertEquals(-100, copy.getSize().get(1));
-        assertEquals(-1000, copy.getSize().get(2));
-        assertTrue(copy != deliver);
+        Assertions.assertEquals(1., copy.getTheoreticalEarliestOperationStartTime(), 0.01);
+        Assertions.assertEquals(2., copy.getTheoreticalLatestOperationStartTime(), 0.01);
+        Assertions.assertEquals(copy.getLocation().getId(), "loc");
+        Assertions.assertEquals(-10, copy.getSize().get(0));
+        Assertions.assertEquals(-100, copy.getSize().get(1));
+        Assertions.assertEquals(-1000, copy.getSize().get(2));
+        Assertions.assertTrue(copy != deliver);
     }
 }

--- a/jsprit-core/src/test/java/com/graphhopper/jsprit/core/problem/solution/route/activity/DeliverShipmentTest.java
+++ b/jsprit-core/src/test/java/com/graphhopper/jsprit/core/problem/solution/route/activity/DeliverShipmentTest.java
@@ -26,6 +26,8 @@ import org.junit.jupiter.api.Test;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import org.junit.jupiter.api.Assertions;
+
 @DisplayName("Deliver Shipment Test")
 class DeliverShipmentTest {
 
@@ -42,54 +44,54 @@ class DeliverShipmentTest {
     @Test
     @DisplayName("When Calling Capacity _ it Should Return Correct Capacity")
     void whenCallingCapacity_itShouldReturnCorrectCapacity() {
-        assertEquals(-10, deliver.getSize().get(0));
-        assertEquals(-100, deliver.getSize().get(1));
-        assertEquals(-1000, deliver.getSize().get(2));
+        Assertions.assertEquals(-10, deliver.getSize().get(0));
+        Assertions.assertEquals(-100, deliver.getSize().get(1));
+        Assertions.assertEquals(-1000, deliver.getSize().get(2));
     }
 
     @Test
     @DisplayName("When Start Is Ini With Earliest Start _ it Should Be Set Correctly")
     void whenStartIsIniWithEarliestStart_itShouldBeSetCorrectly() {
-        assertEquals(3., deliver.getTheoreticalEarliestOperationStartTime(), 0.01);
+        Assertions.assertEquals(3., deliver.getTheoreticalEarliestOperationStartTime(), 0.01);
     }
 
     @Test
     @DisplayName("When Start Is Ini With Latest Start _ it Should Be Set Correctly")
     void whenStartIsIniWithLatestStart_itShouldBeSetCorrectly() {
-        assertEquals(4., deliver.getTheoreticalLatestOperationStartTime(), 0.01);
+        Assertions.assertEquals(4., deliver.getTheoreticalLatestOperationStartTime(), 0.01);
     }
 
     @Test
     @DisplayName("When Setting Arr Time _ it Should Be Set Correctly")
     void whenSettingArrTime_itShouldBeSetCorrectly() {
         deliver.setArrTime(4.0);
-        assertEquals(4., deliver.getArrTime(), 0.01);
+        Assertions.assertEquals(4., deliver.getArrTime(), 0.01);
     }
 
     @Test
     @DisplayName("When Setting End Time _ it Should Be Set Correctly")
     void whenSettingEndTime_itShouldBeSetCorrectly() {
         deliver.setEndTime(5.0);
-        assertEquals(5., deliver.getEndTime(), 0.01);
+        Assertions.assertEquals(5., deliver.getEndTime(), 0.01);
     }
 
     @Test
     @DisplayName("When Ini Location Id _ it Should Be Set Correctly")
     void whenIniLocationId_itShouldBeSetCorrectly() {
-        assertEquals(deliver.getLocation().getId(), "deliveryLoc");
+        Assertions.assertEquals(deliver.getLocation().getId(), "deliveryLoc");
     }
 
     @Test
     @DisplayName("When Copying Start _ it Should Be Done Correctly")
     void whenCopyingStart_itShouldBeDoneCorrectly() {
         DeliverShipment copy = (DeliverShipment) deliver.duplicate();
-        assertEquals(3., copy.getTheoreticalEarliestOperationStartTime(), 0.01);
-        assertEquals(4., copy.getTheoreticalLatestOperationStartTime(), 0.01);
-        assertEquals(copy.getLocation().getId(), "deliveryLoc");
-        assertEquals(-10, copy.getSize().get(0));
-        assertEquals(-100, copy.getSize().get(1));
-        assertEquals(-1000, copy.getSize().get(2));
-        assertTrue(copy != deliver);
+        Assertions.assertEquals(3., copy.getTheoreticalEarliestOperationStartTime(), 0.01);
+        Assertions.assertEquals(4., copy.getTheoreticalLatestOperationStartTime(), 0.01);
+        Assertions.assertEquals(copy.getLocation().getId(), "deliveryLoc");
+        Assertions.assertEquals(-10, copy.getSize().get(0));
+        Assertions.assertEquals(-100, copy.getSize().get(1));
+        Assertions.assertEquals(-1000, copy.getSize().get(2));
+        Assertions.assertTrue(copy != deliver);
     }
 
     @Test
@@ -97,7 +99,7 @@ class DeliverShipmentTest {
     void whenGettingCapacity_itShouldReturnItCorrectly() {
         Shipment shipment = Shipment.Builder.newInstance("s").setPickupLocation(Location.Builder.newInstance().setId("pickLoc").build()).setDeliveryLocation(Location.newInstance("delLoc")).addSizeDimension(0, 10).addSizeDimension(1, 100).build();
         PickupShipment pick = new PickupShipment(shipment);
-        assertEquals(10, pick.getSize().get(0));
-        assertEquals(100, pick.getSize().get(1));
+        Assertions.assertEquals(10, pick.getSize().get(0));
+        Assertions.assertEquals(100, pick.getSize().get(1));
     }
 }

--- a/jsprit-core/src/test/java/com/graphhopper/jsprit/core/problem/solution/route/activity/EndTest.java
+++ b/jsprit-core/src/test/java/com/graphhopper/jsprit/core/problem/solution/route/activity/EndTest.java
@@ -23,6 +23,8 @@ import org.junit.jupiter.api.Test;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import org.junit.jupiter.api.Assertions;
+
 @DisplayName("End Test")
 class EndTest {
 
@@ -30,21 +32,21 @@ class EndTest {
     @DisplayName("When Calling Capacity _ it Should Return Empty Capacity")
     void whenCallingCapacity_itShouldReturnEmptyCapacity() {
         End end = End.newInstance("loc", 0., 0.);
-        assertEquals(0, end.getSize().get(0));
+        Assertions.assertEquals(0, end.getSize().get(0));
     }
 
     @Test
     @DisplayName("When Start Is Ini With Earliest Start _ it Should Be Set Correctly")
     void whenStartIsIniWithEarliestStart_itShouldBeSetCorrectly() {
         End end = End.newInstance("loc", 1., 2.);
-        assertEquals(1., end.getTheoreticalEarliestOperationStartTime(), 0.01);
+        Assertions.assertEquals(1., end.getTheoreticalEarliestOperationStartTime(), 0.01);
     }
 
     @Test
     @DisplayName("When Start Is Ini With Latest Start _ it Should Be Set Correctly")
     void whenStartIsIniWithLatestStart_itShouldBeSetCorrectly() {
         End end = End.newInstance("loc", 1., 2.);
-        assertEquals(2., end.getTheoreticalLatestOperationStartTime(), 0.01);
+        Assertions.assertEquals(2., end.getTheoreticalLatestOperationStartTime(), 0.01);
     }
 
     @Test
@@ -52,7 +54,7 @@ class EndTest {
     void whenSettingEndTime_itShouldBeSetCorrectly() {
         End end = End.newInstance("loc", 1., 2.);
         end.setEndTime(4.0);
-        assertEquals(4., end.getEndTime(), 0.01);
+        Assertions.assertEquals(4., end.getEndTime(), 0.01);
     }
 
     @Test
@@ -60,7 +62,7 @@ class EndTest {
     void whenSettingEarliestStart_itShouldBeSetCorrectly() {
         End end = End.newInstance("loc", 1., 2.);
         end.setTheoreticalEarliestOperationStartTime(5.);
-        assertEquals(5., end.getTheoreticalEarliestOperationStartTime(), 0.01);
+        Assertions.assertEquals(5., end.getTheoreticalEarliestOperationStartTime(), 0.01);
     }
 
     @Test
@@ -68,7 +70,7 @@ class EndTest {
     void whenSettingLatestStart_itShouldBeSetCorrectly() {
         End end = End.newInstance("loc", 1., 2.);
         end.setTheoreticalLatestOperationStartTime(5.);
-        assertEquals(5., end.getTheoreticalLatestOperationStartTime(), 0.01);
+        Assertions.assertEquals(5., end.getTheoreticalLatestOperationStartTime(), 0.01);
     }
 
     @Test
@@ -78,9 +80,9 @@ class EndTest {
         end.setTheoreticalEarliestOperationStartTime(3.);
         end.setTheoreticalLatestOperationStartTime(5.);
         End copy = End.copyOf(end);
-        assertEquals(3., copy.getTheoreticalEarliestOperationStartTime(), 0.01);
-        assertEquals(5., copy.getTheoreticalLatestOperationStartTime(), 0.01);
-        assertEquals(copy.getLocation().getId(), "loc");
-        assertTrue(copy != end);
+        Assertions.assertEquals(3., copy.getTheoreticalEarliestOperationStartTime(), 0.01);
+        Assertions.assertEquals(5., copy.getTheoreticalLatestOperationStartTime(), 0.01);
+        Assertions.assertEquals(copy.getLocation().getId(), "loc");
+        Assertions.assertTrue(copy != end);
     }
 }

--- a/jsprit-core/src/test/java/com/graphhopper/jsprit/core/problem/solution/route/activity/PickupServiceTest.java
+++ b/jsprit-core/src/test/java/com/graphhopper/jsprit/core/problem/solution/route/activity/PickupServiceTest.java
@@ -26,6 +26,8 @@ import org.junit.jupiter.api.Test;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import org.junit.jupiter.api.Assertions;
+
 @DisplayName("Pickup Service Test")
 class PickupServiceTest {
 
@@ -44,53 +46,53 @@ class PickupServiceTest {
     @Test
     @DisplayName("When Calling Capacity _ it Should Return Correct Capacity")
     void whenCallingCapacity_itShouldReturnCorrectCapacity() {
-        assertEquals(10, pickup.getSize().get(0));
-        assertEquals(100, pickup.getSize().get(1));
-        assertEquals(1000, pickup.getSize().get(2));
+        Assertions.assertEquals(10, pickup.getSize().get(0));
+        Assertions.assertEquals(100, pickup.getSize().get(1));
+        Assertions.assertEquals(1000, pickup.getSize().get(2));
     }
 
     @Test
     @DisplayName("When Start Is Ini With Earliest Start _ it Should Be Set Correctly")
     void whenStartIsIniWithEarliestStart_itShouldBeSetCorrectly() {
-        assertEquals(1., pickup.getTheoreticalEarliestOperationStartTime(), 0.01);
+        Assertions.assertEquals(1., pickup.getTheoreticalEarliestOperationStartTime(), 0.01);
     }
 
     @Test
     @DisplayName("When Start Is Ini With Latest Start _ it Should Be Set Correctly")
     void whenStartIsIniWithLatestStart_itShouldBeSetCorrectly() {
-        assertEquals(2., pickup.getTheoreticalLatestOperationStartTime(), 0.01);
+        Assertions.assertEquals(2., pickup.getTheoreticalLatestOperationStartTime(), 0.01);
     }
 
     @Test
     @DisplayName("When Setting Arr Time _ it Should Be Set Correctly")
     void whenSettingArrTime_itShouldBeSetCorrectly() {
         pickup.setArrTime(4.0);
-        assertEquals(4., pickup.getArrTime(), 0.01);
+        Assertions.assertEquals(4., pickup.getArrTime(), 0.01);
     }
 
     @Test
     @DisplayName("When Setting End Time _ it Should Be Set Correctly")
     void whenSettingEndTime_itShouldBeSetCorrectly() {
         pickup.setEndTime(5.0);
-        assertEquals(5., pickup.getEndTime(), 0.01);
+        Assertions.assertEquals(5., pickup.getEndTime(), 0.01);
     }
 
     @Test
     @DisplayName("When Ini Location Id _ it Should Be Set Correctly")
     void whenIniLocationId_itShouldBeSetCorrectly() {
-        assertEquals(pickup.getLocation().getId(), "loc");
+        Assertions.assertEquals(pickup.getLocation().getId(), "loc");
     }
 
     @Test
     @DisplayName("When Copying Start _ it Should Be Done Correctly")
     void whenCopyingStart_itShouldBeDoneCorrectly() {
         PickupService copy = (PickupService) pickup.duplicate();
-        assertEquals(1., copy.getTheoreticalEarliestOperationStartTime(), 0.01);
-        assertEquals(2., copy.getTheoreticalLatestOperationStartTime(), 0.01);
-        assertEquals(copy.getLocation().getId(), "loc");
-        assertEquals(10, copy.getSize().get(0));
-        assertEquals(100, copy.getSize().get(1));
-        assertEquals(1000, copy.getSize().get(2));
-        assertTrue(copy != pickup);
+        Assertions.assertEquals(1., copy.getTheoreticalEarliestOperationStartTime(), 0.01);
+        Assertions.assertEquals(2., copy.getTheoreticalLatestOperationStartTime(), 0.01);
+        Assertions.assertEquals(copy.getLocation().getId(), "loc");
+        Assertions.assertEquals(10, copy.getSize().get(0));
+        Assertions.assertEquals(100, copy.getSize().get(1));
+        Assertions.assertEquals(1000, copy.getSize().get(2));
+        Assertions.assertTrue(copy != pickup);
     }
 }

--- a/jsprit-core/src/test/java/com/graphhopper/jsprit/core/problem/solution/route/activity/PickupShipmentTest.java
+++ b/jsprit-core/src/test/java/com/graphhopper/jsprit/core/problem/solution/route/activity/PickupShipmentTest.java
@@ -26,6 +26,8 @@ import org.junit.jupiter.api.Test;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import org.junit.jupiter.api.Assertions;
+
 @DisplayName("Pickup Shipment Test")
 class PickupShipmentTest {
 
@@ -42,54 +44,54 @@ class PickupShipmentTest {
     @Test
     @DisplayName("When Calling Capacity _ it Should Return Correct Capacity")
     void whenCallingCapacity_itShouldReturnCorrectCapacity() {
-        assertEquals(10, pickup.getSize().get(0));
-        assertEquals(100, pickup.getSize().get(1));
-        assertEquals(1000, pickup.getSize().get(2));
+        Assertions.assertEquals(10, pickup.getSize().get(0));
+        Assertions.assertEquals(100, pickup.getSize().get(1));
+        Assertions.assertEquals(1000, pickup.getSize().get(2));
     }
 
     @Test
     @DisplayName("When Start Is Ini With Earliest Start _ it Should Be Set Correctly")
     void whenStartIsIniWithEarliestStart_itShouldBeSetCorrectly() {
-        assertEquals(1., pickup.getTheoreticalEarliestOperationStartTime(), 0.01);
+        Assertions.assertEquals(1., pickup.getTheoreticalEarliestOperationStartTime(), 0.01);
     }
 
     @Test
     @DisplayName("When Start Is Ini With Latest Start _ it Should Be Set Correctly")
     void whenStartIsIniWithLatestStart_itShouldBeSetCorrectly() {
-        assertEquals(2., pickup.getTheoreticalLatestOperationStartTime(), 0.01);
+        Assertions.assertEquals(2., pickup.getTheoreticalLatestOperationStartTime(), 0.01);
     }
 
     @Test
     @DisplayName("When Setting Arr Time _ it Should Be Set Correctly")
     void whenSettingArrTime_itShouldBeSetCorrectly() {
         pickup.setArrTime(4.0);
-        assertEquals(4., pickup.getArrTime(), 0.01);
+        Assertions.assertEquals(4., pickup.getArrTime(), 0.01);
     }
 
     @Test
     @DisplayName("When Setting End Time _ it Should Be Set Correctly")
     void whenSettingEndTime_itShouldBeSetCorrectly() {
         pickup.setEndTime(5.0);
-        assertEquals(5., pickup.getEndTime(), 0.01);
+        Assertions.assertEquals(5., pickup.getEndTime(), 0.01);
     }
 
     @Test
     @DisplayName("When Ini Location Id _ it Should Be Set Correctly")
     void whenIniLocationId_itShouldBeSetCorrectly() {
-        assertEquals(pickup.getLocation().getId(), "pickupLoc");
+        Assertions.assertEquals(pickup.getLocation().getId(), "pickupLoc");
     }
 
     @Test
     @DisplayName("When Copying Start _ it Should Be Done Correctly")
     void whenCopyingStart_itShouldBeDoneCorrectly() {
         PickupShipment copy = (PickupShipment) pickup.duplicate();
-        assertEquals(1., copy.getTheoreticalEarliestOperationStartTime(), 0.01);
-        assertEquals(2., copy.getTheoreticalLatestOperationStartTime(), 0.01);
-        assertEquals(copy.getLocation().getId(), "pickupLoc");
-        assertEquals(10, copy.getSize().get(0));
-        assertEquals(100, copy.getSize().get(1));
-        assertEquals(1000, copy.getSize().get(2));
-        assertTrue(copy != pickup);
+        Assertions.assertEquals(1., copy.getTheoreticalEarliestOperationStartTime(), 0.01);
+        Assertions.assertEquals(2., copy.getTheoreticalLatestOperationStartTime(), 0.01);
+        Assertions.assertEquals(copy.getLocation().getId(), "pickupLoc");
+        Assertions.assertEquals(10, copy.getSize().get(0));
+        Assertions.assertEquals(100, copy.getSize().get(1));
+        Assertions.assertEquals(1000, copy.getSize().get(2));
+        Assertions.assertNotSame(copy, pickup);
     }
 
     @Test
@@ -97,7 +99,7 @@ class PickupShipmentTest {
     void whenGettingCapacity_itShouldReturnItCorrectly() {
         Shipment shipment = Shipment.Builder.newInstance("s").setPickupLocation(Location.Builder.newInstance().setId("pickLoc").build()).setDeliveryLocation(Location.newInstance("delLoc")).addSizeDimension(0, 10).addSizeDimension(1, 100).build();
         PickupShipment pick = new PickupShipment(shipment);
-        assertEquals(10, pick.getSize().get(0));
-        assertEquals(100, pick.getSize().get(1));
+        Assertions.assertEquals(10, pick.getSize().get(0));
+        Assertions.assertEquals(100, pick.getSize().get(1));
     }
 }

--- a/jsprit-core/src/test/java/com/graphhopper/jsprit/core/problem/solution/route/activity/ServiceActivityTest.java
+++ b/jsprit-core/src/test/java/com/graphhopper/jsprit/core/problem/solution/route/activity/ServiceActivityTest.java
@@ -23,7 +23,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
-import static org.junit.jupiter.api.Assertions.*;
+import org.junit.jupiter.api.Assertions;
 
 @DisplayName("Service Activity Test")
 class ServiceActivityTest {
@@ -43,51 +43,51 @@ class ServiceActivityTest {
     @Test
     @DisplayName("When Calling Capacity _ it Should Return Correct Capacity")
     void whenCallingCapacity_itShouldReturnCorrectCapacity() {
-        assertEquals(10, serviceActivity.getSize().get(0));
-        assertEquals(100, serviceActivity.getSize().get(1));
-        assertEquals(1000, serviceActivity.getSize().get(2));
+        Assertions.assertEquals(10, serviceActivity.getSize().get(0));
+        Assertions.assertEquals(100, serviceActivity.getSize().get(1));
+        Assertions.assertEquals(1000, serviceActivity.getSize().get(2));
     }
 
     @Test
     @DisplayName("When Start Is Ini With Earliest Start _ it Should Be Set Correctly")
     void whenStartIsIniWithEarliestStart_itShouldBeSetCorrectly() {
-        assertEquals(1., serviceActivity.getTheoreticalEarliestOperationStartTime(), 0.01);
+        Assertions.assertEquals(1., serviceActivity.getTheoreticalEarliestOperationStartTime(), 0.01);
     }
 
     @Test
     @DisplayName("When Start Is Ini With Latest Start _ it Should Be Set Correctly")
     void whenStartIsIniWithLatestStart_itShouldBeSetCorrectly() {
-        assertEquals(2., serviceActivity.getTheoreticalLatestOperationStartTime(), 0.01);
+        Assertions.assertEquals(2., serviceActivity.getTheoreticalLatestOperationStartTime(), 0.01);
     }
 
     @Test
     @DisplayName("When Setting Arr Time _ it Should Be Set Correctly")
     void whenSettingArrTime_itShouldBeSetCorrectly() {
         serviceActivity.setArrTime(4.0);
-        assertEquals(4., serviceActivity.getArrTime(), 0.01);
+        Assertions.assertEquals(4., serviceActivity.getArrTime(), 0.01);
     }
 
     @Test
     @DisplayName("When Setting End Time _ it Should Be Set Correctly")
     void whenSettingEndTime_itShouldBeSetCorrectly() {
         serviceActivity.setEndTime(5.0);
-        assertEquals(5., serviceActivity.getEndTime(), 0.01);
+        Assertions.assertEquals(5., serviceActivity.getEndTime(), 0.01);
     }
 
     @Test
     @DisplayName("When Ini Location Id _ it Should Be Set Correctly")
     void whenIniLocationId_itShouldBeSetCorrectly() {
-        assertEquals(serviceActivity.getLocation().getId(), "loc");
+        Assertions.assertEquals(serviceActivity.getLocation().getId(), "loc");
     }
 
     @Test
     @DisplayName("When Copying Start _ it Should Be Done Correctly")
     void whenCopyingStart_itShouldBeDoneCorrectly() {
         ServiceActivity copy = (ServiceActivity) serviceActivity.duplicate();
-        assertEquals(1., copy.getTheoreticalEarliestOperationStartTime(), 0.01);
-        assertEquals(2., copy.getTheoreticalLatestOperationStartTime(), 0.01);
-        assertEquals(copy.getLocation().getId(), "loc");
-        assertTrue(copy != serviceActivity);
+        Assertions.assertEquals(1., copy.getTheoreticalEarliestOperationStartTime(), 0.01);
+        Assertions.assertEquals(2., copy.getTheoreticalLatestOperationStartTime(), 0.01);
+        Assertions.assertEquals(copy.getLocation().getId(), "loc");
+        Assertions.assertTrue(copy != serviceActivity);
     }
 
     @Test
@@ -97,7 +97,7 @@ class ServiceActivityTest {
         Service s2 = Service.Builder.newInstance("s").setLocation(Location.newInstance("loc")).build();
         ServiceActivity d1 = ServiceActivity.newInstance(s1);
         ServiceActivity d2 = ServiceActivity.newInstance(s2);
-        assertTrue(d1.equals(d2));
+        Assertions.assertTrue(d1.equals(d2));
     }
 
     @Test
@@ -107,6 +107,6 @@ class ServiceActivityTest {
         Service s2 = Service.Builder.newInstance("s1").setLocation(Location.newInstance("loc")).build();
         ServiceActivity d1 = ServiceActivity.newInstance(s1);
         ServiceActivity d2 = ServiceActivity.newInstance(s2);
-        assertFalse(d1.equals(d2));
+        Assertions.assertFalse(d1.equals(d2));
     }
 }

--- a/jsprit-core/src/test/java/com/graphhopper/jsprit/core/problem/solution/route/activity/StartTest.java
+++ b/jsprit-core/src/test/java/com/graphhopper/jsprit/core/problem/solution/route/activity/StartTest.java
@@ -23,6 +23,8 @@ import org.junit.jupiter.api.Test;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import org.junit.jupiter.api.Assertions;
+
 @DisplayName("Start Test")
 class StartTest {
 
@@ -30,21 +32,21 @@ class StartTest {
     @DisplayName("When Calling Capacity _ it Should Return Empty Capacity")
     void whenCallingCapacity_itShouldReturnEmptyCapacity() {
         Start start = Start.newInstance("loc", 0., 0.);
-        assertEquals(0, start.getSize().get(0));
+        Assertions.assertEquals(0, start.getSize().get(0));
     }
 
     @Test
     @DisplayName("When Start Is Ini With Earliest Start _ it Should Be Set Correctly")
     void whenStartIsIniWithEarliestStart_itShouldBeSetCorrectly() {
         Start start = Start.newInstance("loc", 1., 2.);
-        assertEquals(1., start.getTheoreticalEarliestOperationStartTime(), 0.01);
+        Assertions.assertEquals(1., start.getTheoreticalEarliestOperationStartTime(), 0.01);
     }
 
     @Test
     @DisplayName("When Start Is Ini With Latest Start _ it Should Be Set Correctly")
     void whenStartIsIniWithLatestStart_itShouldBeSetCorrectly() {
         Start start = Start.newInstance("loc", 1., 2.);
-        assertEquals(2., start.getTheoreticalLatestOperationStartTime(), 0.01);
+        Assertions.assertEquals(2., start.getTheoreticalLatestOperationStartTime(), 0.01);
     }
 
     @Test
@@ -52,7 +54,7 @@ class StartTest {
     void whenSettingStartEndTime_itShouldBeSetCorrectly() {
         Start start = Start.newInstance("loc", 1., 2.);
         start.setEndTime(4.0);
-        assertEquals(4., start.getEndTime(), 0.01);
+        Assertions.assertEquals(4., start.getEndTime(), 0.01);
     }
 
     @Test
@@ -60,7 +62,7 @@ class StartTest {
     void whenSettingEarliestStart_itShouldBeSetCorrectly() {
         Start start = Start.newInstance("loc", 1., 2.);
         start.setTheoreticalEarliestOperationStartTime(5.);
-        assertEquals(5., start.getTheoreticalEarliestOperationStartTime(), 0.01);
+        Assertions.assertEquals(5., start.getTheoreticalEarliestOperationStartTime(), 0.01);
     }
 
     @Test
@@ -68,7 +70,7 @@ class StartTest {
     void whenSettingLatestStart_itShouldBeSetCorrectly() {
         Start start = Start.newInstance("loc", 1., 2.);
         start.setTheoreticalLatestOperationStartTime(5.);
-        assertEquals(5., start.getTheoreticalLatestOperationStartTime(), 0.01);
+        Assertions.assertEquals(5., start.getTheoreticalLatestOperationStartTime(), 0.01);
     }
 
     @Test
@@ -78,9 +80,9 @@ class StartTest {
         start.setTheoreticalEarliestOperationStartTime(3.);
         start.setTheoreticalLatestOperationStartTime(5.);
         Start copy = Start.copyOf(start);
-        assertEquals(3., copy.getTheoreticalEarliestOperationStartTime(), 0.01);
-        assertEquals(5., copy.getTheoreticalLatestOperationStartTime(), 0.01);
-        assertEquals(copy.getLocation().getId(), "loc");
-        assertTrue(copy != start);
+        Assertions.assertEquals(3., copy.getTheoreticalEarliestOperationStartTime(), 0.01);
+        Assertions.assertEquals(5., copy.getTheoreticalLatestOperationStartTime(), 0.01);
+        Assertions.assertEquals(copy.getLocation().getId(), "loc");
+        Assertions.assertTrue(copy != start);
     }
 }

--- a/jsprit-core/src/test/java/com/graphhopper/jsprit/core/problem/solution/route/activity/TestRefs.java
+++ b/jsprit-core/src/test/java/com/graphhopper/jsprit/core/problem/solution/route/activity/TestRefs.java
@@ -17,12 +17,11 @@
  */
 package com.graphhopper.jsprit.core.problem.solution.route.activity;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import java.util.ArrayList;
 import java.util.List;
-
-import static org.junit.Assert.assertTrue;
 
 
 public class TestRefs {
@@ -35,8 +34,8 @@ public class TestRefs {
 
         doSmth(starts);
 
-        assertTrue(starts.get(0).getLocation().getId().startsWith("foo"));
-        assertTrue(starts.get(1).getLocation().getId().startsWith("foo"));
+        Assertions.assertTrue(starts.get(0).getLocation().getId().startsWith("foo"));
+        Assertions.assertTrue(starts.get(1).getLocation().getId().startsWith("foo"));
     }
 
     private void doSmth(List<Start> starts) {

--- a/jsprit-core/src/test/java/com/graphhopper/jsprit/core/problem/solution/route/activity/TestTourActivities.java
+++ b/jsprit-core/src/test/java/com/graphhopper/jsprit/core/problem/solution/route/activity/TestTourActivities.java
@@ -20,11 +20,10 @@ package com.graphhopper.jsprit.core.problem.solution.route.activity;
 import com.graphhopper.jsprit.core.problem.Location;
 import com.graphhopper.jsprit.core.problem.job.Service;
 import com.graphhopper.jsprit.core.problem.job.Shipment;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
-
-import static org.junit.Assert.*;
 
 
 public class TestTourActivities {
@@ -33,7 +32,7 @@ public class TestTourActivities {
     private ServiceActivity act;
     private TourActivities tour;
 
-    @Before
+    @BeforeEach
     public void doBefore() {
         service = Service.Builder.newInstance("yo").addSizeDimension(0, 10).setLocation(Location.newInstance("loc")).build();
         act = ServiceActivity.newInstance(service);
@@ -42,37 +41,39 @@ public class TestTourActivities {
 
     @Test
     public void whenAddingServiceAct_serviceActIsAdded() {
-        assertFalse(tour.servesJob(service));
+        Assertions.assertFalse(tour.servesJob(service));
         tour.addActivity(act);
-        assertTrue(tour.servesJob(service));
+        Assertions.assertTrue(tour.servesJob(service));
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void whenAddingServiceActTwice_anExceptionIsThrown() {
-        assertFalse(tour.servesJob(service));
-        tour.addActivity(act);
-        tour.addActivity(act);
+        Assertions.assertFalse(tour.servesJob(service));
+        Assertions.assertThrows(IllegalArgumentException.class, () -> {
+            tour.addActivity(act);
+            tour.addActivity(act);
+        });
     }
 
     @Test
     public void whenAddingServiceAndRemovingItImmediately_tourShouldNotServeServiceAnymore() {
-        assertFalse(tour.servesJob(service));
+        Assertions.assertFalse(tour.servesJob(service));
         tour.addActivity(act);
-        assertTrue(tour.servesJob(service));
+        Assertions.assertTrue(tour.servesJob(service));
         tour.removeJob(service);
-        assertFalse(tour.servesJob(service));
+        Assertions.assertFalse(tour.servesJob(service));
     }
 
     @Test
     public void whenAddingAServiceAndThenRemovingTheServiceAgain_tourShouldNotServeItAnymore() {
-        assertEquals(0, tour.getActivities().size());
+        Assertions.assertEquals(0, tour.getActivities().size());
         tour.addActivity(act);
-        assertEquals(1, tour.getActivities().size());
+        Assertions.assertEquals(1, tour.getActivities().size());
         Service anotherServiceInstance = Service.Builder.newInstance("yo").addSizeDimension(0, 10).setLocation(Location.newInstance("loc")).build();
-        assertTrue(service.equals(anotherServiceInstance));
+        Assertions.assertTrue(service.equals(anotherServiceInstance));
         boolean removed = tour.removeJob(anotherServiceInstance);
-        assertTrue(removed);
-        assertEquals(0, tour.getActivities().size());
+        Assertions.assertTrue(removed);
+        Assertions.assertEquals(0, tour.getActivities().size());
     }
 
     @Test
@@ -84,8 +85,8 @@ public class TestTourActivities {
         TourActivity deliverShipment = fac.createDelivery(s);
         tour.addActivity(pickupShipment);
         tour.addActivity(deliverShipment);
-        assertTrue(tour.servesJob(s));
-        assertEquals(2, tour.getActivities().size());
+        Assertions.assertTrue(tour.servesJob(s));
+        Assertions.assertEquals(2, tour.getActivities().size());
     }
 
 
@@ -99,7 +100,7 @@ public class TestTourActivities {
         tour.addActivity(deliverShipment);
 
         tour.removeJob(s);
-        assertFalse(tour.servesJob(s));
+        Assertions.assertFalse(tour.servesJob(s));
     }
 
 
@@ -114,9 +115,9 @@ public class TestTourActivities {
         tour.addActivity(pickupShipment);
         tour.addActivity(deliverShipment);
 
-        assertEquals(2, tour.getActivities().size());
+        Assertions.assertEquals(2, tour.getActivities().size());
         tour.removeJob(s);
-        assertEquals(0, tour.getActivities().size());
+        Assertions.assertEquals(0, tour.getActivities().size());
     }
 
     @Test
@@ -124,38 +125,38 @@ public class TestTourActivities {
         TourActivity nonJobAct = Mockito.mock(TourActivity.class);
 
         tour.addActivity(nonJobAct);
-        assertTrue(tour.getActivities().contains(nonJobAct));
+        Assertions.assertTrue(tour.getActivities().contains(nonJobAct));
 
         tour.removeActivity(nonJobAct);
 
-        assertTrue(tour.isEmpty());
-        assertFalse(tour.getActivities().contains(nonJobAct));
+        Assertions.assertTrue(tour.isEmpty());
+        Assertions.assertFalse(tour.getActivities().contains(nonJobAct));
     }
 
     @Test
     public void removingActivityShouldWork() {
         tour.addActivity(act);
-        assertTrue(tour.servesJob(service));
-        assertTrue(tour.getActivities().contains(act));
+        Assertions.assertTrue(tour.servesJob(service));
+        Assertions.assertTrue(tour.getActivities().contains(act));
 
         tour.removeActivity(act);
 
-        assertTrue(tour.isEmpty());
-        assertFalse(tour.getActivities().contains(act));
-        assertFalse(tour.servesJob(service));
-        assertEquals(0, tour.jobSize());
+        Assertions.assertTrue(tour.isEmpty());
+        Assertions.assertFalse(tour.getActivities().contains(act));
+        Assertions.assertFalse(tour.servesJob(service));
+        Assertions.assertEquals(0, tour.jobSize());
     }
 
     @Test
     public void copyingSeqShouldWork() {
         tour.addActivity(act);
 
-        assertTrue(tour.servesJob(service));
+        Assertions.assertTrue(tour.servesJob(service));
 
         TourActivities acts = TourActivities.copyOf(tour);
 
-        assertTrue(acts.servesJob(service));
-        assertTrue(acts.getActivities().contains(act));
+        Assertions.assertTrue(acts.servesJob(service));
+        Assertions.assertTrue(acts.getActivities().contains(act));
     }
 
     @Test
@@ -169,19 +170,19 @@ public class TestTourActivities {
         tour.addActivity(pickupShipment);
         tour.addActivity(deliverShipment);
 
-        assertEquals(1, tour.jobSize());
-        assertEquals(2, tour.getActivities().size());
-        assertTrue(tour.getActivities().contains(pickupShipment));
-        assertTrue(tour.getActivities().contains(pickupShipment));
-        assertTrue(tour.getActivities().contains(deliverShipment));
+        Assertions.assertEquals(1, tour.jobSize());
+        Assertions.assertEquals(2, tour.getActivities().size());
+        Assertions.assertTrue(tour.getActivities().contains(pickupShipment));
+        Assertions.assertTrue(tour.getActivities().contains(pickupShipment));
+        Assertions.assertTrue(tour.getActivities().contains(deliverShipment));
 
         tour.removeActivity(pickupShipment);
 
-        assertEquals(1, tour.jobSize());
-        assertEquals(1, tour.getActivities().size());
-        assertTrue(tour.getActivities().contains(deliverShipment));
-        assertFalse(tour.getActivities().contains(pickupShipment));
-        assertFalse(tour.getActivities().contains(pickupShipment));
+        Assertions.assertEquals(1, tour.jobSize());
+        Assertions.assertEquals(1, tour.getActivities().size());
+        Assertions.assertTrue(tour.getActivities().contains(deliverShipment));
+        Assertions.assertFalse(tour.getActivities().contains(pickupShipment));
+        Assertions.assertFalse(tour.getActivities().contains(pickupShipment));
 
     }
 
@@ -196,15 +197,15 @@ public class TestTourActivities {
         tour.addActivity(pickupShipment);
         tour.addActivity(deliverShipment);
 
-        assertEquals(1, tour.jobSize());
-        assertEquals(2, tour.getActivities().size());
-        assertTrue(tour.getActivities().contains(pickupShipment));
-        assertTrue(tour.getActivities().contains(pickupShipment));
-        assertTrue(tour.getActivities().contains(deliverShipment));
+        Assertions.assertEquals(1, tour.jobSize());
+        Assertions.assertEquals(2, tour.getActivities().size());
+        Assertions.assertTrue(tour.getActivities().contains(pickupShipment));
+        Assertions.assertTrue(tour.getActivities().contains(pickupShipment));
+        Assertions.assertTrue(tour.getActivities().contains(deliverShipment));
 
         TourActivities copiedTour = TourActivities.copyOf(tour);
 
-        assertEquals(1, copiedTour.jobSize());
+        Assertions.assertEquals(1, copiedTour.jobSize());
     }
 
     @Test
@@ -217,15 +218,15 @@ public class TestTourActivities {
         tour.addActivity(pickupShipment);
         tour.addActivity(deliverShipment);
 
-        assertEquals(1, tour.jobSize());
-        assertEquals(2, tour.getActivities().size());
-        assertTrue(tour.getActivities().contains(pickupShipment));
-        assertTrue(tour.getActivities().contains(pickupShipment));
-        assertTrue(tour.getActivities().contains(deliverShipment));
+        Assertions.assertEquals(1, tour.jobSize());
+        Assertions.assertEquals(2, tour.getActivities().size());
+        Assertions.assertTrue(tour.getActivities().contains(pickupShipment));
+        Assertions.assertTrue(tour.getActivities().contains(pickupShipment));
+        Assertions.assertTrue(tour.getActivities().contains(deliverShipment));
 
         TourActivities copiedTour = TourActivities.copyOf(tour);
 
-        assertEquals(2, copiedTour.getActivities().size());
+        Assertions.assertEquals(2, copiedTour.getActivities().size());
     }
 
     @Test
@@ -238,15 +239,15 @@ public class TestTourActivities {
         tour.addActivity(pickupShipment);
         tour.addActivity(deliverShipment);
 
-        assertEquals(1, tour.jobSize());
-        assertEquals(2, tour.getActivities().size());
-        assertTrue(tour.getActivities().contains(pickupShipment));
-        assertTrue(tour.getActivities().contains(pickupShipment));
-        assertTrue(tour.getActivities().contains(deliverShipment));
+        Assertions.assertEquals(1, tour.jobSize());
+        Assertions.assertEquals(2, tour.getActivities().size());
+        Assertions.assertTrue(tour.getActivities().contains(pickupShipment));
+        Assertions.assertTrue(tour.getActivities().contains(pickupShipment));
+        Assertions.assertTrue(tour.getActivities().contains(deliverShipment));
 
         TourActivities copiedTour = TourActivities.copyOf(tour);
 
-        assertTrue(copiedTour.servesJob(s));
+        Assertions.assertTrue(copiedTour.servesJob(s));
     }
 
 }

--- a/jsprit-core/src/test/java/com/graphhopper/jsprit/core/problem/vehicle/TestVehicleFleetManagerImpl.java
+++ b/jsprit-core/src/test/java/com/graphhopper/jsprit/core/problem/vehicle/TestVehicleFleetManagerImpl.java
@@ -19,15 +19,14 @@ package com.graphhopper.jsprit.core.problem.vehicle;
 
 import com.graphhopper.jsprit.core.problem.Location;
 import com.graphhopper.jsprit.core.problem.VehicleRoutingProblem;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.List;
-
-import static org.junit.Assert.*;
 
 public class TestVehicleFleetManagerImpl {
 
@@ -37,7 +36,7 @@ public class TestVehicleFleetManagerImpl {
 
     VehicleImpl v2;
 
-    @Before
+    @BeforeEach
     public void setUp() {
         List<Vehicle> vehicles = new ArrayList<Vehicle>();
 
@@ -45,7 +44,7 @@ public class TestVehicleFleetManagerImpl {
         v2 = VehicleImpl.Builder.newInstance("foo").setStartLocation(Location.newInstance("fooLoc")).setType(VehicleTypeImpl.Builder.newInstance("foo").build()).build();
 
         VehicleRoutingProblem.Builder.newInstance().addVehicle(v1).addVehicle(v2).build();
-//		v1.
+        // v1.
         vehicles.add(v1);
         vehicles.add(v2);
         fleetManager = new FiniteFleetManagerFactory(vehicles).createFleetManager();
@@ -54,14 +53,14 @@ public class TestVehicleFleetManagerImpl {
     @Test
     public void testGetVehicles() {
         Collection<Vehicle> vehicles = fleetManager.getAvailableVehicles();
-        assertEquals(2, vehicles.size());
+        Assertions.assertEquals(2, vehicles.size());
     }
 
     @Test
     public void testLock() {
         fleetManager.lock(v1);
         Collection<Vehicle> vehicles = fleetManager.getAvailableVehicles();
-        assertEquals(1, vehicles.size());
+        Assertions.assertEquals(1, vehicles.size());
     }
 
     @Test
@@ -69,27 +68,27 @@ public class TestVehicleFleetManagerImpl {
         fleetManager.lock(v1);
         fleetManager.lock(v2);
         fleetManager.unlock(v2);
-        assertTrue(fleetManager.isLocked(v1));
+        Assertions.assertTrue(fleetManager.isLocked(v1));
     }
 
     @Test
     public void testIsLocked() {
         fleetManager.lock(v1);
-        assertTrue(fleetManager.isLocked(v1));
+        Assertions.assertTrue(fleetManager.isLocked(v1));
     }
 
     @Test
     public void testLockTwice() {
         fleetManager.lock(v1);
         Collection<Vehicle> vehicles = fleetManager.getAvailableVehicles();
-        assertEquals(1, vehicles.size());
+        Assertions.assertEquals(1, vehicles.size());
         try {
             fleetManager.lock(v1);
             @SuppressWarnings("unused")
             Collection<Vehicle> vehicles_ = fleetManager.getAvailableVehicles();
-            assertFalse(true);
+            Assertions.assertFalse(true);
         } catch (IllegalStateException e) {
-            assertTrue(true);
+            Assertions.assertTrue(true);
         }
     }
 
@@ -97,18 +96,18 @@ public class TestVehicleFleetManagerImpl {
     public void testGetVehiclesWithout() {
         Collection<Vehicle> vehicles = fleetManager.getAvailableVehicles(v1);
 
-        assertEquals(v2, vehicles.iterator().next());
-        assertEquals(1, vehicles.size());
+        Assertions.assertEquals(v2, vehicles.iterator().next());
+        Assertions.assertEquals(1, vehicles.size());
     }
 
     @Test
     public void testUnlock() {
         fleetManager.lock(v1);
         Collection<Vehicle> vehicles = fleetManager.getAvailableVehicles();
-        assertEquals(1, vehicles.size());
+        Assertions.assertEquals(1, vehicles.size());
         fleetManager.unlock(v1);
         Collection<Vehicle> vehicles_ = fleetManager.getAvailableVehicles();
-        assertEquals(2, vehicles_.size());
+        Assertions.assertEquals(2, vehicles_.size());
     }
 
     @Test
@@ -118,7 +117,7 @@ public class TestVehicleFleetManagerImpl {
         Vehicle v2 = VehicleImpl.Builder.newInstance("v2").setStartLocation(Location.newInstance("loc")).setType(type).build();
         VehicleFleetManager fleetManager = new FiniteFleetManagerFactory(Arrays.asList(v1, v2)).createFleetManager();
         Collection<Vehicle> vehicles = fleetManager.getAvailableVehicles();
-        assertEquals(1, vehicles.size());
+        Assertions.assertEquals(1, vehicles.size());
     }
 
     @Test
@@ -130,7 +129,7 @@ public class TestVehicleFleetManagerImpl {
             .setType(type).setEarliestStart(0.).setLatestArrival(10.).build();
         VehicleFleetManager fleetManager = new FiniteFleetManagerFactory(Arrays.asList(v1, v2)).createFleetManager();
         Collection<Vehicle> vehicles = fleetManager.getAvailableVehicles();
-        assertEquals(1, vehicles.size());
+        Assertions.assertEquals(1, vehicles.size());
     }
 
     @Test
@@ -144,9 +143,9 @@ public class TestVehicleFleetManagerImpl {
         VehicleRoutingProblem.Builder.newInstance().addVehicle(v1).addVehicle(v2).build();
         VehicleFleetManager fleetManager = new FiniteFleetManagerFactory(Arrays.asList(v1, v2)).createFleetManager();
         Collection<Vehicle> vehicles = fleetManager.getAvailableVehicles();
-        assertEquals(2, vehicles.size());
-        assertTrue(vehicleInCollection(v1, vehicles));
-        assertTrue(vehicleInCollection(v2, vehicles));
+        Assertions.assertEquals(2, vehicles.size());
+        Assertions.assertTrue(vehicleInCollection(v1, vehicles));
+        Assertions.assertTrue(vehicleInCollection(v2, vehicles));
     }
 
     @Test
@@ -159,9 +158,9 @@ public class TestVehicleFleetManagerImpl {
         VehicleRoutingProblem.Builder.newInstance().addVehicle(v1).addVehicle(v2).build();
         VehicleFleetManager fleetManager = new FiniteFleetManagerFactory(Arrays.asList(v1, v2)).createFleetManager();
         Collection<Vehicle> vehicles = fleetManager.getAvailableVehicles();
-        assertEquals(2, vehicles.size());
-        assertTrue(vehicleInCollection(v1, vehicles));
-        assertTrue(vehicleInCollection(v2, vehicles));
+        Assertions.assertEquals(2, vehicles.size());
+        Assertions.assertTrue(vehicleInCollection(v1, vehicles));
+        Assertions.assertTrue(vehicleInCollection(v2, vehicles));
     }
 
     @Test
@@ -174,9 +173,9 @@ public class TestVehicleFleetManagerImpl {
         VehicleRoutingProblem.Builder.newInstance().addVehicle(v1).addVehicle(v2).build();
         VehicleFleetManager fleetManager = new FiniteFleetManagerFactory(Arrays.asList(v1, v2)).createFleetManager();
         Collection<Vehicle> vehicles = fleetManager.getAvailableVehicles();
-        assertEquals(2, vehicles.size());
-        assertTrue(vehicleInCollection(v1, vehicles));
-        assertTrue(vehicleInCollection(v2, vehicles));
+        Assertions.assertEquals(2, vehicles.size());
+        Assertions.assertTrue(vehicleInCollection(v1, vehicles));
+        Assertions.assertTrue(vehicleInCollection(v2, vehicles));
     }
 
     @Test
@@ -189,9 +188,9 @@ public class TestVehicleFleetManagerImpl {
         VehicleRoutingProblem.Builder.newInstance().addVehicle(v1).addVehicle(v2).build();
         VehicleFleetManager fleetManager = new FiniteFleetManagerFactory(Arrays.asList(v1, v2)).createFleetManager();
         Collection<Vehicle> vehicles = fleetManager.getAvailableVehicles();
-        assertEquals(2, vehicles.size());
-        assertTrue(vehicleInCollection(v1, vehicles));
-        assertTrue(vehicleInCollection(v2, vehicles));
+        Assertions.assertEquals(2, vehicles.size());
+        Assertions.assertTrue(vehicleInCollection(v1, vehicles));
+        Assertions.assertTrue(vehicleInCollection(v2, vehicles));
     }
 
     @Test
@@ -204,9 +203,9 @@ public class TestVehicleFleetManagerImpl {
         VehicleRoutingProblem.Builder.newInstance().addVehicle(v1).addVehicle(v2).build();
         VehicleFleetManager fleetManager = new FiniteFleetManagerFactory(Arrays.asList(v1, v2)).createFleetManager();
         Collection<Vehicle> vehicles = fleetManager.getAvailableVehicles();
-        assertEquals(2, vehicles.size());
-        assertTrue(vehicleInCollection(v1, vehicles));
-        assertTrue(vehicleInCollection(v2, vehicles));
+        Assertions.assertEquals(2, vehicles.size());
+        Assertions.assertTrue(vehicleInCollection(v1, vehicles));
+        Assertions.assertTrue(vehicleInCollection(v2, vehicles));
     }
 
     private boolean vehicleInCollection(Vehicle v, Collection<Vehicle> vehicles) {

--- a/jsprit-core/src/test/java/com/graphhopper/jsprit/core/problem/vehicle/VehicleImplTest.java
+++ b/jsprit-core/src/test/java/com/graphhopper/jsprit/core/problem/vehicle/VehicleImplTest.java
@@ -20,6 +20,8 @@ package com.graphhopper.jsprit.core.problem.vehicle;
 import com.graphhopper.jsprit.core.problem.Location;
 import com.graphhopper.jsprit.core.problem.job.Break;
 import com.graphhopper.jsprit.core.problem.solution.route.activity.TimeWindow;
+
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
@@ -47,9 +49,9 @@ class VehicleImplTest {
         Break aBreak = Break.Builder.newInstance("break").setTimeWindow(TimeWindow.newInstance(100, 200)).setServiceTime(30).build();
         Vehicle v = VehicleImpl.Builder.newInstance("v").setStartLocation(Location.newInstance("start")).setType(type1).setEndLocation(Location.newInstance("start")).setBreak(aBreak).build();
         assertNotNull(v.getBreak());
-        assertEquals(100., v.getBreak().getTimeWindow().getStart(), 0.1);
-        assertEquals(200., v.getBreak().getTimeWindow().getEnd(), 0.1);
-        assertEquals(30., v.getBreak().getServiceDuration(), 0.1);
+        Assertions.assertEquals(100., v.getBreak().getTimeWindow().getStart(), 0.1);
+        Assertions.assertEquals(200., v.getBreak().getTimeWindow().getEnd(), 0.1);
+        Assertions.assertEquals(30., v.getBreak().getServiceDuration(), 0.1);
     }
 
     @Test
@@ -60,11 +62,11 @@ class VehicleImplTest {
         Vehicle v = VehicleImpl.Builder.newInstance("v").setStartLocation(Location.newInstance("start")).setType(type1).setEndLocation(Location.newInstance("start")).setBreak(aBreak).build();
         Vehicle newVehicle = VehicleImpl.Builder.newInstance(v).setStartLocation(Location.newInstance("newStartLocation")).build();
         assertNotNull(newVehicle.getBreak());
-        assertEquals(100., newVehicle.getBreak().getTimeWindow().getStart(), 0.1);
-        assertEquals(200., newVehicle.getBreak().getTimeWindow().getEnd(), 0.1);
-        assertEquals(30., newVehicle.getBreak().getServiceDuration(), 0.1);
-        assertEquals(newVehicle.getStartLocation().getId(), "newStartLocation");
-        assertEquals(type1, newVehicle.getType());
+        Assertions.assertEquals(100., newVehicle.getBreak().getTimeWindow().getStart(), 0.1);
+        Assertions.assertEquals(200., newVehicle.getBreak().getTimeWindow().getEnd(), 0.1);
+        Assertions.assertEquals(30., newVehicle.getBreak().getServiceDuration(), 0.1);
+        Assertions.assertEquals(newVehicle.getStartLocation().getId(), "newStartLocation");
+        Assertions.assertEquals(type1, newVehicle.getType());
     }
 
     @Test
@@ -72,9 +74,9 @@ class VehicleImplTest {
     void whenAddingSkills_theyShouldBeAddedCorrectly() {
         VehicleTypeImpl type1 = VehicleTypeImpl.Builder.newInstance("type").build();
         Vehicle v = VehicleImpl.Builder.newInstance("v").setStartLocation(Location.newInstance("start")).setType(type1).setEndLocation(Location.newInstance("start")).addSkill("drill").addSkill("screwdriver").build();
-        assertTrue(v.getSkills().containsSkill("drill"));
-        assertTrue(v.getSkills().containsSkill("drill"));
-        assertTrue(v.getSkills().containsSkill("screwdriver"));
+        Assertions.assertTrue(v.getSkills().containsSkill("drill"));
+        Assertions.assertTrue(v.getSkills().containsSkill("drill"));
+        Assertions.assertTrue(v.getSkills().containsSkill("screwdriver"));
     }
 
     @Test
@@ -82,80 +84,80 @@ class VehicleImplTest {
     void whenAddingSkillsCaseSens_theyShouldBeAddedCorrectly() {
         VehicleTypeImpl type1 = VehicleTypeImpl.Builder.newInstance("type").build();
         Vehicle v = VehicleImpl.Builder.newInstance("v").setStartLocation(Location.newInstance("start")).setType(type1).setEndLocation(Location.newInstance("start")).addSkill("drill").addSkill("screwdriver").build();
-        assertTrue(v.getSkills().containsSkill("drill"));
-        assertTrue(v.getSkills().containsSkill("dRill"));
-        assertTrue(v.getSkills().containsSkill("ScrewDriver"));
+        Assertions.assertTrue(v.getSkills().containsSkill("drill"));
+        Assertions.assertTrue(v.getSkills().containsSkill("dRill"));
+        Assertions.assertTrue(v.getSkills().containsSkill("ScrewDriver"));
     }
 
     @Test
     @DisplayName("When Vehicle Is Built To Return To Depot _ it Should Return To Depot")
     void whenVehicleIsBuiltToReturnToDepot_itShouldReturnToDepot() {
         Vehicle v = VehicleImpl.Builder.newInstance("v").setReturnToDepot(true).setStartLocation(Location.newInstance("loc")).build();
-        assertTrue(v.isReturnToDepot());
+        Assertions.assertTrue(v.isReturnToDepot());
     }
 
     @Test
     @DisplayName("When Vehicle Is Built To Not Return To Depot _ it Should Not Return To Depot")
     void whenVehicleIsBuiltToNotReturnToDepot_itShouldNotReturnToDepot() {
         Vehicle v = VehicleImpl.Builder.newInstance("v").setReturnToDepot(false).setStartLocation(Location.newInstance("loc")).build();
-        assertFalse(v.isReturnToDepot());
+        Assertions.assertFalse(v.isReturnToDepot());
     }
 
     @Test
     @DisplayName("When Vehicle Is Built With Location _ it Should Hv The Correct Location")
     void whenVehicleIsBuiltWithLocation_itShouldHvTheCorrectLocation() {
         Vehicle v = VehicleImpl.Builder.newInstance("v").setStartLocation(Location.newInstance("loc")).build();
-        assertEquals(v.getStartLocation().getId(), "loc");
+        Assertions.assertEquals(v.getStartLocation().getId(), "loc");
     }
 
     @Test
     @DisplayName("When Vehicle Is Built With Coord _ it Should Hv The Correct Coord")
     void whenVehicleIsBuiltWithCoord_itShouldHvTheCorrectCoord() {
         Vehicle v = VehicleImpl.Builder.newInstance("v").setStartLocation(Location.newInstance(1, 2)).build();
-        assertEquals(1.0, v.getStartLocation().getCoordinate().getX(), 0.01);
-        assertEquals(2.0, v.getStartLocation().getCoordinate().getY(), 0.01);
+        Assertions.assertEquals(1.0, v.getStartLocation().getCoordinate().getX(), 0.01);
+        Assertions.assertEquals(2.0, v.getStartLocation().getCoordinate().getY(), 0.01);
     }
 
     @Test
     @DisplayName("When Vehicle Is Built And Earliest Start Is Not Set _ it Should Set The Default Of Zero")
     void whenVehicleIsBuiltAndEarliestStartIsNotSet_itShouldSetTheDefaultOfZero() {
         Vehicle v = VehicleImpl.Builder.newInstance("v").setStartLocation(Location.newInstance(1, 2)).build();
-        assertEquals(0.0, v.getEarliestDeparture(), 0.01);
+        Assertions.assertEquals(0.0, v.getEarliestDeparture(), 0.01);
     }
 
     @Test
     @DisplayName("When Vehicle Is Built And Earliest Start Set _ it Should Be Set Correctly")
     void whenVehicleIsBuiltAndEarliestStartSet_itShouldBeSetCorrectly() {
         Vehicle v = VehicleImpl.Builder.newInstance("v").setEarliestStart(10.0).setStartLocation(Location.newInstance(1, 2)).build();
-        assertEquals(10.0, v.getEarliestDeparture(), 0.01);
+        Assertions.assertEquals(10.0, v.getEarliestDeparture(), 0.01);
     }
 
     @Test
     @DisplayName("When Vehicle Is Built And Latest Arrival Is Not Set _ it Should Set Default Of Double Max Value")
     void whenVehicleIsBuiltAndLatestArrivalIsNotSet_itShouldSetDefaultOfDoubleMaxValue() {
         Vehicle v = VehicleImpl.Builder.newInstance("v").setStartLocation(Location.newInstance(1, 2)).build();
-        assertEquals(Double.MAX_VALUE, v.getLatestArrival(), 0.01);
+        Assertions.assertEquals(Double.MAX_VALUE, v.getLatestArrival(), 0.01);
     }
 
     @Test
     @DisplayName("When Vehicle Is Built And Latest Arrival Is Set _ it Should Be Set Correctly")
     void whenVehicleIsBuiltAndLatestArrivalIsSet_itShouldBeSetCorrectly() {
         Vehicle v = VehicleImpl.Builder.newInstance("v").setLatestArrival(30.0).setStartLocation(Location.newInstance(1, 2)).build();
-        assertEquals(30.0, v.getLatestArrival(), 0.01);
+        Assertions.assertEquals(30.0, v.getLatestArrival(), 0.01);
     }
 
     @Test
     @DisplayName("When No Vehicle Is Create _ it Should Hv The Correct Id")
     void whenNoVehicleIsCreate_itShouldHvTheCorrectId() {
         Vehicle v = VehicleImpl.createNoVehicle();
-        assertEquals(v.getId(), "noVehicle");
+        Assertions.assertEquals(v.getId(), "noVehicle");
     }
 
     @Test
     @DisplayName("When Start Location Is Set _ it Is Done Correctly")
     void whenStartLocationIsSet_itIsDoneCorrectly() {
         Vehicle v = VehicleImpl.Builder.newInstance("v").setStartLocation(Location.newInstance("startLoc")).build();
-        assertEquals(v.getStartLocation().getId(), "startLoc");
+        Assertions.assertEquals(v.getStartLocation().getId(), "startLoc");
     }
 
     @Test
@@ -171,52 +173,52 @@ class VehicleImplTest {
     @DisplayName("When Start Location Coord Is Set _ it Is Done Correctly")
     void whenStartLocationCoordIsSet_itIsDoneCorrectly() {
         Vehicle v = VehicleImpl.Builder.newInstance("v").setStartLocation(Location.newInstance(1, 2)).build();
-        assertEquals(1.0, v.getStartLocation().getCoordinate().getX(), 0.01);
-        assertEquals(2.0, v.getStartLocation().getCoordinate().getY(), 0.01);
+        Assertions.assertEquals(1.0, v.getStartLocation().getCoordinate().getX(), 0.01);
+        Assertions.assertEquals(2.0, v.getStartLocation().getCoordinate().getY(), 0.01);
     }
 
     @Test
     @DisplayName("When End Location Is Set _ it Is Done Correctly")
     void whenEndLocationIsSet_itIsDoneCorrectly() {
         Vehicle v = VehicleImpl.Builder.newInstance("v").setStartLocation(Location.newInstance("startLoc")).setEndLocation(Location.newInstance("endLoc")).build();
-        assertEquals(v.getStartLocation().getId(), "startLoc");
-        assertEquals(v.getEndLocation().getId(), "endLoc");
+        Assertions.assertEquals(v.getStartLocation().getId(), "startLoc");
+        Assertions.assertEquals(v.getEndLocation().getId(), "endLoc");
     }
 
     @Test
     @DisplayName("When End Location Coord Is Set _ it Is Done Correctly")
     void whenEndLocationCoordIsSet_itIsDoneCorrectly() {
         Vehicle v = VehicleImpl.Builder.newInstance("v").setStartLocation(Location.newInstance("startLoc")).setEndLocation(Location.newInstance(1, 2)).build();
-        assertEquals(1.0, v.getEndLocation().getCoordinate().getX(), 0.01);
-        assertEquals(2.0, v.getEndLocation().getCoordinate().getY(), 0.01);
+        Assertions.assertEquals(1.0, v.getEndLocation().getCoordinate().getX(), 0.01);
+        Assertions.assertEquals(2.0, v.getEndLocation().getCoordinate().getY(), 0.01);
     }
 
     @Test
     @DisplayName("When Neither End Location Id Nor End Location Coord Are Set _ end Location Id Must Be Equal To Start Location Id")
     void whenNeitherEndLocationIdNorEndLocationCoordAreSet_endLocationIdMustBeEqualToStartLocationId() {
         Vehicle v = VehicleImpl.Builder.newInstance("v").setStartLocation(Location.newInstance("startLoc")).build();
-        assertEquals(v.getEndLocation().getId(), "startLoc");
+        Assertions.assertEquals(v.getEndLocation().getId(), "startLoc");
     }
 
     @Test
     @DisplayName("When Neither End Location Id Nor End Location Coord Are Set _ end Location Coord Must Be Equal To Start Location Coord")
     void whenNeitherEndLocationIdNorEndLocationCoordAreSet_endLocationCoordMustBeEqualToStartLocationCoord() {
         Vehicle v = VehicleImpl.Builder.newInstance("v").setStartLocation(Location.newInstance("startLoc")).build();
-        assertEquals(v.getEndLocation().getCoordinate(), v.getStartLocation().getCoordinate());
+        Assertions.assertEquals(v.getEndLocation().getCoordinate(), v.getStartLocation().getCoordinate());
     }
 
     @Test
     @DisplayName("When Neither End Location Id Nor End Location Coord Are Set _ end Location Coord Must Be Equal To Start Location Coord V 2")
     void whenNeitherEndLocationIdNorEndLocationCoordAreSet_endLocationCoordMustBeEqualToStartLocationCoordV2() {
         Vehicle v = VehicleImpl.Builder.newInstance("v").setStartLocation(Location.newInstance(1.0, 2.0)).build();
-        assertEquals(v.getEndLocation().getCoordinate(), v.getStartLocation().getCoordinate());
+        Assertions.assertEquals(v.getEndLocation().getCoordinate(), v.getStartLocation().getCoordinate());
     }
 
     @Test
     @DisplayName("When End Location Coordinate Is Set But No Id _ id Must Be Coord To String")
     void whenEndLocationCoordinateIsSetButNoId_idMustBeCoordToString() {
         Vehicle v = VehicleImpl.Builder.newInstance("v").setStartLocation(Location.newInstance(1.0, 2.0)).setEndLocation(Location.newInstance(3.0, 4.0)).build();
-        assertEquals(v.getEndLocation().getCoordinate().toString(), v.getEndLocation().getId());
+        Assertions.assertEquals(v.getEndLocation().getCoordinate().toString(), v.getEndLocation().getId());
     }
 
     @Test
@@ -241,14 +243,14 @@ class VehicleImplTest {
     @DisplayName("When End Location Coord Is Not Specified AND Return To Depot Is False _ end Location Coord Must Be Start Location Coord")
     void whenEndLocationCoordIsNotSpecifiedANDReturnToDepotIsFalse_endLocationCoordMustBeStartLocationCoord() {
         Vehicle v = VehicleImpl.Builder.newInstance("v").setStartLocation(Location.newInstance(1.0, 2.0)).setReturnToDepot(false).build();
-        assertEquals(v.getStartLocation().getCoordinate(), v.getEndLocation().getCoordinate());
+        Assertions.assertEquals(v.getStartLocation().getCoordinate(), v.getEndLocation().getCoordinate());
     }
 
     @Test
     @DisplayName("When End Location Id Is Not Specified AND Return To Depot Is False _ end Location Id Must Be Start Location Id")
     void whenEndLocationIdIsNotSpecifiedANDReturnToDepotIsFalse_endLocationIdMustBeStartLocationId() {
         Vehicle v = VehicleImpl.Builder.newInstance("v").setStartLocation(Location.newInstance(1.0, 2.0)).setReturnToDepot(false).build();
-        assertEquals(v.getStartLocation().getCoordinate().toString(), v.getEndLocation().getId());
+        Assertions.assertEquals(v.getStartLocation().getCoordinate().toString(), v.getEndLocation().getId());
     }
 
     @Test
@@ -265,7 +267,7 @@ class VehicleImplTest {
     void whenStartAndEndAreEqualANDReturnToDepotIsFalse_itShouldThrowException() {
         @SuppressWarnings("unused")
         Vehicle v = VehicleImpl.Builder.newInstance("v").setStartLocation(Location.newInstance("start")).setEndLocation(Location.newInstance("start")).setReturnToDepot(false).build();
-        assertTrue(true);
+        Assertions.assertTrue(true);
     }
 
     @Test
@@ -273,7 +275,7 @@ class VehicleImplTest {
     void whenTwoVehiclesHaveTheSameId_theyShouldBeEqual() {
         Vehicle v = VehicleImpl.Builder.newInstance("v").setStartLocation(Location.newInstance("start")).setEndLocation(Location.newInstance("start")).setReturnToDepot(false).build();
         Vehicle v2 = VehicleImpl.Builder.newInstance("v").setStartLocation(Location.newInstance("start")).setEndLocation(Location.newInstance("start")).setReturnToDepot(false).build();
-        assertTrue(v.equals(v2));
+        Assertions.assertTrue(v.equals(v2));
     }
 
     @Test
@@ -281,7 +283,7 @@ class VehicleImplTest {
     void whenAddingSkillsCaseSensV2_theyShouldBeAddedCorrectly() {
         VehicleTypeImpl type1 = VehicleTypeImpl.Builder.newInstance("type").build();
         Vehicle v = VehicleImpl.Builder.newInstance("v").setStartLocation(Location.newInstance("start")).setType(type1).setEndLocation(Location.newInstance("start")).addSkill("drill").build();
-        assertFalse(v.getSkills().containsSkill("ScrewDriver"));
+        Assertions.assertFalse(v.getSkills().containsSkill("ScrewDriver"));
     }
 
     @Test
@@ -291,8 +293,8 @@ class VehicleImplTest {
         Vehicle one = VehicleImpl.Builder.newInstance("v").setType(type1).setStartLocation(Location.newInstance("start")).setUserData(new HashMap<String, Object>()).build();
         Vehicle two = VehicleImpl.Builder.newInstance("v").setType(type1).setStartLocation(Location.newInstance("start")).setUserData(42).build();
         Vehicle three = VehicleImpl.Builder.newInstance("v").setType(type1).setStartLocation(Location.newInstance("start")).build();
-        assertTrue(one.getUserData() instanceof Map);
-        assertEquals(42, two.getUserData());
+        Assertions.assertTrue(one.getUserData() instanceof Map);
+        Assertions.assertEquals(42, two.getUserData());
         assertNull(three.getUserData());
     }
 }

--- a/jsprit-core/src/test/java/com/graphhopper/jsprit/core/problem/vehicle/VehicleTypeImplTest.java
+++ b/jsprit-core/src/test/java/com/graphhopper/jsprit/core/problem/vehicle/VehicleTypeImplTest.java
@@ -17,6 +17,7 @@
  */
 package com.graphhopper.jsprit.core.problem.vehicle;
 
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
@@ -41,29 +42,29 @@ class VehicleTypeImplTest {
     @DisplayName("When Adding Two Cap Dimension _ nu Of Dims Should Be Two")
     void whenAddingTwoCapDimension_nuOfDimsShouldBeTwo() {
         VehicleTypeImpl type = VehicleTypeImpl.Builder.newInstance("t").addCapacityDimension(0, 2).addCapacityDimension(1, 4).build();
-        assertEquals(2, type.getCapacityDimensions().getNuOfDimensions());
+        Assertions.assertEquals(2, type.getCapacityDimensions().getNuOfDimensions());
     }
 
     @Test
     @DisplayName("When Adding Two Cap Dimension _ dim Values Must Be Correct")
     void whenAddingTwoCapDimension_dimValuesMustBeCorrect() {
         VehicleTypeImpl type = VehicleTypeImpl.Builder.newInstance("t").addCapacityDimension(0, 2).addCapacityDimension(1, 4).build();
-        assertEquals(2, type.getCapacityDimensions().get(0));
-        assertEquals(4, type.getCapacityDimensions().get(1));
+        Assertions.assertEquals(2, type.getCapacityDimensions().get(0));
+        Assertions.assertEquals(4, type.getCapacityDimensions().get(1));
     }
 
     @Test
     @DisplayName("When Type Is Built Without Specifying Capacity _ it Should Hv Cap With One Dim")
     void whenTypeIsBuiltWithoutSpecifyingCapacity_itShouldHvCapWithOneDim() {
         VehicleTypeImpl type = VehicleTypeImpl.Builder.newInstance("t").build();
-        assertEquals(1, type.getCapacityDimensions().getNuOfDimensions());
+        Assertions.assertEquals(1, type.getCapacityDimensions().getNuOfDimensions());
     }
 
     @Test
     @DisplayName("When Type Is Built Without Specifying Capacity _ it Should Hv Cap Dim Val Of Zero")
     void whenTypeIsBuiltWithoutSpecifyingCapacity_itShouldHvCapDimValOfZero() {
         VehicleTypeImpl type = VehicleTypeImpl.Builder.newInstance("t").build();
-        assertEquals(0, type.getCapacityDimensions().get(0));
+        Assertions.assertEquals(0, type.getCapacityDimensions().get(0));
     }
 
     @Test
@@ -77,14 +78,14 @@ class VehicleTypeImplTest {
     @DisplayName("When Building Type Just By Calling New Instance _ type Id Must Be Correct")
     void whenBuildingTypeJustByCallingNewInstance_typeIdMustBeCorrect() {
         VehicleTypeImpl type = VehicleTypeImpl.Builder.newInstance("foo").build();
-        assertEquals(type.getTypeId(), "foo");
+        Assertions.assertEquals(type.getTypeId(), "foo");
     }
 
     @Test
     @DisplayName("When Building Type Just By Calling New Instance _ cap Must Be Correct")
     void whenBuildingTypeJustByCallingNewInstance_capMustBeCorrect() {
         VehicleTypeImpl type = VehicleTypeImpl.Builder.newInstance("foo").build();
-        assertEquals(0, type.getCapacityDimensions().get(0));
+        Assertions.assertEquals(0, type.getCapacityDimensions().get(0));
     }
 
     @Test
@@ -109,7 +110,7 @@ class VehicleTypeImplTest {
     @DisplayName("When Setting Max Velocity _ it Should Be Set Correctly")
     void whenSettingMaxVelocity_itShouldBeSetCorrectly() {
         VehicleTypeImpl type = VehicleTypeImpl.Builder.newInstance("type").setMaxVelocity(10).build();
-        assertEquals(10, type.getMaxVelocity(), 0.0);
+        Assertions.assertEquals(10, type.getMaxVelocity(), 0.0);
     }
 
     @Test
@@ -132,7 +133,7 @@ class VehicleTypeImplTest {
 
     public void whenSettingFixedCosts_itShouldBeSetCorrectly() {
         VehicleTypeImpl type = VehicleTypeImpl.Builder.newInstance("type").setFixedCost(10).build();
-        assertEquals(10.0, type.getVehicleCostParams().fix, 0.0);
+        Assertions.assertEquals(10.0, type.getVehicleCostParams().fix, 0.0);
     }
 
     @Test
@@ -148,7 +149,7 @@ class VehicleTypeImplTest {
     @DisplayName("When Setting Per Distance Costs _ it Should Be Set Correctly")
     void whenSettingPerDistanceCosts_itShouldBeSetCorrectly() {
         VehicleTypeImpl type = VehicleTypeImpl.Builder.newInstance("type").setCostPerDistance(10).build();
-        assertEquals(10.0, type.getVehicleCostParams().perDistanceUnit, 0.0);
+        Assertions.assertEquals(10.0, type.getVehicleCostParams().perDistanceUnit, 0.0);
     }
 
     @Test
@@ -165,14 +166,14 @@ class VehicleTypeImplTest {
     void whenHavingTwoTypesWithTheSameId_theyShouldBeEqual() {
         VehicleTypeImpl type = VehicleTypeImpl.Builder.newInstance("type").setCostPerTime(10).build();
         VehicleTypeImpl type2 = VehicleTypeImpl.Builder.newInstance("type").setCostPerTime(10).build();
-        assertTrue(type.equals(type2));
+        Assertions.assertTrue(type.equals(type2));
     }
 
     @Test
     @DisplayName("When Adding Profile _ it Should Be Correct")
     void whenAddingProfile_itShouldBeCorrect() {
         VehicleTypeImpl type = VehicleTypeImpl.Builder.newInstance("type").setProfile("car").build();
-        assertEquals(type.getProfile(), "car");
+        Assertions.assertEquals(type.getProfile(), "car");
     }
 
     @Test
@@ -181,8 +182,8 @@ class VehicleTypeImplTest {
         VehicleType one = VehicleTypeImpl.Builder.newInstance("type").setUserData(new HashMap<String, Object>()).build();
         VehicleType two = VehicleTypeImpl.Builder.newInstance("type").setUserData(42).build();
         VehicleType three = VehicleTypeImpl.Builder.newInstance("type").build();
-        assertTrue(one.getUserData() instanceof Map);
-        assertEquals(42, two.getUserData());
+        Assertions.assertTrue(one.getUserData() instanceof Map);
+        Assertions.assertEquals(42, two.getUserData());
         assertNull(three.getUserData());
     }
 
@@ -191,7 +192,7 @@ class VehicleTypeImplTest {
     void typesShouldBeEqual() {
         VehicleType one = VehicleTypeImpl.Builder.newInstance("type").setFixedCost(100).build();
         VehicleType two = VehicleTypeImpl.Builder.newInstance("type").setFixedCost(100).build();
-        assertTrue(one.equals(two));
+        Assertions.assertTrue(one.equals(two));
     }
 
     @Test
@@ -199,7 +200,7 @@ class VehicleTypeImplTest {
     void typesShouldBeNotEqual() {
         VehicleType one = VehicleTypeImpl.Builder.newInstance("type").build();
         VehicleType two = VehicleTypeImpl.Builder.newInstance("type").setFixedCost(100).build();
-        assertFalse(one.equals(two));
+        Assertions.assertFalse(one.equals(two));
     }
 
     @Test
@@ -207,7 +208,7 @@ class VehicleTypeImplTest {
     void typesShouldBeNotEqual2() {
         VehicleType one = VehicleTypeImpl.Builder.newInstance("type").addCapacityDimension(0, 10).build();
         VehicleType two = VehicleTypeImpl.Builder.newInstance("type").addCapacityDimension(0, 20).build();
-        assertFalse(one.equals(two));
+        Assertions.assertFalse(one.equals(two));
     }
 
     @Test
@@ -215,6 +216,6 @@ class VehicleTypeImplTest {
     void typesShouldBeEqual2() {
         VehicleType one = VehicleTypeImpl.Builder.newInstance("type").addCapacityDimension(0, 10).build();
         VehicleType two = VehicleTypeImpl.Builder.newInstance("type").addCapacityDimension(0, 10).build();
-        assertTrue(one.equals(two));
+        Assertions.assertTrue(one.equals(two));
     }
 }

--- a/jsprit-core/src/test/java/com/graphhopper/jsprit/core/problem/vehicle/VehicleTypeKeyTest.java
+++ b/jsprit-core/src/test/java/com/graphhopper/jsprit/core/problem/vehicle/VehicleTypeKeyTest.java
@@ -24,6 +24,8 @@ import org.junit.jupiter.api.Test;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import org.junit.jupiter.api.Assertions;
+
 @DisplayName("Vehicle Type Key Test")
 class VehicleTypeKeyTest {
 
@@ -32,7 +34,7 @@ class VehicleTypeKeyTest {
     void typeIdentifierShouldBeEqual() {
         Vehicle v1 = VehicleImpl.Builder.newInstance("v1").setStartLocation(Location.newInstance("start")).addSkill("skill1").addSkill("skill2").addSkill("skill3").build();
         Vehicle v2 = VehicleImpl.Builder.newInstance("v2").setStartLocation(Location.newInstance("start")).addSkill("skill2").addSkill("skill1").addSkill("skill3").build();
-        assertTrue(v1.getVehicleTypeIdentifier().equals(v2.getVehicleTypeIdentifier()));
+        Assertions.assertTrue(v1.getVehicleTypeIdentifier().equals(v2.getVehicleTypeIdentifier()));
     }
 
     @Test
@@ -40,6 +42,6 @@ class VehicleTypeKeyTest {
     void typeIdentifierShouldNotBeEqual() {
         Vehicle v1 = VehicleImpl.Builder.newInstance("v1").setStartLocation(Location.newInstance("start")).addSkill("skill1").addSkill("skill2").build();
         Vehicle v2 = VehicleImpl.Builder.newInstance("v2").setStartLocation(Location.newInstance("start")).addSkill("skill2").addSkill("skill1").addSkill("skill3").build();
-        assertFalse(v1.getVehicleTypeIdentifier().equals(v2.getVehicleTypeIdentifier()));
+        Assertions.assertFalse(v1.getVehicleTypeIdentifier().equals(v2.getVehicleTypeIdentifier()));
     }
 }

--- a/jsprit-core/src/test/java/com/graphhopper/jsprit/core/util/FastVehicleRoutingTransportCostsMatrixTest.java
+++ b/jsprit-core/src/test/java/com/graphhopper/jsprit/core/util/FastVehicleRoutingTransportCostsMatrixTest.java
@@ -21,6 +21,8 @@ import com.graphhopper.jsprit.core.problem.Location;
 import com.graphhopper.jsprit.core.problem.vehicle.Vehicle;
 import com.graphhopper.jsprit.core.problem.vehicle.VehicleType;
 import com.graphhopper.jsprit.core.problem.vehicle.VehicleTypeImpl;
+
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
@@ -37,10 +39,10 @@ class FastVehicleRoutingTransportCostsMatrixTest {
         FastVehicleRoutingTransportCostsMatrix.Builder matrixBuilder = FastVehicleRoutingTransportCostsMatrix.Builder.newInstance(3, true);
         matrixBuilder.addTransportDistance(1, 2, 2.);
         FastVehicleRoutingTransportCostsMatrix matrix = matrixBuilder.build();
-        assertEquals(2., matrix.getTransportCost(loc(1), loc(2), 0.0, null, null), 0.1);
-        assertEquals(2., matrix.getDistance(1, 2), 0.1);
-        assertEquals(2., matrix.getTransportCost(loc(2), loc(1), 0.0, null, null), 0.1);
-        assertEquals(2., matrix.getDistance(2, 1), 0.1);
+        Assertions.assertEquals(2., matrix.getTransportCost(loc(1), loc(2), 0.0, null, null), 0.1);
+        Assertions.assertEquals(2., matrix.getDistance(1, 2), 0.1);
+        Assertions.assertEquals(2., matrix.getTransportCost(loc(2), loc(1), 0.0, null, null), 0.1);
+        Assertions.assertEquals(2., matrix.getDistance(2, 1), 0.1);
     }
 
     @Test
@@ -49,7 +51,7 @@ class FastVehicleRoutingTransportCostsMatrixTest {
         FastVehicleRoutingTransportCostsMatrix.Builder matrixBuilder = FastVehicleRoutingTransportCostsMatrix.Builder.newInstance(3, false);
         matrixBuilder.addTransportDistance(1, 2, 2.);
         FastVehicleRoutingTransportCostsMatrix matrix = matrixBuilder.build();
-        assertEquals(2., matrix.getTransportCost(loc(1), loc(2), 0.0, null, null), 0.1);
+        Assertions.assertEquals(2., matrix.getTransportCost(loc(1), loc(2), 0.0, null, null), 0.1);
     }
 
     private Location loc(int index) {
@@ -62,8 +64,8 @@ class FastVehicleRoutingTransportCostsMatrixTest {
         FastVehicleRoutingTransportCostsMatrix.Builder matrixBuilder = FastVehicleRoutingTransportCostsMatrix.Builder.newInstance(3, true);
         matrixBuilder.addTransportTime(1, 2, 2.);
         FastVehicleRoutingTransportCostsMatrix matrix = matrixBuilder.build();
-        assertEquals(2., matrix.getTransportTime(loc(1), loc(2), 0.0, null, null), 0.1);
-        assertEquals(2., matrix.getTransportTime(loc(2), loc(1), 0.0, null, null), 0.1);
+        Assertions.assertEquals(2., matrix.getTransportTime(loc(1), loc(2), 0.0, null, null), 0.1);
+        Assertions.assertEquals(2., matrix.getTransportTime(loc(2), loc(1), 0.0, null, null), 0.1);
     }
 
     @Test
@@ -72,10 +74,10 @@ class FastVehicleRoutingTransportCostsMatrixTest {
         FastVehicleRoutingTransportCostsMatrix.Builder matrixBuilder = FastVehicleRoutingTransportCostsMatrix.Builder.newInstance(3, true);
         matrixBuilder.addTransportTimeAndDistance(1, 2, 2., 100.);
         FastVehicleRoutingTransportCostsMatrix matrix = matrixBuilder.build();
-        assertEquals(2., matrix.getTransportTime(loc(1), loc(2), 0.0, null, null), 0.1);
-        assertEquals(2., matrix.getTransportTime(loc(2), loc(1), 0.0, null, null), 0.1);
-        assertEquals(100., matrix.getDistance(loc(1), loc(2), 0.0, null), 0.1);
-        assertEquals(100., matrix.getDistance(loc(2), loc(1), 0.0, null), 0.1);
+        Assertions.assertEquals(2., matrix.getTransportTime(loc(1), loc(2), 0.0, null, null), 0.1);
+        Assertions.assertEquals(2., matrix.getTransportTime(loc(2), loc(1), 0.0, null, null), 0.1);
+        Assertions.assertEquals(100., matrix.getDistance(loc(1), loc(2), 0.0, null), 0.1);
+        Assertions.assertEquals(100., matrix.getDistance(loc(2), loc(1), 0.0, null), 0.1);
     }
 
     @Test
@@ -84,7 +86,7 @@ class FastVehicleRoutingTransportCostsMatrixTest {
         FastVehicleRoutingTransportCostsMatrix.Builder matrixBuilder = FastVehicleRoutingTransportCostsMatrix.Builder.newInstance(3, false);
         matrixBuilder.addTransportTime(1, 2, 2.);
         FastVehicleRoutingTransportCostsMatrix matrix = matrixBuilder.build();
-        assertEquals(2., matrix.getTransportTime(loc(1), loc(2), 0.0, null, null), 0.1);
+        Assertions.assertEquals(2., matrix.getTransportTime(loc(1), loc(2), 0.0, null, null), 0.1);
     }
 
     @Test
@@ -97,8 +99,8 @@ class FastVehicleRoutingTransportCostsMatrixTest {
         Vehicle vehicle = mock(Vehicle.class);
         VehicleType type = VehicleTypeImpl.Builder.newInstance("t").setCostPerDistance(1.).setCostPerTime(2.).build();
         when(vehicle.getType()).thenReturn(type);
-        assertEquals(24., matrix.getTransportCost(loc(1), loc(2), 0.0, null, vehicle), 0.1);
-        assertEquals(24., matrix.getTransportCost(loc(2), loc(1), 0.0, null, vehicle), 0.1);
+        Assertions.assertEquals(24., matrix.getTransportCost(loc(1), loc(2), 0.0, null, vehicle), 0.1);
+        Assertions.assertEquals(24., matrix.getTransportCost(loc(2), loc(1), 0.0, null, vehicle), 0.1);
     }
 
     @Test
@@ -111,7 +113,7 @@ class FastVehicleRoutingTransportCostsMatrixTest {
         Vehicle vehicle = mock(Vehicle.class);
         VehicleType type = VehicleTypeImpl.Builder.newInstance("t").setCostPerDistance(1.).setCostPerTime(2.).build();
         when(vehicle.getType()).thenReturn(type);
-        assertEquals(4., matrix.getTransportCost(loc(1), loc(2), 0.0, null, vehicle), 0.1);
-        assertEquals(16., matrix.getTransportCost(loc(2), loc(1), 0.0, null, vehicle), 0.1);
+        Assertions.assertEquals(4., matrix.getTransportCost(loc(1), loc(2), 0.0, null, vehicle), 0.1);
+        Assertions.assertEquals(16., matrix.getTransportCost(loc(2), loc(1), 0.0, null, vehicle), 0.1);
     }
 }

--- a/jsprit-core/src/test/java/com/graphhopper/jsprit/core/util/GreatCircleDistanceCalculatorTest.java
+++ b/jsprit-core/src/test/java/com/graphhopper/jsprit/core/util/GreatCircleDistanceCalculatorTest.java
@@ -23,6 +23,8 @@ import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
+import org.junit.jupiter.api.Assertions;
+
 /**
  * Created by schroeder on 28.11.14.
  */
@@ -37,7 +39,7 @@ class GreatCircleDistanceCalculatorTest {
         double lon2 = 12.1333333;
         double lat2 = 54.0833333;
         double greatCircle = GreatCircleDistanceCalculator.calculateDistance(Coordinate.newInstance(lon1, lat1), Coordinate.newInstance(lon2, lat2), DistanceUnit.Kilometer);
-        assertEquals(600, greatCircle, 30.);
+        Assertions.assertEquals(600, greatCircle, 30.);
     }
 
     @Test
@@ -48,6 +50,6 @@ class GreatCircleDistanceCalculatorTest {
         double lon2 = 12.1333333;
         double lat2 = 54.0833333;
         double greatCircle = GreatCircleDistanceCalculator.calculateDistance(Coordinate.newInstance(lon1, lat1), Coordinate.newInstance(lon2, lat2), DistanceUnit.Meter);
-        assertEquals(600000, greatCircle, 30000.);
+        Assertions.assertEquals(600000, greatCircle, 30000.);
     }
 }

--- a/jsprit-core/src/test/java/com/graphhopper/jsprit/core/util/LiLimReader.java
+++ b/jsprit-core/src/test/java/com/graphhopper/jsprit/core/util/LiLimReader.java
@@ -161,7 +161,7 @@ public class LiLimReader {
                     double startTimeWindow = getDouble(tokens[4]);
                     double endTimeWindow = getDouble(tokens[5]);
                     double serviceTime = getDouble(tokens[6]);
-//					vrpBuilder.addLocation(customerId, coord);
+					// vrpBuilder.addLocation(customerId, coord);
                     customers.put(customerId, new CustomerData(coord, startTimeWindow, endTimeWindow, serviceTime));
                     if (customerId.equals("0")) {
                         depotId = customerId;

--- a/jsprit-core/src/test/java/com/graphhopper/jsprit/core/util/RandomUtilsTest.java
+++ b/jsprit-core/src/test/java/com/graphhopper/jsprit/core/util/RandomUtilsTest.java
@@ -18,6 +18,8 @@
 package com.graphhopper.jsprit.core.util;
 
 import com.graphhopper.jsprit.core.problem.job.Job;
+
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
@@ -41,7 +43,7 @@ class RandomUtilsTest {
     void shouldReturnSingleJob() {
         Job job = mock(Job.class);
         Collection<Job> jobs = Arrays.asList(job);
-        assertEquals(job, RandomUtils.nextItem(jobs, RandomNumberGeneration.getRandom()));
+        Assertions.assertEquals(job, RandomUtils.nextItem(jobs, RandomNumberGeneration.getRandom()));
     }
 
     @Test
@@ -49,7 +51,7 @@ class RandomUtilsTest {
     void shouldReturnSingleJob_() {
         Job job = mock(Job.class);
         Collection<Job> jobs = Arrays.asList(job);
-        assertEquals(job, RandomUtils.nextJob(jobs, RandomNumberGeneration.getRandom()));
+        Assertions.assertEquals(job, RandomUtils.nextJob(jobs, RandomNumberGeneration.getRandom()));
     }
 
     @Test
@@ -59,6 +61,6 @@ class RandomUtilsTest {
         List<Job> jobs = Arrays.asList(mock(Job.class), mock(Job.class), job3);
         Random random = mock(Random.class);
         when(random.nextInt(jobs.size())).thenReturn(2);
-        assertEquals(job3, RandomUtils.nextJob(jobs, random));
+        Assertions.assertEquals(job3, RandomUtils.nextJob(jobs, random));
     }
 }

--- a/jsprit-core/src/test/java/com/graphhopper/jsprit/core/util/TimeTest.java
+++ b/jsprit-core/src/test/java/com/graphhopper/jsprit/core/util/TimeTest.java
@@ -23,6 +23,8 @@ import org.junit.jupiter.api.Test;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
+import org.junit.jupiter.api.Assertions;
+
 @DisplayName("Time Test")
 class TimeTest {
 
@@ -30,140 +32,140 @@ class TimeTest {
     @DisplayName("Six AM _ should Be Parsed Correctly")
     void sixAM_shouldBeParsedCorrectly() {
         double sec = Time.parseTimeToSeconds("6AM");
-        assertEquals(6. * 3600., sec, 0.01);
+        Assertions.assertEquals(6. * 3600., sec, 0.01);
     }
 
     @Test
     @DisplayName("Six AM With White Space _ should Be Parsed Correctly")
     void sixAMWithWhiteSpace_shouldBeParsedCorrectly() {
         double sec = Time.parseTimeToSeconds("6 AM");
-        assertEquals(6. * 3600., sec, 0.01);
+        Assertions.assertEquals(6. * 3600., sec, 0.01);
     }
 
     @Test
     @DisplayName("Sixa M With White Space _ should Be Parsed Correctly")
     void sixaMWithWhiteSpace_shouldBeParsedCorrectly() {
         double sec = Time.parseTimeToSeconds("6 aM");
-        assertEquals(6. * 3600., sec, 0.01);
+        Assertions.assertEquals(6. * 3600., sec, 0.01);
     }
 
     @Test
     @DisplayName("Sixam With White Space _ should Be Parsed Correctly")
     void sixamWithWhiteSpace_shouldBeParsedCorrectly() {
         double sec = Time.parseTimeToSeconds("6 am");
-        assertEquals(6. * 3600., sec, 0.01);
+        Assertions.assertEquals(6. * 3600., sec, 0.01);
     }
 
     @Test
     @DisplayName("Six Am With White Space _ should Be Parsed Correctly")
     void sixAmWithWhiteSpace_shouldBeParsedCorrectly() {
         double sec = Time.parseTimeToSeconds("6 Am");
-        assertEquals(6. * 3600., sec, 0.01);
+        Assertions.assertEquals(6. * 3600., sec, 0.01);
     }
 
     @Test
     @DisplayName("Six PM _ should Be Parsed Correctly")
     void sixPM_shouldBeParsedCorrectly() {
         double sec = Time.parseTimeToSeconds("6PM");
-        assertEquals(6. * 3600. + 12. * 3600., sec, 0.01);
+        Assertions.assertEquals(6. * 3600. + 12. * 3600., sec, 0.01);
     }
 
     @Test
     @DisplayName("Six PM With White Space _ should Be Parsed Correctly")
     void sixPMWithWhiteSpace_shouldBeParsedCorrectly() {
         double sec = Time.parseTimeToSeconds("6 PM");
-        assertEquals(6. * 3600. + 12. * 3600., sec, 0.01);
+        Assertions.assertEquals(6. * 3600. + 12. * 3600., sec, 0.01);
     }
 
     @Test
     @DisplayName("Sixp M With White Space _ should Be Parsed Correctly")
     void sixpMWithWhiteSpace_shouldBeParsedCorrectly() {
         double sec = Time.parseTimeToSeconds("6 pM");
-        assertEquals(6. * 3600. + 12. * 3600., sec, 0.01);
+        Assertions.assertEquals(6. * 3600. + 12. * 3600., sec, 0.01);
     }
 
     @Test
     @DisplayName("Sixpm With White Space _ should Be Parsed Correctly")
     void sixpmWithWhiteSpace_shouldBeParsedCorrectly() {
         double sec = Time.parseTimeToSeconds("6 pm");
-        assertEquals(6. * 3600. + 12. * 3600., sec, 0.01);
+        Assertions.assertEquals(6. * 3600. + 12. * 3600., sec, 0.01);
     }
 
     @Test
     @DisplayName("Six Pm With White Space _ should Be Parsed Correctly")
     void sixPmWithWhiteSpace_shouldBeParsedCorrectly() {
         double sec = Time.parseTimeToSeconds("6 Pm");
-        assertEquals(6. * 3600. + 12. * 3600, sec, 0.01);
+        Assertions.assertEquals(6. * 3600. + 12. * 3600, sec, 0.01);
     }
 
     @Test
     @DisplayName("Six AM With Leading Zero _ should Be Parsed Correctly")
     void sixAMWithLeadingZero_shouldBeParsedCorrectly() {
         double sec = Time.parseTimeToSeconds("06AM");
-        assertEquals(6. * 3600., sec, 0.01);
+        Assertions.assertEquals(6. * 3600., sec, 0.01);
     }
 
     @Test
     @DisplayName("Six Hour _ twelve Min _ AM _ should Be Parsed Correctly")
     void sixHour_twelveMin_AM_shouldBeParsedCorrectly() {
         double sec = Time.parseTimeToSeconds("6:12AM");
-        assertEquals(6. * 3600. + 12. * 60., sec, 0.01);
+        Assertions.assertEquals(6. * 3600. + 12. * 60., sec, 0.01);
     }
 
     @Test
     @DisplayName("Six Hour _ six Min _ AM _ should Be Parsed Correctly")
     void sixHour_sixMin_AM_shouldBeParsedCorrectly() {
         double sec = Time.parseTimeToSeconds("6:6AM");
-        assertEquals(6. * 3600. + 6. * 60., sec, 0.01);
+        Assertions.assertEquals(6. * 3600. + 6. * 60., sec, 0.01);
     }
 
     @Test
     @DisplayName("Six Hour _ six Min With Leading Zero _ AM _ should Be Parsed Correctly")
     void sixHour_sixMinWithLeadingZero_AM_shouldBeParsedCorrectly() {
         double sec = Time.parseTimeToSeconds("6:06AM");
-        assertEquals(6. * 3600. + 6. * 60., sec, 0.01);
+        Assertions.assertEquals(6. * 3600. + 6. * 60., sec, 0.01);
     }
 
     @Test
     @DisplayName("Six Hour _ twelve Min _ PM _ should Be Parsed Correctly")
     void sixHour_twelveMin_PM_shouldBeParsedCorrectly() {
         double sec = Time.parseTimeToSeconds("6:12PM");
-        assertEquals(6. * 3600. + 12. * 60. + 12. * 3600., sec, 0.01);
+        Assertions.assertEquals(6. * 3600. + 12. * 60. + 12. * 3600., sec, 0.01);
     }
 
     @Test
     @DisplayName("Six Hour _ six Min _ PM _ should Be Parsed Correctly")
     void sixHour_sixMin_PM_shouldBeParsedCorrectly() {
         double sec = Time.parseTimeToSeconds("6:6PM");
-        assertEquals(6. * 3600. + 6. * 60. + 12. * 3600., sec, 0.01);
+        Assertions.assertEquals(6. * 3600. + 6. * 60. + 12. * 3600., sec, 0.01);
     }
 
     @Test
     @DisplayName("Six Hour _ six Min With Leading Zero _ PM _ should Be Parsed Correctly")
     void sixHour_sixMinWithLeadingZero_PM_shouldBeParsedCorrectly() {
         double sec = Time.parseTimeToSeconds("6:06PM");
-        assertEquals(6. * 3600. + 6. * 60. + 12. * 3600., sec, 0.01);
+        Assertions.assertEquals(6. * 3600. + 6. * 60. + 12. * 3600., sec, 0.01);
     }
 
     @Test
     @DisplayName("Six Hour _ six Min With Leading Zero _ twelve Sec _ PM _ should Be Parsed Correctly")
     void sixHour_sixMinWithLeadingZero_twelveSec_PM_shouldBeParsedCorrectly() {
         double sec = Time.parseTimeToSeconds("6:06:12PM");
-        assertEquals(6. * 3600. + 6. * 60. + 12. * 3600. + 12., sec, 0.01);
+        Assertions.assertEquals(6. * 3600. + 6. * 60. + 12. * 3600. + 12., sec, 0.01);
     }
 
     @Test
     @DisplayName("Six Hour _ six Min With Leading Zero _ twelve Sec _ should Be Parsed Correctly")
     void sixHour_sixMinWithLeadingZero_twelveSec_shouldBeParsedCorrectly() {
         double sec = Time.parseTimeToSeconds("6:06:12");
-        assertEquals(6. * 3600. + 6. * 60. + 12., sec, 0.01);
+        Assertions.assertEquals(6. * 3600. + 6. * 60. + 12., sec, 0.01);
     }
 
     @Test
     @DisplayName("Six Hour _ six Min With Leading Zero _ six Sec With Leading Zero _ should Be Parsed Correctly")
     void sixHour_sixMinWithLeadingZero_sixSecWithLeadingZero_shouldBeParsedCorrectly() {
         double sec = Time.parseTimeToSeconds("6:06:06");
-        assertEquals(6. * 3600. + 6. * 60. + 6., sec, 0.01);
+        Assertions.assertEquals(6. * 3600. + 6. * 60. + 6., sec, 0.01);
     }
 
     @Test
@@ -186,27 +188,27 @@ class TimeTest {
     @DisplayName("Zero Hour _ zero Min With Leading Zero _ one Sec With Leading Zero _ should Be Parsed Correctly")
     void zeroHour_zeroMinWithLeadingZero_oneSecWithLeadingZero_shouldBeParsedCorrectly() {
         double sec = Time.parseTimeToSeconds("0:00:01");
-        assertEquals(1., sec, 0.01);
+        Assertions.assertEquals(1., sec, 0.01);
     }
 
     @Test
     @DisplayName("When Sec Is 3600 _ should Return Correct Time String")
     void whenSecIs3600_shouldReturnCorrectTimeString() {
         String time = Time.parseSecondsToTime(3600);
-        assertEquals(3600., Time.parseTimeToSeconds(time), 0.01);
+        Assertions.assertEquals(3600., Time.parseTimeToSeconds(time), 0.01);
     }
 
     @Test
     @DisplayName("When Sec Is 4000 _ should Return Correct Time String")
     void whenSecIs4000_shouldReturnCorrectTimeString() {
         String time = Time.parseSecondsToTime(4000);
-        assertEquals(4000., Time.parseTimeToSeconds(time), 0.01);
+        Assertions.assertEquals(4000., Time.parseTimeToSeconds(time), 0.01);
     }
 
     @Test
     @DisplayName("When Sec Is 86399 _ should Return Correct Time String")
     void whenSecIs86399_shouldReturnCorrectTimeString() {
         String time = Time.parseSecondsToTime(86399);
-        assertEquals(86399., Time.parseTimeToSeconds(time), 0.01);
+        Assertions.assertEquals(86399., Time.parseTimeToSeconds(time), 0.01);
     }
 }

--- a/jsprit-core/src/test/java/com/graphhopper/jsprit/core/util/VehicleRoutingTransportCostsMatrixTest.java
+++ b/jsprit-core/src/test/java/com/graphhopper/jsprit/core/util/VehicleRoutingTransportCostsMatrixTest.java
@@ -21,6 +21,8 @@ import com.graphhopper.jsprit.core.problem.Location;
 import com.graphhopper.jsprit.core.problem.vehicle.Vehicle;
 import com.graphhopper.jsprit.core.problem.vehicle.VehicleType;
 import com.graphhopper.jsprit.core.problem.vehicle.VehicleTypeImpl;
+
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
@@ -38,10 +40,10 @@ class VehicleRoutingTransportCostsMatrixTest {
         VehicleRoutingTransportCostsMatrix.Builder matrixBuilder = VehicleRoutingTransportCostsMatrix.Builder.newInstance(true);
         matrixBuilder.addTransportDistance("1", "2", 2.);
         VehicleRoutingTransportCostsMatrix matrix = matrixBuilder.build();
-        assertEquals(2., matrix.getTransportCost(loc("1"), loc("2"), 0.0, null, null), 0.1);
-        assertEquals(2., matrix.getDistance("1", "2"), 0.1);
-        assertEquals(2., matrix.getTransportCost(loc("2"), loc("1"), 0.0, null, null), 0.1);
-        assertEquals(2., matrix.getDistance("2", "1"), 0.1);
+        Assertions.assertEquals(2., matrix.getTransportCost(loc("1"), loc("2"), 0.0, null, null), 0.1);
+        Assertions.assertEquals(2., matrix.getDistance("1", "2"), 0.1);
+        Assertions.assertEquals(2., matrix.getTransportCost(loc("2"), loc("1"), 0.0, null, null), 0.1);
+        Assertions.assertEquals(2., matrix.getDistance("2", "1"), 0.1);
     }
 
     @Test
@@ -50,10 +52,10 @@ class VehicleRoutingTransportCostsMatrixTest {
         VehicleRoutingTransportCostsMatrix.Builder matrixBuilder = VehicleRoutingTransportCostsMatrix.Builder.newInstance(true);
         matrixBuilder.addTransportDistance("from", "to", 2.);
         VehicleRoutingTransportCostsMatrix matrix = matrixBuilder.build();
-        assertEquals(2., matrix.getTransportCost(loc("from"), loc("to"), 0.0, null, null), 0.1);
-        assertEquals(2., matrix.getDistance("from", "to"), 0.1);
-        assertEquals(2., matrix.getTransportCost(loc("to"), loc("from"), 0.0, null, null), 0.1);
-        assertEquals(2., matrix.getDistance("from", "to"), 0.1);
+        Assertions.assertEquals(2., matrix.getTransportCost(loc("from"), loc("to"), 0.0, null, null), 0.1);
+        Assertions.assertEquals(2., matrix.getDistance("from", "to"), 0.1);
+        Assertions.assertEquals(2., matrix.getTransportCost(loc("to"), loc("from"), 0.0, null, null), 0.1);
+        Assertions.assertEquals(2., matrix.getDistance("from", "to"), 0.1);
     }
 
     @Test
@@ -64,10 +66,10 @@ class VehicleRoutingTransportCostsMatrixTest {
         // overide
         matrixBuilder.addTransportDistance("from", "to", 4.);
         VehicleRoutingTransportCostsMatrix matrix = matrixBuilder.build();
-        assertEquals(4., matrix.getTransportCost(loc("from"), loc("to"), 0.0, null, null), 0.1);
-        assertEquals(4., matrix.getDistance("from", "to"), 0.1);
-        assertEquals(4., matrix.getTransportCost(loc("to"), loc("from"), 0.0, null, null), 0.1);
-        assertEquals(4., matrix.getDistance("from", "to"), 0.1);
+        Assertions.assertEquals(4., matrix.getTransportCost(loc("from"), loc("to"), 0.0, null, null), 0.1);
+        Assertions.assertEquals(4., matrix.getDistance("from", "to"), 0.1);
+        Assertions.assertEquals(4., matrix.getTransportCost(loc("to"), loc("from"), 0.0, null, null), 0.1);
+        Assertions.assertEquals(4., matrix.getDistance("from", "to"), 0.1);
     }
 
     @Test
@@ -78,10 +80,10 @@ class VehicleRoutingTransportCostsMatrixTest {
         // overide
         matrixBuilder.addTransportDistance("to", "from", 4.);
         VehicleRoutingTransportCostsMatrix matrix = matrixBuilder.build();
-        assertEquals(4., matrix.getTransportCost(loc("from"), loc("to"), 0.0, null, null), 0.1);
-        assertEquals(4., matrix.getDistance("from", "to"), 0.1);
-        assertEquals(4., matrix.getTransportCost(loc("to"), loc("from"), 0.0, null, null), 0.1);
-        assertEquals(4., matrix.getDistance("from", "to"), 0.1);
+        Assertions.assertEquals(4., matrix.getTransportCost(loc("from"), loc("to"), 0.0, null, null), 0.1);
+        Assertions.assertEquals(4., matrix.getDistance("from", "to"), 0.1);
+        Assertions.assertEquals(4., matrix.getTransportCost(loc("to"), loc("from"), 0.0, null, null), 0.1);
+        Assertions.assertEquals(4., matrix.getDistance("from", "to"), 0.1);
     }
 
     @Test
@@ -90,7 +92,7 @@ class VehicleRoutingTransportCostsMatrixTest {
         VehicleRoutingTransportCostsMatrix.Builder matrixBuilder = VehicleRoutingTransportCostsMatrix.Builder.newInstance(false);
         matrixBuilder.addTransportDistance("1", "2", 2.);
         VehicleRoutingTransportCostsMatrix matrix = matrixBuilder.build();
-        assertEquals(2., matrix.getTransportCost(loc("1"), loc("2"), 0.0, null, null), 0.1);
+        Assertions.assertEquals(2., matrix.getTransportCost(loc("1"), loc("2"), 0.0, null, null), 0.1);
     }
 
     private Location loc(String s) {
@@ -115,8 +117,8 @@ class VehicleRoutingTransportCostsMatrixTest {
         matrixBuilder.addTransportDistance("from", "to", 2.);
         matrixBuilder.addTransportDistance("to", "from", 4.);
         VehicleRoutingTransportCostsMatrix matrix = matrixBuilder.build();
-        assertEquals(2., matrix.getTransportCost(loc("from"), loc("to"), 0.0, null, null), 0.1);
-        assertEquals(4., matrix.getTransportCost(loc("to"), loc("from"), 0.0, null, null), 0.1);
+        Assertions.assertEquals(2., matrix.getTransportCost(loc("from"), loc("to"), 0.0, null, null), 0.1);
+        Assertions.assertEquals(4., matrix.getTransportCost(loc("to"), loc("from"), 0.0, null, null), 0.1);
     }
 
     @Test
@@ -125,8 +127,8 @@ class VehicleRoutingTransportCostsMatrixTest {
         VehicleRoutingTransportCostsMatrix.Builder matrixBuilder = VehicleRoutingTransportCostsMatrix.Builder.newInstance(true);
         matrixBuilder.addTransportTime("1", "2", 2.);
         VehicleRoutingTransportCostsMatrix matrix = matrixBuilder.build();
-        assertEquals(2., matrix.getTransportTime(loc("1"), loc("2"), 0.0, null, null), 0.1);
-        assertEquals(2., matrix.getTransportTime(loc("2"), loc("1"), 0.0, null, null), 0.1);
+        Assertions.assertEquals(2., matrix.getTransportTime(loc("1"), loc("2"), 0.0, null, null), 0.1);
+        Assertions.assertEquals(2., matrix.getTransportTime(loc("2"), loc("1"), 0.0, null, null), 0.1);
     }
 
     @Test
@@ -135,8 +137,8 @@ class VehicleRoutingTransportCostsMatrixTest {
         VehicleRoutingTransportCostsMatrix.Builder matrixBuilder = VehicleRoutingTransportCostsMatrix.Builder.newInstance(true);
         matrixBuilder.addTransportTime("from", "to", 2.);
         VehicleRoutingTransportCostsMatrix matrix = matrixBuilder.build();
-        assertEquals(2., matrix.getTransportTime(loc("from"), loc("to"), 0.0, null, null), 0.1);
-        assertEquals(2., matrix.getTransportTime(loc("to"), loc("from"), 0.0, null, null), 0.1);
+        Assertions.assertEquals(2., matrix.getTransportTime(loc("from"), loc("to"), 0.0, null, null), 0.1);
+        Assertions.assertEquals(2., matrix.getTransportTime(loc("to"), loc("from"), 0.0, null, null), 0.1);
     }
 
     @Test
@@ -145,7 +147,7 @@ class VehicleRoutingTransportCostsMatrixTest {
         VehicleRoutingTransportCostsMatrix.Builder matrixBuilder = VehicleRoutingTransportCostsMatrix.Builder.newInstance(false);
         matrixBuilder.addTransportTime("1", "2", 2.);
         VehicleRoutingTransportCostsMatrix matrix = matrixBuilder.build();
-        assertEquals(2., matrix.getTransportTime(loc("1"), loc("2"), 0.0, null, null), 0.1);
+        Assertions.assertEquals(2., matrix.getTransportTime(loc("1"), loc("2"), 0.0, null, null), 0.1);
     }
 
     @Test
@@ -166,8 +168,8 @@ class VehicleRoutingTransportCostsMatrixTest {
         matrixBuilder.addTransportTime("from", "to", 2.);
         matrixBuilder.addTransportTime("to", "from", 4.);
         VehicleRoutingTransportCostsMatrix matrix = matrixBuilder.build();
-        assertEquals(2., matrix.getTransportTime(loc("from"), loc("to"), 0.0, null, null), 0.1);
-        assertEquals(4., matrix.getTransportTime(loc("to"), loc("from"), 0.0, null, null), 0.1);
+        Assertions.assertEquals(2., matrix.getTransportTime(loc("from"), loc("to"), 0.0, null, null), 0.1);
+        Assertions.assertEquals(4., matrix.getTransportTime(loc("to"), loc("from"), 0.0, null, null), 0.1);
     }
 
     @Test
@@ -182,8 +184,8 @@ class VehicleRoutingTransportCostsMatrixTest {
         VehicleRoutingTransportCostsMatrix matrix = matrixBuilder.build();
         // assertEquals(2.,matrix.getTransportTime("from", "to", 0.0, null, null),0.1);
         // assertEquals(4.,matrix.getTransportTime("to", "from", 0.0, null, null),0.1);
-        assertEquals(2., matrix.getTransportCost(loc("from"), loc("to"), 0.0, null, vehicle), 0.1);
-        assertEquals(4., matrix.getTransportCost(loc("to"), loc("from"), 0.0, null, vehicle), 0.1);
+        Assertions.assertEquals(2., matrix.getTransportCost(loc("from"), loc("to"), 0.0, null, vehicle), 0.1);
+        Assertions.assertEquals(4., matrix.getTransportCost(loc("to"), loc("from"), 0.0, null, vehicle), 0.1);
     }
 
     @Test
@@ -196,8 +198,8 @@ class VehicleRoutingTransportCostsMatrixTest {
         Vehicle vehicle = mock(Vehicle.class);
         VehicleType type = VehicleTypeImpl.Builder.newInstance("t").setCostPerDistance(1.).setCostPerTime(2.).build();
         when(vehicle.getType()).thenReturn(type);
-        assertEquals(24., matrix.getTransportCost(loc("1"), loc("2"), 0.0, null, vehicle), 0.1);
-        assertEquals(24., matrix.getTransportCost(loc("2"), loc("1"), 0.0, null, vehicle), 0.1);
+        Assertions.assertEquals(24., matrix.getTransportCost(loc("1"), loc("2"), 0.0, null, vehicle), 0.1);
+        Assertions.assertEquals(24., matrix.getTransportCost(loc("2"), loc("1"), 0.0, null, vehicle), 0.1);
     }
 
     @Test
@@ -209,8 +211,8 @@ class VehicleRoutingTransportCostsMatrixTest {
         VehicleType type = VehicleTypeImpl.Builder.newInstance("t").setCostPerDistance(1.).setCostPerTime(2.).build();
         when(vehicle.getType()).thenReturn(type);
         VehicleRoutingTransportCostsMatrix matrix = matrixBuilder.build();
-        assertEquals(4., matrix.getTransportCost(loc("from"), loc("to"), 0.0, null, vehicle), 0.1);
-        assertEquals(4., matrix.getTransportCost(loc("to"), loc("from"), 0.0, null, vehicle), 0.1);
+        Assertions.assertEquals(4., matrix.getTransportCost(loc("from"), loc("to"), 0.0, null, vehicle), 0.1);
+        Assertions.assertEquals(4., matrix.getTransportCost(loc("to"), loc("from"), 0.0, null, vehicle), 0.1);
     }
 
     @Test
@@ -223,8 +225,8 @@ class VehicleRoutingTransportCostsMatrixTest {
         Vehicle vehicle = mock(Vehicle.class);
         VehicleType type = VehicleTypeImpl.Builder.newInstance("t").setCostPerDistance(1.).setCostPerTime(2.).build();
         when(vehicle.getType()).thenReturn(type);
-        assertEquals(4., matrix.getTransportCost(loc("1"), loc("2"), 0.0, null, vehicle), 0.1);
-        assertEquals(16., matrix.getTransportCost(loc("2"), loc("1"), 0.0, null, vehicle), 0.1);
+        Assertions.assertEquals(4., matrix.getTransportCost(loc("1"), loc("2"), 0.0, null, vehicle), 0.1);
+        Assertions.assertEquals(16., matrix.getTransportCost(loc("2"), loc("1"), 0.0, null, vehicle), 0.1);
     }
 
     @Test
@@ -239,8 +241,8 @@ class VehicleRoutingTransportCostsMatrixTest {
         Vehicle vehicle = mock(Vehicle.class);
         VehicleType type = VehicleTypeImpl.Builder.newInstance("t").setCostPerDistance(1.).setCostPerTime(2.).build();
         when(vehicle.getType()).thenReturn(type);
-        assertEquals(5., matrix.getTransportCost(loc("from"), loc("to"), 0.0, null, vehicle), 0.1);
-        assertEquals(11., matrix.getTransportCost(loc("to"), loc("from"), 0.0, null, vehicle), 0.1);
+        Assertions.assertEquals(5., matrix.getTransportCost(loc("from"), loc("to"), 0.0, null, vehicle), 0.1);
+        Assertions.assertEquals(11., matrix.getTransportCost(loc("to"), loc("from"), 0.0, null, vehicle), 0.1);
     }
 
     @Test
@@ -255,8 +257,8 @@ class VehicleRoutingTransportCostsMatrixTest {
         matrixBuilder.addTransportTime("to", "from", 4.);
         matrixBuilder.addTransportDistance("to", "from", 5.);
         VehicleRoutingTransportCostsMatrix matrix = matrixBuilder.build();
-        assertEquals(8., matrix.getTransportCost(loc("from"), loc("to"), 0.0, null, vehicle), 0.1);
-        assertEquals(14., matrix.getTransportCost(loc("to"), loc("from"), 0.0, null, vehicle), 0.1);
+        Assertions.assertEquals(8., matrix.getTransportCost(loc("from"), loc("to"), 0.0, null, vehicle), 0.1);
+        Assertions.assertEquals(14., matrix.getTransportCost(loc("to"), loc("from"), 0.0, null, vehicle), 0.1);
     }
 
     @Test
@@ -271,9 +273,9 @@ class VehicleRoutingTransportCostsMatrixTest {
         Vehicle vehicle = mock(Vehicle.class);
         VehicleType type = VehicleTypeImpl.Builder.newInstance("t").setCostPerDistance(1.).setCostPerTime(0.).build();
         when(vehicle.getType()).thenReturn(type);
-        assertEquals(1., matrix.getDistance("from", "to"), 0.1);
-        assertEquals(1., matrix.getDistance("to", "from"), 0.1);
-        assertEquals(1., matrix.getTransportCost(loc("from"), loc("to"), 0.0, null, vehicle), 0.1);
-        assertEquals(1., matrix.getTransportCost(loc("to"), loc("from"), 0.0, null, vehicle), 0.1);
+        Assertions.assertEquals(1., matrix.getDistance("from", "to"), 0.1);
+        Assertions.assertEquals(1., matrix.getDistance("to", "from"), 0.1);
+        Assertions.assertEquals(1., matrix.getTransportCost(loc("from"), loc("to"), 0.0, null, vehicle), 0.1);
+        Assertions.assertEquals(1., matrix.getTransportCost(loc("to"), loc("from"), 0.0, null, vehicle), 0.1);
     }
 }

--- a/pom.xml
+++ b/pom.xml
@@ -186,13 +186,6 @@
         </dependency>
 
         <dependency>
-            <groupId>org.junit.vintage</groupId>
-            <artifactId>junit-vintage-engine</artifactId>
-            <version>${junit.version}</version>
-            <scope>test</scope>
-        </dependency>
-
-        <dependency>
             <groupId>org.mockito</groupId>
             <artifactId>mockito-core</artifactId>
             <version>${mockito.version}</version>


### PR DESCRIPTION
This change removes all JUnit 4 methods and replaces them with their JUnit 5 counterparts.